### PR TITLE
feat(iceberg): support sql catalog interface

### DIFF
--- a/crates/catalog/sql/Cargo.toml
+++ b/crates/catalog/sql/Cargo.toml
@@ -31,8 +31,10 @@ keywords = ["iceberg", "sql", "catalog"]
 [dependencies]
 async-trait = { workspace = true }
 iceberg = { workspace = true }
+serde_json = { workspace = true }
 sqlx = { version = "0.8.1", features = ["any"], default-features = false }
 typed-builder = { workspace = true }
+uuid = { workspace = true, features = ["v4"] }
 
 [dev-dependencies]
 iceberg_test_utils = { path = "../../test_utils", features = ["tests"] }

--- a/crates/catalog/sql/src/catalog.rs
+++ b/crates/catalog/sql/src/catalog.rs
@@ -630,7 +630,7 @@ impl Catalog for SqlCatalog {
         let new_table_name = creation.name.clone();
 
         // build table location
-        let table_creation_localtion = match creation.location {
+        let table_creation_location = match creation.location {
             Some(location) => location,
             None => {
                 let namespace_properties =
@@ -653,14 +653,14 @@ impl Catalog for SqlCatalog {
 
         // build table metadata
         let table_metadata = TableMetadataBuilder::from_table_creation(TableCreation {
-            location: Some(table_creation_localtion.clone()),
+            location: Some(table_creation_location.clone()),
             ..creation
         })?
         .build()?;
 
         // serde table to json
-        let new_table_meta_localtion = metadata_path(&table_creation_localtion, Uuid::new_v4());
-        let file = self.fileio.new_output(&new_table_meta_localtion)?;
+        let new_table_meta_location = metadata_path(&table_creation_location, Uuid::new_v4());
+        let file = self.fileio.new_output(&new_table_meta_location)?;
         file.write(serde_json::to_vec(&table_metadata)?.into())
             .await?;
 
@@ -673,7 +673,7 @@ impl Catalog for SqlCatalog {
             Some(&self.name),
             Some(&namespace_name),
             Some(&new_table_name),
-            Some(&new_table_meta_localtion),
+            Some(&new_table_meta_location),
             Some(CATALOG_FIELD_TABLE_RECORD_TYPE),
         ];
 
@@ -682,7 +682,7 @@ impl Catalog for SqlCatalog {
         Ok(Table::builder()
             .file_io(self.fileio.clone())
             .identifier(identifier)
-            .metadata_location(new_table_meta_localtion)
+            .metadata_location(new_table_meta_location)
             .metadata(table_metadata)
             .build()?)
     }
@@ -723,8 +723,8 @@ impl Catalog for SqlCatalog {
             }
         }
 
-        let new_table_meta_localtion = metadata_path(table.metadata().location(), Uuid::new_v4());
-        let file = self.fileio.new_output(&new_table_meta_localtion)?;
+        let new_table_meta_location = metadata_path(table.metadata().location(), Uuid::new_v4());
+        let file = self.fileio.new_output(&new_table_meta_location)?;
         file.write(serde_json::to_vec(&update_table_metadata)?.into())
             .await?;
 
@@ -742,7 +742,7 @@ impl Catalog for SqlCatalog {
 
         let namespace_name = identifier.namespace().join(".");
         let args: Vec<Option<&str>> = vec![
-            Some(&new_table_meta_localtion),
+            Some(&new_table_meta_location),
             Some(&self.name),
             Some(&namespace_name),
             Some(identifier.name()),
@@ -753,7 +753,7 @@ impl Catalog for SqlCatalog {
         Ok(Table::builder()
             .file_io(self.fileio.clone())
             .identifier(identifier)
-            .metadata_location(new_table_meta_localtion)
+            .metadata_location(new_table_meta_location)
             .metadata(update_table_metadata)
             .build()?)
     }

--- a/crates/catalog/sql/src/error.rs
+++ b/crates/catalog/sql/src/error.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use iceberg::{Error, ErrorKind, NamespaceIdent, Result};
+use iceberg::{Error, ErrorKind, NamespaceIdent, Result, TableIdent};
 
 /// Format an sqlx error into iceberg error.
 pub fn from_sqlx_error(error: sqlx::Error) -> Error {
@@ -30,5 +30,22 @@ pub fn no_such_namespace_err<T>(namespace: &NamespaceIdent) -> Result<T> {
     Err(Error::new(
         ErrorKind::Unexpected,
         format!("No such namespace: {:?}", namespace),
+    ))
+}
+
+pub fn no_such_table_err<T>(table_ident: &TableIdent) -> Result<T> {
+    Err(Error::new(
+        ErrorKind::Unexpected,
+        format!("No such table: {:?}", table_ident),
+    ))
+}
+
+pub fn table_already_exists_err<T>(table_ident: &TableIdent) -> Result<T> {
+    Err(Error::new(
+        ErrorKind::Unexpected,
+        format!(
+            "Cannot create table {:?}. Table already exists.",
+            table_ident
+        ),
     ))
 }

--- a/crates/iceberg/src/catalog/mod.rs
+++ b/crates/iceberg/src/catalog/mod.rs
@@ -241,7 +241,7 @@ pub struct TableCreation {
 
 /// TableCommit represents the commit of a table in the catalog.
 #[derive(Debug, TypedBuilder)]
-#[builder(build_method(vis = "pub(crate)"))]
+#[builder(build_method(vis = "pub"))]
 pub struct TableCommit {
     /// The table ident.
     ident: TableIdent,

--- a/crates/iceberg/src/spec/table_metadata.rs
+++ b/crates/iceberg/src/spec/table_metadata.rs
@@ -278,6 +278,18 @@ impl TableMetadata {
         self.snapshots
             .insert(snapshot.snapshot_id(), Arc::new(snapshot));
     }
+
+    /// update snapshot ref of table
+    #[inline]
+    pub fn update_snapshot_ref(&mut self, ref_name: String, reference: SnapshotReference) {
+        self.refs.insert(ref_name, reference);
+    }
+
+    /// Returns snapshot references.
+    #[inline]
+    pub fn snapshot_refs(&self) -> &HashMap<String, SnapshotReference> {
+        &self.refs
+    }
 }
 
 /// Manipulating table metadata.


### PR DESCRIPTION
Introducing a partial implementation of sql catalog (support the functionality used by rw)

1. list_tables
2. create_table
3. drop_table
4. update_table
5. UT