### PR TITLE
fix: fix merge on read and cherry-pick

### DIFF
--- a/crates/iceberg/src/arrow/reader.rs
+++ b/crates/iceberg/src/arrow/reader.rs
@@ -1409,6 +1409,7 @@ message schema {
                 predicate: Some(predicate.bind(schema, true).unwrap()),
                 deletes: vec![],
                 sequence_number: 0,
+                equality_ids: vec![],
             })]
             .into_iter(),
         )) as FileScanTaskStream;

--- a/crates/iceberg/src/arrow/reader.rs
+++ b/crates/iceberg/src/arrow/reader.rs
@@ -1408,6 +1408,7 @@ message schema {
                 project_field_ids: vec![1],
                 predicate: Some(predicate.bind(schema, true).unwrap()),
                 deletes: vec![],
+                sequence_number: 0,
             })]
             .into_iter(),
         )) as FileScanTaskStream;

--- a/crates/iceberg/src/arrow/reader.rs
+++ b/crates/iceberg/src/arrow/reader.rs
@@ -26,7 +26,7 @@ use arrow_arith::boolean::{and, and_kleene, is_not_null, is_null, not, or, or_kl
 use arrow_array::{Array, ArrayRef, BooleanArray, RecordBatch};
 use arrow_ord::cmp::{eq, gt, gt_eq, lt, lt_eq, neq};
 use arrow_schema::{
-    ArrowError, DataType, FieldRef, Fields, Schema as ArrowSchema, SchemaRef as ArrowSchemaRef,
+    ArrowError, DataType, FieldRef, Schema as ArrowSchema, SchemaRef as ArrowSchemaRef,
 };
 use arrow_string::like::starts_with;
 use bytes::Bytes;
@@ -356,34 +356,29 @@ impl ArrowReader {
             // some Arrow types that are not yet supported.
             let mut projected_fields: HashMap<FieldRef, i32> = HashMap::new();
             let projected_arrow_schema = ArrowSchema::new_with_metadata(
-                Fields::from_iter(
-                    fields
-                        .iter()
-                        .filter(|f| {
-                            f.metadata()
-                                .get(PARQUET_FIELD_ID_META_KEY)
-                                .and_then(|field_id| i32::from_str(field_id).ok())
-                                .map_or(false, |field_id| {
-                                    projected_fields.insert((*f).clone(), field_id);
-                                    leaf_field_ids.contains(&field_id)
-                                })
+                fields.filter_leaves(|_, f| {
+                    f.metadata()
+                        .get(PARQUET_FIELD_ID_META_KEY)
+                        .and_then(|field_id| i32::from_str(field_id).ok())
+                        .map_or(false, |field_id| {
+                            projected_fields.insert((*f).clone(), field_id);
+                            leaf_field_ids.contains(&field_id)
                         })
-                        .cloned(),
-                ),
+                }),
                 arrow_schema.metadata().clone(),
             );
             let iceberg_schema = arrow_schema_to_schema(&projected_arrow_schema)?;
 
-            fields.iter().enumerate().for_each(|(idx, field)| {
+            fields.filter_leaves(|idx, field| {
                 let Some(field_id) = projected_fields.get(field).cloned() else {
-                    return;
+                    return false;
                 };
 
                 let iceberg_field = iceberg_schema_of_task.field_by_id(field_id);
                 let parquet_iceberg_field = iceberg_schema.field_by_id(field_id);
 
                 if iceberg_field.is_none() || parquet_iceberg_field.is_none() {
-                    return;
+                    return false;
                 }
 
                 if !type_promotion_is_valid(
@@ -393,10 +388,11 @@ impl ArrowReader {
                         .as_primitive_type(),
                     iceberg_field.unwrap().field_type.as_primitive_type(),
                 ) {
-                    return;
+                    return false;
                 }
 
                 column_map.insert(field_id, idx);
+                true
             });
 
             if column_map.len() != leaf_field_ids.len() {
@@ -427,7 +423,7 @@ impl ArrowReader {
                     ));
                 }
             }
-            Ok(ProjectionMask::roots(parquet_schema, indices))
+            Ok(ProjectionMask::leaves(parquet_schema, indices))
         }
     }
 

--- a/crates/iceberg/src/delete_file_index.rs
+++ b/crates/iceberg/src/delete_file_index.rs
@@ -26,7 +26,7 @@ use futures::channel::mpsc::{channel, Sender};
 use futures::StreamExt;
 
 use crate::runtime::spawn;
-use crate::scan::{DeleteFileContext, FileScanTaskDeleteFile};
+use crate::scan::{DeleteFileContext, FileScanTask};
 use crate::spec::{DataContentType, DataFile, Struct};
 use crate::{Error, ErrorKind, Result};
 
@@ -142,7 +142,7 @@ impl PopulatedDeleteFileIndex {
         &self,
         data_file: &DataFile,
         seq_num: Option<i64>,
-    ) -> Vec<FileScanTaskDeleteFile> {
+    ) -> Vec<FileScanTask> {
         let mut results = vec![];
 
         self.global_deletes
@@ -195,7 +195,7 @@ pub(crate) struct DeletesForDataFile<'a> {
 }
 
 impl Future for DeletesForDataFile<'_> {
-    type Output = Result<Vec<FileScanTaskDeleteFile>>;
+    type Output = Result<Vec<FileScanTask>>;
 
     fn poll(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Self::Output> {
         match self.state.try_read() {

--- a/crates/iceberg/src/delete_file_index.rs
+++ b/crates/iceberg/src/delete_file_index.rs
@@ -110,10 +110,11 @@ impl PopulatedDeleteFileIndex {
             // The spec states that "Equality delete files stored with an unpartitioned spec are applied as global deletes".
             if partition.fields().is_empty() {
                 // TODO: confirm we're good to skip here if we encounter a pos del
-                if arc_ctx.manifest_entry.content_type() != DataContentType::PositionDeletes {
-                    global_deletes.push(arc_ctx);
-                    return;
-                }
+                // FIXME(Dylan): allow putting position delete to global deletes.
+                // if arc_ctx.manifest_entry.content_type() != DataContentType::PositionDeletes {
+                global_deletes.push(arc_ctx);
+                return;
+                // }
             }
 
             let destination_map = match arc_ctx.manifest_entry.content_type() {

--- a/crates/iceberg/src/delete_file_index.rs
+++ b/crates/iceberg/src/delete_file_index.rs
@@ -162,7 +162,7 @@ impl PopulatedDeleteFileIndex {
                 // filter that returns true if the provided delete file's sequence number is **greater than or equal to** `seq_num`
                 .filter(|&delete| {
                     seq_num
-                        .map(|seq_num| delete.manifest_entry.sequence_number() >= Some(seq_num))
+                        .map(|seq_num| delete.manifest_entry.sequence_number() > Some(seq_num))
                         .unwrap_or_else(|| true)
                 })
                 .for_each(|delete| results.push(delete.as_ref().into()));

--- a/crates/iceberg/src/delete_file_index.rs
+++ b/crates/iceberg/src/delete_file_index.rs
@@ -178,7 +178,7 @@ impl PopulatedDeleteFileIndex {
                 // filter that returns true if the provided delete file's sequence number is **greater thano** `seq_num`
                 .filter(|&delete| {
                     seq_num
-                        .map(|seq_num| delete.manifest_entry.sequence_number() > Some(seq_num))
+                        .map(|seq_num| delete.manifest_entry.sequence_number() >= Some(seq_num))
                         .unwrap_or_else(|| true)
                 })
                 .for_each(|delete| results.push(delete.as_ref().into()));

--- a/crates/iceberg/src/scan.rs
+++ b/crates/iceberg/src/scan.rs
@@ -266,18 +266,18 @@ impl<'a> TableScanBuilder<'a> {
                 )
             })?;
 
-            schema
-                .as_struct()
-                .field_by_id(field_id)
-                .ok_or_else(|| {
-                    Error::new(
-                        ErrorKind::FeatureUnsupported,
-                        format!(
-                            "Column {} is not a direct child of schema but a nested field, which is not supported now. Schema: {}",
-                            column_name, schema
-                        ),
-                    )
-                })?;
+            // schema
+            //     .as_struct()
+            //     .field_by_id(field_id)
+            //     .ok_or_else(|| {
+            //         Error::new(
+            //             ErrorKind::FeatureUnsupported,
+            //             format!(
+            //                 "Column {} is not a direct child of schema but a nested field, which is not supported now. Schema: {}",
+            //                 column_name, schema
+            //             ),
+            //         )
+            //     })?;
 
             field_ids.push(field_id);
         }

--- a/crates/iceberg/src/scan.rs
+++ b/crates/iceberg/src/scan.rs
@@ -266,18 +266,18 @@ impl<'a> TableScanBuilder<'a> {
                 )
             })?;
 
-            // schema
-            //     .as_struct()
-            //     .field_by_id(field_id)
-            //     .ok_or_else(|| {
-            //         Error::new(
-            //             ErrorKind::FeatureUnsupported,
-            //             format!(
-            //                 "Column {} is not a direct child of schema but a nested field, which is not supported now. Schema: {}",
-            //                 column_name, schema
-            //             ),
-            //         )
-            //     })?;
+            schema
+                .as_struct()
+                .field_by_id(field_id)
+                .ok_or_else(|| {
+                    Error::new(
+                        ErrorKind::FeatureUnsupported,
+                        format!(
+                            "Column {} is not a direct child of schema but a nested field, which is not supported now. Schema: {}",
+                            column_name, schema
+                        ),
+                    )
+                })?;
 
             field_ids.push(field_id);
         }

--- a/crates/iceberg/src/scan.rs
+++ b/crates/iceberg/src/scan.rs
@@ -697,6 +697,7 @@ impl ManifestEntryContext {
 
             deletes,
             sequence_number: self.manifest_entry.sequence_number().unwrap_or(0),
+            equality_ids: self.manifest_entry.data_file().equality_ids().to_vec(),
         })
     }
 }
@@ -1061,6 +1062,8 @@ pub struct FileScanTask {
     pub deletes: Vec<FileScanTask>,
     /// sequence number
     pub sequence_number: i64,
+    /// equality ids
+    pub equality_ids: Vec<i32>,
 }
 
 /// A task to scan part of file.
@@ -1074,10 +1077,6 @@ pub struct FileScanTaskDeleteFile {
 
     /// partition id
     pub partition_spec_id: i32,
-    /// sequence number
-    pub sequence_number: i64,
-    /// equality ids
-    pub equality_ids: Vec<i32>,
 }
 
 #[derive(Debug)]
@@ -1093,8 +1092,6 @@ impl From<&DeleteFileContext> for FileScanTaskDeleteFile {
             file_path: ctx.manifest_entry.file_path().to_string(),
             file_type: ctx.manifest_entry.content_type(),
             partition_spec_id: ctx.partition_spec_id,
-            sequence_number: ctx.manifest_entry.sequence_number().unwrap_or(0),
-            equality_ids: ctx.manifest_entry.data_file().equality_ids().to_vec(),
         }
     }
 }
@@ -1115,6 +1112,7 @@ impl From<&DeleteFileContext> for FileScanTask {
             predicate: None,
             deletes: vec![],
             sequence_number: ctx.manifest_entry.sequence_number().unwrap_or(0),
+            equality_ids: ctx.manifest_entry.data_file().equality_ids().to_vec(),
         }
     }
 }
@@ -2315,6 +2313,7 @@ pub mod tests {
             data_file_format: DataFileFormat::Parquet,
             deletes: vec![],
             sequence_number: 0,
+            equality_ids: vec![],
         };
         test_fn(task);
 
@@ -2331,6 +2330,7 @@ pub mod tests {
             data_file_format: DataFileFormat::Avro,
             deletes: vec![],
             sequence_number: 0,
+            equality_ids: vec![],
         };
         test_fn(task);
     }

--- a/crates/iceberg/src/scan.rs
+++ b/crates/iceberg/src/scan.rs
@@ -695,6 +695,7 @@ impl ManifestEntryContext {
                 .map(|x| x.as_ref().snapshot_bound_predicate.clone()),
 
             deletes,
+            sequence_number: self.manifest_entry.sequence_number().unwrap_or(0),
         })
     }
 }
@@ -1057,6 +1058,8 @@ pub struct FileScanTask {
 
     /// The list of delete files that may need to be applied to this data file
     pub deletes: Vec<FileScanTaskDeleteFile>,
+    /// sequence number
+    pub sequence_number: i64,
 }
 
 /// A task to scan part of file.
@@ -1070,6 +1073,10 @@ pub struct FileScanTaskDeleteFile {
 
     /// partition id
     pub partition_spec_id: i32,
+    /// sequence number
+    pub sequence_number: i64,
+    /// equality ids
+    pub equality_ids: Vec<i32>,
 }
 
 #[derive(Debug)]
@@ -1084,6 +1091,8 @@ impl From<&DeleteFileContext> for FileScanTaskDeleteFile {
             file_path: ctx.manifest_entry.file_path().to_string(),
             file_type: ctx.manifest_entry.content_type(),
             partition_spec_id: ctx.partition_spec_id,
+            sequence_number: ctx.manifest_entry.sequence_number().unwrap_or(0),
+            equality_ids: ctx.manifest_entry.data_file().equality_ids().to_vec(),
         }
     }
 }
@@ -2283,6 +2292,7 @@ pub mod tests {
             record_count: Some(100),
             data_file_format: DataFileFormat::Parquet,
             deletes: vec![],
+            sequence_number: 0,
         };
         test_fn(task);
 
@@ -2298,6 +2308,7 @@ pub mod tests {
             record_count: None,
             data_file_format: DataFileFormat::Avro,
             deletes: vec![],
+            sequence_number: 0,
         };
         test_fn(task);
     }

--- a/crates/iceberg/src/scan.rs
+++ b/crates/iceberg/src/scan.rs
@@ -585,6 +585,7 @@ impl TableScan {
                 manifest_entry: manifest_entry_context.manifest_entry.clone(),
                 partition_spec_id: manifest_entry_context.partition_spec_id,
                 snapshot_schema: manifest_entry_context.snapshot_schema.clone(),
+                field_ids: manifest_entry_context.field_ids.clone(),
             })
             .await?;
 
@@ -1084,6 +1085,7 @@ pub(crate) struct DeleteFileContext {
     pub(crate) manifest_entry: ManifestEntryRef,
     pub(crate) partition_spec_id: i32,
     pub(crate) snapshot_schema: SchemaRef,
+    pub(crate) field_ids: Arc<Vec<i32>>,
 }
 
 impl From<&DeleteFileContext> for FileScanTaskDeleteFile {
@@ -1108,7 +1110,7 @@ impl From<&DeleteFileContext> for FileScanTask {
             data_file_format: ctx.manifest_entry.file_format(),
 
             schema: ctx.snapshot_schema.clone(),
-            project_field_ids: vec![],
+            project_field_ids: ctx.field_ids.to_vec(),
             predicate: None,
             deletes: vec![],
             sequence_number: ctx.manifest_entry.sequence_number().unwrap_or(0),

--- a/crates/iceberg/src/spec/manifest.rs
+++ b/crates/iceberg/src/spec/manifest.rs
@@ -1554,6 +1554,8 @@ impl std::fmt::Display for DataFileFormat {
     }
 }
 
+pub use _serde::DataFile as SerializedDataFile;
+
 mod _serde {
     use std::collections::HashMap;
 
@@ -1632,7 +1634,7 @@ mod _serde {
 
     #[serde_as]
     #[derive(Serialize, Deserialize)]
-    pub(super) struct DataFile {
+    pub struct DataFile {
         #[serde(default)]
         content: i32,
         file_path: String,

--- a/crates/iceberg/src/spec/manifest.rs
+++ b/crates/iceberg/src/spec/manifest.rs
@@ -1554,6 +1554,7 @@ impl std::fmt::Display for DataFileFormat {
     }
 }
 
+/// Data file
 pub use _serde::DataFile as SerializedDataFile;
 
 mod _serde {
@@ -1632,6 +1633,7 @@ mod _serde {
         }
     }
 
+    /// Data file
     #[serde_as]
     #[derive(Serialize, Deserialize)]
     pub struct DataFile {
@@ -1658,6 +1660,7 @@ mod _serde {
     }
 
     impl DataFile {
+        /// Convert to a data file with the given partition type.
         pub fn try_from(
             value: super::DataFile,
             partition_type: &StructType,
@@ -1688,6 +1691,7 @@ mod _serde {
             })
         }
 
+        /// Convert to a data file with the given partition type.
         pub fn try_into(
             self,
             partition_type: &StructType,

--- a/crates/iceberg/src/spec/manifest.rs
+++ b/crates/iceberg/src/spec/manifest.rs
@@ -1635,7 +1635,7 @@ mod _serde {
 
     /// Data file
     #[serde_as]
-    #[derive(Serialize, Deserialize)]
+    #[derive(Serialize, Deserialize, Clone)]
     pub struct DataFile {
         #[serde(default)]
         content: i32,
@@ -1758,7 +1758,7 @@ mod _serde {
     }
 
     #[serde_as]
-    #[derive(Serialize, Deserialize)]
+    #[derive(Serialize, Deserialize, Clone)]
     #[cfg_attr(test, derive(Debug, PartialEq, Eq))]
     struct BytesEntry {
         key: i32,
@@ -1802,7 +1802,7 @@ mod _serde {
         Ok(bs)
     }
 
-    #[derive(Serialize, Deserialize)]
+    #[derive(Serialize, Deserialize, Clone)]
     #[cfg_attr(test, derive(Debug, PartialEq, Eq))]
     struct I64Entry {
         key: i32,

--- a/crates/iceberg/src/spec/values.rs
+++ b/crates/iceberg/src/spec/values.rs
@@ -2241,7 +2241,7 @@ mod _serde {
     use crate::spec::{PrimitiveType, Type, MAP_KEY_FIELD_NAME, MAP_VALUE_FIELD_NAME};
     use crate::{Error, ErrorKind};
 
-    #[derive(SerializeDerive, DeserializeDerive, Debug)]
+    #[derive(SerializeDerive, DeserializeDerive, Debug, Clone)]
     #[serde(transparent)]
     /// Raw literal representation used for serde. The serialize way is used for Avro serializer.
     pub struct RawLiteral(RawLiteralEnum);

--- a/crates/iceberg/src/transaction.rs
+++ b/crates/iceberg/src/transaction.rs
@@ -111,7 +111,8 @@ impl<'a> Transaction<'a> {
         Ok(self)
     }
 
-    fn generate_unique_snapshot_id(&self) -> i64 {
+    /// Generate a unique snapshot id.
+    pub fn generate_unique_snapshot_id(&self) -> i64 {
         let generate_random_id = || -> i64 {
             let (lhs, rhs) = Uuid::new_v4().as_u64_pair();
             let snapshot_id = (lhs ^ rhs) as i64;
@@ -136,10 +137,26 @@ impl<'a> Transaction<'a> {
     /// Creates a fast append action.
     pub fn fast_append(
         self,
+        snapshot_id: Option<i64>,
         commit_uuid: Option<Uuid>,
         key_metadata: Vec<u8>,
     ) -> Result<FastAppendAction<'a>> {
-        let snapshot_id = self.generate_unique_snapshot_id();
+        let snapshot_id = if let Some(snapshot_id) = snapshot_id {
+            if self
+                .table
+                .metadata()
+                .snapshots()
+                .any(|s| s.snapshot_id() == snapshot_id)
+            {
+                return Err(Error::new(
+                    ErrorKind::DataInvalid,
+                    format!("Snapshot id {} already exists", snapshot_id),
+                ));
+            }
+            snapshot_id
+        } else {
+            self.generate_unique_snapshot_id()
+        };
         FastAppendAction::new(
             self,
             snapshot_id,
@@ -894,7 +911,7 @@ mod tests {
     async fn test_fast_append_action() {
         let table = make_v2_minimal_table();
         let tx = Transaction::new(&table);
-        let mut action = tx.fast_append(None, vec![]).unwrap();
+        let mut action = tx.fast_append(None, None, vec![]).unwrap();
 
         // check add data file with incompatible partition value
         let data_file = DataFileBuilder::default()

--- a/crates/iceberg/src/writer/function_writer/mod.rs
+++ b/crates/iceberg/src/writer/function_writer/mod.rs
@@ -17,6 +17,6 @@
 
 //! This module contains the functional writer.
 
+pub mod equality_delta_writer;
 pub mod fanout_partition_writer;
 pub mod precompute_partition_writer;
-pub mod equality_delta_writer;

--- a/crates/iceberg/src/writer/function_writer/mod.rs
+++ b/crates/iceberg/src/writer/function_writer/mod.rs
@@ -19,3 +19,4 @@
 
 pub mod fanout_partition_writer;
 pub mod precompute_partition_writer;
+pub mod equality_delta_writer;

--- a/crates/integration_tests/tests/shared_tests/append_data_file_test.rs
+++ b/crates/integration_tests/tests/shared_tests/append_data_file_test.rs
@@ -112,7 +112,7 @@ async fn test_append_data_file() {
 
     // commit result
     let tx = Transaction::new(&table);
-    let mut append_action = tx.fast_append(None, vec![]).unwrap();
+    let mut append_action = tx.fast_append(None, None, vec![]).unwrap();
     append_action.add_data_files(data_file.clone()).unwrap();
     let tx = append_action.apply().await.unwrap();
     let table = tx.commit(&rest_catalog).await.unwrap();
@@ -132,7 +132,7 @@ async fn test_append_data_file() {
 
     // commit result again
     let tx = Transaction::new(&table);
-    let mut append_action = tx.fast_append(None, vec![]).unwrap();
+    let mut append_action = tx.fast_append(None, None, vec![]).unwrap();
     append_action.add_data_files(data_file.clone()).unwrap();
     let tx = append_action.apply().await.unwrap();
     let table = tx.commit(&rest_catalog).await.unwrap();

--- a/crates/integration_tests/tests/shared_tests/append_partition_data_file_test.rs
+++ b/crates/integration_tests/tests/shared_tests/append_partition_data_file_test.rs
@@ -119,7 +119,7 @@ async fn test_append_partition_data_file() {
 
     // commit result
     let tx = Transaction::new(&table);
-    let mut append_action = tx.fast_append(None, vec![]).unwrap();
+    let mut append_action = tx.fast_append(None, None, vec![]).unwrap();
     append_action
         .add_data_files(data_file_valid.clone())
         .unwrap();
@@ -178,7 +178,7 @@ async fn test_schema_incompatible_partition_type(
     let data_file_invalid = data_file_writer_invalid.close().await.unwrap();
 
     let tx = Transaction::new(&table);
-    let mut append_action = tx.fast_append(None, vec![]).unwrap();
+    let mut append_action = tx.fast_append(None, None, vec![]).unwrap();
     if append_action
         .add_data_files(data_file_invalid.clone())
         .is_ok()
@@ -217,7 +217,7 @@ async fn test_schema_incompatible_partition_fields(
     let data_file_invalid = data_file_writer_invalid.close().await.unwrap();
 
     let tx = Transaction::new(&table);
-    let mut append_action = tx.fast_append(None, vec![]).unwrap();
+    let mut append_action = tx.fast_append(None, None, vec![]).unwrap();
     if append_action
         .add_data_files(data_file_invalid.clone())
         .is_ok()

--- a/crates/integration_tests/tests/shared_tests/conflict_commit_test.rs
+++ b/crates/integration_tests/tests/shared_tests/conflict_commit_test.rs
@@ -90,12 +90,12 @@ async fn test_append_data_file_conflict() {
 
     // start two transaction and commit one of them
     let tx1 = Transaction::new(&table);
-    let mut append_action = tx1.fast_append(None, vec![]).unwrap();
+    let mut append_action = tx1.fast_append(None, None, vec![]).unwrap();
     append_action.add_data_files(data_file.clone()).unwrap();
     let tx1 = append_action.apply().await.unwrap();
 
     let tx2 = Transaction::new(&table);
-    let mut append_action = tx2.fast_append(None, vec![]).unwrap();
+    let mut append_action = tx2.fast_append(None, None, vec![]).unwrap();
     append_action.add_data_files(data_file.clone()).unwrap();
     let tx2 = append_action.apply().await.unwrap();
     let table = tx2


### PR DESCRIPTION
- Fix merge on read: 
  - change FileScanTaskDeleteFile to FileScanTask 
  - bypass position delete read stream
  - add sequence number and equity delete to FileScanTask
  - Fix position delete and equality delete sequence number comparison
  - add position delete to the global delete map
- Change fast append api
- Add Clone trait to DataFile
- Expose SerializedDataFile
