### PR TITLE
fix(iceberg): Introduce new data sequence for RewriteFilesAction

### DIFF
--- a/crates/integration_tests/tests/shared_tests/rewrite_files_test.rs
+++ b/crates/integration_tests/tests/shared_tests/rewrite_files_test.rs
@@ -165,11 +165,13 @@ async fn test_rewrite_data_files() {
 
     // commit result again
     let tx = Transaction::new(&table);
-    let mut rewrite_action = tx.rewrite_files(None, vec![]).unwrap();
-    rewrite_action
+    let rewrite_action = tx
+        .rewrite_files(None, vec![])
+        .unwrap()
         .add_data_files(data_file_rewrite.clone())
+        .unwrap()
+        .delete_files(data_file.clone())
         .unwrap();
-    rewrite_action.delete_files(data_file.clone()).unwrap();
 
     let tx = rewrite_action.apply().await.unwrap();
     let table = tx.commit(&rest_catalog).await.unwrap();
@@ -279,9 +281,13 @@ async fn test_multiple_file_rewrite() {
     let data_file2 = data_file_writer.close().await.unwrap();
 
     let tx = Transaction::new(&table);
-    let mut rewrite_action = tx.rewrite_files(None, vec![]).unwrap();
-    rewrite_action.add_data_files(data_file1.clone()).unwrap();
-    rewrite_action.add_data_files(data_file2.clone()).unwrap();
+    let rewrite_action = tx
+        .rewrite_files(None, vec![])
+        .unwrap()
+        .add_data_files(data_file1.clone())
+        .unwrap()
+        .add_data_files(data_file2.clone())
+        .unwrap();
     let tx = rewrite_action.apply().await.unwrap();
     let table = tx.commit(&rest_catalog).await.unwrap();
 
@@ -357,7 +363,7 @@ async fn test_rewrite_nonexistent_file() {
     let nonexistent_data_file = valid_data_file.clone();
 
     let tx = Transaction::new(&table);
-    let mut rewrite_action = tx.rewrite_files(None, vec![]).unwrap();
+    let rewrite_action = tx.rewrite_files(None, vec![]).unwrap();
 
     // Attempt to delete the nonexistent file
     let result = rewrite_action.delete_files(nonexistent_data_file);

--- a/crates/integration_tests/tests/shared_tests/rewrite_files_test.rs
+++ b/crates/integration_tests/tests/shared_tests/rewrite_files_test.rs
@@ -370,3 +370,91 @@ async fn test_rewrite_nonexistent_file() {
 
     assert!(result.is_ok());
 }
+
+#[tokio::test]
+async fn test_sequence_number_in_manifest_entry() {
+    let fixture = get_shared_containers();
+    let rest_catalog = RestCatalog::new(fixture.catalog_config.clone());
+    let ns = random_ns().await;
+    let schema = test_schema();
+
+    let table_creation = TableCreation::builder()
+        .name("t3".to_string())
+        .schema(schema.clone())
+        .build();
+
+    let table = rest_catalog
+        .create_table(ns.name(), table_creation)
+        .await
+        .unwrap();
+
+    let schema: Arc<arrow_schema::Schema> = Arc::new(
+        table
+            .metadata()
+            .current_schema()
+            .as_ref()
+            .try_into()
+            .unwrap(),
+    );
+    let location_generator = DefaultLocationGenerator::new(table.metadata().clone()).unwrap();
+    let file_name_generator = DefaultFileNameGenerator::new(
+        "test".to_string(),
+        None,
+        iceberg::spec::DataFileFormat::Parquet,
+    );
+    let parquet_writer_builder = ParquetWriterBuilder::new(
+        WriterProperties::default(),
+        table.metadata().current_schema().clone(),
+        table.file_io().clone(),
+        location_generator.clone(),
+        file_name_generator.clone(),
+    );
+    let data_file_writer_builder = DataFileWriterBuilder::new(parquet_writer_builder, None, 0);
+    let mut data_file_writer = data_file_writer_builder.clone().build().await.unwrap();
+    let col1 = StringArray::from(vec![Some("foo"), Some("bar"), None, Some("baz")]);
+    let col2 = Int32Array::from(vec![Some(1), Some(2), Some(3), Some(4)]);
+    let col3 = BooleanArray::from(vec![Some(true), Some(false), None, Some(false)]);
+    let batch = RecordBatch::try_new(schema.clone(), vec![
+        Arc::new(col1) as ArrayRef,
+        Arc::new(col2) as ArrayRef,
+        Arc::new(col3) as ArrayRef,
+    ])
+    .unwrap();
+    data_file_writer.write(batch.clone()).await.unwrap();
+    let data_file1 = data_file_writer.close().await.unwrap();
+
+    let mut data_file_writer = data_file_writer_builder.clone().build().await.unwrap();
+    data_file_writer.write(batch.clone()).await.unwrap();
+    let data_file2 = data_file_writer.close().await.unwrap();
+
+    // Commit with sequence number
+
+    let tx = Transaction::new(&table);
+    let rewrite_action = tx
+        .rewrite_files(None, vec![])
+        .unwrap()
+        .add_data_files(data_file1.clone())
+        .unwrap()
+        .add_data_files(data_file2.clone())
+        .unwrap();
+    // Set sequence number to 12345
+    let rewrite_action = rewrite_action.new_data_file_sequence_number(12345).unwrap();
+    let tx = rewrite_action.apply().await.unwrap();
+    let table = tx.commit(&rest_catalog).await.unwrap();
+
+    // Verify manifest entry has correct sequence number
+    let snapshot = table.metadata().current_snapshot().unwrap();
+    let manifest_list = snapshot
+        .load_manifest_list(table.file_io(), table.metadata())
+        .await
+        .unwrap();
+
+    assert_eq!(manifest_list.entries().len(), 1);
+
+    for manifest_file in manifest_list.entries() {
+        let manifest = manifest_file.load_manifest(table.file_io()).await.unwrap();
+        for entry in manifest.entries() {
+            assert_eq!(entry.sequence_number(), Some(12345));
+        }
+    }
+}


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #.

## What changes are included in this PR?

This PR fixes the Manifest Entry Seq error generated by RewriteFile Action. Provide new_data_sequence_number to set the entry sequence.

related to https://github.com/apache/iceberg/blob/dfa5a979437783877e0f4aedfb62943d4cfcdf8e/core/src/main/java/org/apache/iceberg/actions/RewriteDataFilesCommitManager.java#L74

https://github.com/apache/iceberg/blob/dfa5a979437783877e0f4aedfb62943d4cfcdf8e/core/src/main/java/org/apache/iceberg/MergingSnapshotProducer.java#L1051

<!--
Provide a summary of the modifications in this PR. List the main changes such as new features, bug fixes, refactoring, or any other updates.
-->

## Are these changes tested?

<!--
Specify what test covers (unit test, integration test, etc.).

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->