### PR TITLE
feat: support update table for memory catalog

### DIFF
--- a/crates/catalog/memory/src/namespace_state.rs
+++ b/crates/catalog/memory/src/namespace_state.rs
@@ -301,33 +301,14 @@ impl NamespaceState {
         table_ident: &TableIdent,
         new_metadata_location: String,
     ) -> Result<()> {
-        let namespace_state = self.get_mut_namespace(&table_ident.namespace)?;
-        let namespace_name = table_ident.namespace.as_ref().last().unwrap();
-        let child_state = namespace_state
-            .namespaces
-            .get_mut(namespace_name)
-            .ok_or_else(|| {
-                Error::new(
-                    ErrorKind::DataInvalid,
-                    format!("Namespace '{}' does not exist", table_ident.namespace),
-                )
-            })?;
+        let namespace = self.get_mut_namespace(table_ident.namespace())?;
 
-        let table_name = table_ident.name();
-
-        if !child_state
-            .table_metadata_locations
-            .contains_key(table_name)
-        {
-            return Err(Error::new(
-                ErrorKind::DataInvalid,
-                format!("Table '{}' does not exist", table_ident),
-            ));
+        match namespace.table_metadata_locations.get_mut(table_ident.name()) {
+            None => no_such_table_err(table_ident),
+            Some(location) => {
+                *location = new_metadata_location;
+                Ok(())
+            }
         }
-
-        child_state
-            .table_metadata_locations
-            .insert(table_name.to_string(), new_metadata_location);
-        Ok(())
     }
 }

--- a/crates/catalog/memory/src/namespace_state.rs
+++ b/crates/catalog/memory/src/namespace_state.rs
@@ -303,7 +303,10 @@ impl NamespaceState {
     ) -> Result<()> {
         let namespace = self.get_mut_namespace(table_ident.namespace())?;
 
-        match namespace.table_metadata_locations.get_mut(table_ident.name()) {
+        match namespace
+            .table_metadata_locations
+            .get_mut(table_ident.name())
+        {
             None => no_such_table_err(table_ident),
             Some(location) => {
                 *location = new_metadata_location;


### PR DESCRIPTION
This pull request enhances the functionality of the `MemoryCatalog` by adding support for updating tables, including handling metadata updates and snapshots. The changes primarily focus on implementing table update logic and modifying the namespace state to accommodate metadata location updates.

### Enhancements to table update functionality:

* **Added support for `update_table` in `MemoryCatalog`:** Implemented logic to update table metadata, handle snapshot additions, and manage snapshot references. The new implementation reads the current metadata, applies updates, generates new metadata, writes it to a new location, and updates the namespace state accordingly. (`crates/catalog/memory/src/catalog.rs`, [crates/catalog/memory/src/catalog.rsL274-R343](diffhunk://#diff-fb467ca7921a5d68df4257547cec337a3a3535b264b8bbc4bf69e9f3e808d682L274-R343))

* **Introduced `TableUpdate` to `MemoryCatalog`:** Updated imports to include `TableUpdate`, which is used to apply specific update operations during table updates. (`crates/catalog/memory/src/catalog.rs`, [crates/catalog/memory/src/catalog.rsL29-R29](diffhunk://#diff-fb467ca7921a5d68df4257547cec337a3a3535b264b8bbc4bf69e9f3e808d682L29-R29))

### Modifications to namespace state:

* **Added `update_table_location` method to `NamespaceState`:** Implemented a method to update the metadata location of a table within the namespace state, ensuring the catalog reflects the latest table metadata. (`crates/catalog/memory/src/namespace_state.rs`, [crates/catalog/memory/src/namespace_state.rsR298-R313](diffhunk://#diff-202adb538eb8bce001ab1109cd54b3fc4a607cbee4171aa6cb3f67d92718c453R298-R313))