### PR TITLE
fix: fix location generator

### DIFF
--- a/crates/iceberg/src/writer/file_writer/location_generator.rs
+++ b/crates/iceberg/src/writer/file_writer/location_generator.rs
@@ -47,29 +47,19 @@ impl DefaultLocationGenerator {
     /// Create a new `DefaultLocationGenerator`.
     pub fn new(table_metadata: TableMetadata) -> Result<Self> {
         let table_location = table_metadata.location();
-        let rel_dir_path = {
-            let prop = table_metadata.properties();
-            let data_location = prop
-                .get(WRITE_DATA_LOCATION)
-                .or(prop.get(WRITE_FOLDER_STORAGE_LOCATION));
-            if let Some(data_location) = data_location {
-                data_location.strip_prefix(table_location).ok_or_else(|| {
-                    Error::new(
-                        ErrorKind::DataInvalid,
-                        format!(
-                            "data location {} is not a subpath of table location {}",
-                            data_location, table_location
-                        ),
-                    )
-                })?
-            } else {
-                DEFAULT_DATA_DIR
-            }
-        };
-
-        Ok(Self {
-            dir_path: format!("{}{}", table_location, rel_dir_path),
-        })
+        let prop = table_metadata.properties();
+        let data_location = prop
+            .get(WRITE_DATA_LOCATION)
+            .or(prop.get(WRITE_FOLDER_STORAGE_LOCATION));
+        if let Some(data_location) = data_location {
+            Ok(Self {
+                dir_path: data_location.clone(),
+            })
+        } else {
+            Ok(Self {
+                dir_path: format!("{}{}", table_location, DEFAULT_DATA_DIR),
+            })
+        }
     }
 }
 

--- a/crates/iceberg/src/writer/file_writer/location_generator.rs
+++ b/crates/iceberg/src/writer/file_writer/location_generator.rs
@@ -21,7 +21,7 @@ use std::sync::atomic::AtomicU64;
 use std::sync::Arc;
 
 use crate::spec::{DataFileFormat, TableMetadata};
-use crate::{Error, ErrorKind, Result};
+use crate::Result;
 
 /// `LocationGenerator` used to generate the location of data file.
 pub trait LocationGenerator: Clone + Send + 'static {
@@ -51,15 +51,12 @@ impl DefaultLocationGenerator {
         let data_location = prop
             .get(WRITE_DATA_LOCATION)
             .or(prop.get(WRITE_FOLDER_STORAGE_LOCATION));
-        if let Some(data_location) = data_location {
-            Ok(Self {
-                dir_path: data_location.clone(),
-            })
+        let dir_path = if let Some(data_location) = data_location {
+            data_location.clone()
         } else {
-            Ok(Self {
-                dir_path: format!("{}{}", table_location, DEFAULT_DATA_DIR),
-            })
-        }
+            format!("{}{}", table_location, DEFAULT_DATA_DIR)
+        };
+        Ok(Self { dir_path })
     }
 }
 

--- a/crates/iceberg/src/writer/file_writer/location_generator.rs
+++ b/crates/iceberg/src/writer/file_writer/location_generator.rs
@@ -209,13 +209,15 @@ pub(crate) mod test {
             "s3://data.db/table/data_2/part-00002-test.parquet"
         );
 
-        // test invalid data location
         table_metadata.properties.insert(
             WRITE_DATA_LOCATION.to_string(),
             // invalid table location
             "s3://data.db/data_3".to_string(),
         );
-        let location_generator = super::DefaultLocationGenerator::new(table_metadata.clone());
-        assert!(location_generator.is_err());
+        let location_generator =
+            super::DefaultLocationGenerator::new(table_metadata.clone()).unwrap();
+        let location =
+            location_generator.generate_location(&file_name_genertaor.generate_file_name());
+        assert_eq!(location, "s3://data.db/data_3/part-00003-test.parquet");
     }
 }


### PR DESCRIPTION
## Which issue does this PR close?

- To integrate with Databricks's managed iceberg table, we need to allow write.data.path to be not a subdirectory of the table location.

- Closes #.

## What changes are included in this PR?

<!--
Provide a summary of the modifications in this PR. List the main changes such as new features, bug fixes, refactoring, or any other updates.
-->

## Are these changes tested?

<!--
Specify what test covers (unit test, integration test, etc.).

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->