### PR TITLE
fix(azdls): enable append mode for AZDLS write operations

### DIFF
--- a/crates/iceberg/src/io/file_io.rs
+++ b/crates/iceberg/src/io/file_io.rs
@@ -361,7 +361,7 @@ pub struct OutputFile {
     relative_path_pos: usize,
     // Chunk size for write operations to ensure consistent size of multipart chunks
     chunk_size: Option<usize>,
-    // Whether to use append mode for writes (required for some storage backends like ADLS)
+    // Whether to use append mode for writes (required for some storage backends like AZDLS)
     append_file: bool,
 }
 


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #.

## What changes are included in this PR?

## Summary

Enable append mode for Azure Data Lake Storage (AZDLS) write operations.

## Problem

AZDLS has specific requirements for write operations that necessitate enabling append mode. Previously, there was no clean way to pass this parameter through the `FileIO` interface without affecting read operations.

https://github.com/apache/opendal/blob/9746efca6aaa95776d467e7e5e88c5ec93dfd00d/core/src/services/azfile/backend.rs#L328

When writing to Parquet, triggering a RowGroup switch will cause multiple IOs, thus hitting the OneShot limit.


## Solution

- Add an `append_file: bool` field to `OutputFile` struct
- Determine the append mode based on storage backend type in `new_output()`
- Use conditional compilation to set `append_file = true` for AZDLS, `false` otherwise
- Keep `create_operator()` signature unchanged to avoid polluting read-only interfaces

## Design Rationale

This approach was chosen because:
1. It doesn't modify the `create_operator()` return signature, keeping read operations clean
2. The append mode decision is made at the point where it's needed (`new_output`)
3. Uses pattern matching on `Storage` type, leveraging existing path parsing logic
4. Zero overhead when ADLS feature is not enabled (via conditional compilation)

<!--
Provide a summary of the modifications in this PR. List the main changes such as new features, bug fixes, refactoring, or any other updates.
-->

## Are these changes tested?

<!--
Specify what test covers (unit test, integration test, etc.).

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->