### PR TITLE
Allow to configure timeout settings in OpenDAL

### DIFF
--- a/crates/iceberg/src/io/file_io.rs
+++ b/crates/iceberg/src/io/file_io.rs
@@ -89,7 +89,9 @@ impl FileIO {
     ///
     /// * path: It should be *absolute* path starting with scheme string used to construct [`FileIO`].
     pub async fn delete(&self, path: impl AsRef<str>) -> Result<()> {
-        let (op, relative_path) = self.inner.create_operator_with_config(&path, &self.builder.props)?;
+        let (op, relative_path) = self
+            .inner
+            .create_operator_with_config(&path, &self.builder.props)?;
         Ok(op.delete(relative_path).await?)
     }
 
@@ -100,7 +102,9 @@ impl FileIO {
     /// * path: It should be *absolute* path starting with scheme string used to construct [`FileIO`].
     #[deprecated(note = "use remove_dir_all instead", since = "0.4.0")]
     pub async fn remove_all(&self, path: impl AsRef<str>) -> Result<()> {
-        let (op, relative_path) = self.inner.create_operator_with_config(&path, &self.builder.props)?;
+        let (op, relative_path) = self
+            .inner
+            .create_operator_with_config(&path, &self.builder.props)?;
         Ok(op.remove_all(relative_path).await?)
     }
 
@@ -116,7 +120,9 @@ impl FileIO {
     /// - If the path is a empty directory, this function will remove the directory itself.
     /// - If the path is a non-empty directory, this function will remove the directory and all nested files and directories.
     pub async fn remove_dir_all(&self, path: impl AsRef<str>) -> Result<()> {
-        let (op, relative_path) = self.inner.create_operator_with_config(&path, &self.builder.props)?;
+        let (op, relative_path) = self
+            .inner
+            .create_operator_with_config(&path, &self.builder.props)?;
         let path = if relative_path.ends_with('/') {
             relative_path.to_string()
         } else {
@@ -131,7 +137,9 @@ impl FileIO {
     ///
     /// * path: It should be *absolute* path starting with scheme string used to construct [`FileIO`].
     pub async fn exists(&self, path: impl AsRef<str>) -> Result<bool> {
-        let (op, relative_path) = self.inner.create_operator_with_config(&path, &self.builder.props)?;
+        let (op, relative_path) = self
+            .inner
+            .create_operator_with_config(&path, &self.builder.props)?;
         Ok(op.exists(relative_path).await?)
     }
 
@@ -141,7 +149,9 @@ impl FileIO {
     ///
     /// * path: It should be *absolute* path starting with scheme string used to construct [`FileIO`].
     pub fn new_input(&self, path: impl AsRef<str>) -> Result<InputFile> {
-        let (op, relative_path) = self.inner.create_operator_with_config(&path, &self.builder.props)?;
+        let (op, relative_path) = self
+            .inner
+            .create_operator_with_config(&path, &self.builder.props)?;
         let path = path.as_ref().to_string();
         let relative_path_pos = path.len() - relative_path.len();
         Ok(InputFile {
@@ -157,7 +167,9 @@ impl FileIO {
     ///
     /// * path: It should be *absolute* path starting with scheme string used to construct [`FileIO`].
     pub fn new_output(&self, path: impl AsRef<str>) -> Result<OutputFile> {
-        let (op, relative_path) = self.inner.create_operator_with_config(&path, &self.builder.props)?;
+        let (op, relative_path) = self
+            .inner
+            .create_operator_with_config(&path, &self.builder.props)?;
         let path = path.as_ref().to_string();
         let relative_path_pos = path.len() - relative_path.len();
         Ok(OutputFile {

--- a/crates/iceberg/src/io/storage.rs
+++ b/crates/iceberg/src/io/storage.rs
@@ -15,8 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use std::sync::Arc;
 use std::collections::HashMap;
+use std::sync::Arc;
 use std::time::Duration;
 
 use opendal::layers::{RetryLayer, TimeoutLayer};
@@ -233,23 +233,22 @@ impl Storage {
             .get("io.retry.factor")
             .and_then(|v| v.parse::<f32>().ok())
             .unwrap_or(2.0);
-        
+
         let mut operator = operator.layer(
             RetryLayer::new()
                 .with_max_times(retry_max_attempts)
                 .with_min_delay(Duration::from_millis(retry_min_delay_ms))
                 .with_max_delay(Duration::from_millis(retry_max_delay_ms))
-                .with_factor(retry_factor)
+                .with_factor(retry_factor),
         );
-        
+
         // Apply timeout layer if configured
         if let Some(timeout_ms) = props
             .get("io.timeout-ms")
-            .and_then(|v| v.parse::<u64>().ok()) {
-            operator = operator.layer(
-                TimeoutLayer::new()
-                    .with_timeout(Duration::from_millis(timeout_ms))
-            );
+            .and_then(|v| v.parse::<u64>().ok())
+        {
+            operator =
+                operator.layer(TimeoutLayer::new().with_timeout(Duration::from_millis(timeout_ms)));
         }
 
         Ok((operator, relative_path))


### PR DESCRIPTION
  Available Settings for Retry/Timeout

  - io.retry.max-attempts - Maximum retry attempts (default: 3)
  - io.retry.min-delay-ms - Minimum delay between retries (default: 1000)
  - io.retry.max-delay-ms - Maximum delay between retries (default: 60000)
  - io.retry.factor - Exponential backoff factor (default: 2.0)
  - io.timeout-ms - Operation timeout in milliseconds (optional, no default)

## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #.

## What changes are included in this PR?

<!--
Provide a summary of the modifications in this PR. List the main changes such as new features, bug fixes, refactoring, or any other updates.
-->

## Are these changes tested?

<!--
Specify what test covers (unit test, integration test, etc.).

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->