### PR TITLE
fix: fix record to struct deserialization

### DIFF
--- a/crates/iceberg/src/spec/values.rs
+++ b/crates/iceberg/src/spec/values.rs
@@ -3105,15 +3105,14 @@ mod tests {
 
         let raw =
             RawLiteral::try_from(literal.clone(), &Type::Struct(struct_type.clone())).unwrap();
-        let json = serde_json::to_string(&raw).unwrap();
 
-        // serde_json maps use BTreeMap ordering; this verifies we still recover schema order.
-        let deser: RawLiteral = serde_json::from_str(&json).unwrap();
+        // serde_json::Value uses BTreeMap (sorted keys), which mimics the RW metadata path.
+        let value = serde_json::to_value(&raw).unwrap();
+        let deser: RawLiteral = serde_json::from_value(value).unwrap();
         let roundtrip = deser.try_into(&Type::Struct(struct_type)).unwrap().unwrap();
 
         assert_eq!(roundtrip, literal);
     }
-
     #[test]
     fn json_boolean() {
         let record = r#"true"#;


### PR DESCRIPTION
This pull request improves the deserialization logic for struct types in the Iceberg spec, ensuring that field values are correctly mapped according to the schema's field order and requirements. Additionally, a new test is added to verify that struct field order is preserved during serialization and deserialization.

**Deserialization logic improvements:**

* Updated the struct deserialization process in `_serde` to use a `HashMap` for mapping field names to values, ensuring that required and optional fields are handled correctly and that the resulting struct respects the schema-defined order and requiredness. This change also adds explicit error handling for missing or null required fields. [[1]](diffhunk://#diff-0ab4b2d8c9bcfbb43cb0a06b6ef3015098edf660cbeebb5f196a55eba0326b83R2257-R2258) [[2]](diffhunk://#diff-0ab4b2d8c9bcfbb43cb0a06b6ef3015098edf660cbeebb5f196a55eba0326b83L2907-R2915) [[3]](diffhunk://#diff-0ab4b2d8c9bcfbb43cb0a06b6ef3015098edf660cbeebb5f196a55eba0326b83L2924-R2965)

**Testing enhancements:**

* Added a test, `json_struct_preserves_schema_order`, to verify that struct field order is preserved during JSON serialization and deserialization, and that the implementation can handle fields defined out of order in the schema.