### PR TITLE
feat: support clean_up_expired_files

### DIFF
--- a/crates/iceberg/src/table.rs
+++ b/crates/iceberg/src/table.rs
@@ -25,7 +25,7 @@ use crate::io::FileIO;
 use crate::io::object_cache::ObjectCache;
 use crate::scan::TableScanBuilder;
 use crate::spec::{SchemaRef, TableMetadata, TableMetadataRef};
-use crate::utils::{ReachableFileCleanupStrategy, DEFAULT_DELETE_CONCURRENCY_LIMIT};
+use crate::utils::{DEFAULT_DELETE_CONCURRENCY_LIMIT, ReachableFileCleanupStrategy};
 use crate::{Error, ErrorKind, Result, TableIdent};
 
 /// Builder to create table scan.
@@ -250,12 +250,12 @@ impl Table {
     ///
     /// Compares metadata before and after snapshot expiration to identify and delete
     /// unreachable files (manifest lists, manifests, and data files).
-    pub async fn cleanup_expired_files(
-        &self,
-        before_metadata: &TableMetadataRef,
-    ) -> Result<()> {
-        self.cleanup_expired_files_with_concurrency(before_metadata, DEFAULT_DELETE_CONCURRENCY_LIMIT)
-            .await
+    pub async fn cleanup_expired_files(&self, before_metadata: &TableMetadataRef) -> Result<()> {
+        self.cleanup_expired_files_with_concurrency(
+            before_metadata,
+            DEFAULT_DELETE_CONCURRENCY_LIMIT,
+        )
+        .await
     }
 
     /// Cleans up files from expired snapshots with configurable concurrency.


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #.

## What changes are included in this PR?

- Add cleanup_expired_files support with a configurable concurrency entry point and a default convenience wrapper.
- Clamp cleanup concurrency to a minimum of 1 and expose the default concurrency constant for reuse.
- Harden expired-snapshot cleanup by propagating manifest load errors instead of panicking, and refine tests to cover both expired and non-expired branches with stronger assertions.

<!--
Provide a summary of the modifications in this PR. List the main changes such as new features, bug fixes, refactoring, or any other updates.
-->

## Are these changes tested?

<!--
Specify what test covers (unit test, integration test, etc.).

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->