### PR TITLE
feat: parallel get byte ranges for parquet

### DIFF
--- a/crates/iceberg/src/arrow/reader.rs
+++ b/crates/iceberg/src/arrow/reader.rs
@@ -1700,8 +1700,7 @@ impl<R: FileRead> AsyncFileReader for ArrowFileReader<R> {
         async move {
             let concurrency = available_parallelism()
                 .get()
-                .min(MAX_BYTE_RANGE_CONCURRENCY)
-                .max(1);
+                .clamp(1, MAX_BYTE_RANGE_CONCURRENCY);
             let reads = ranges.into_iter().map(|range| {
                 reader
                     .read(range.start..range.end)


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #.

## What changes are included in this PR?

- Parallel get byte ranges for parquet files. This could significantly improve the query performance of iceberg.

## Are these changes tested?

<!--
Specify what test covers (unit test, integration test, etc.).

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->