### PR TITLE
feat(transaction): add post-commit cleanup support for snapshot expir…

### DIFF
--- a/crates/iceberg/src/transaction/action.rs
+++ b/crates/iceberg/src/transaction/action.rs
@@ -15,15 +15,29 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use std::future::Future;
 use std::mem::take;
+use std::pin::Pin;
 use std::sync::Arc;
 
 use as_any::AsAny;
 use async_trait::async_trait;
 
+use crate::io::FileIO;
+use crate::spec::TableMetadataRef;
 use crate::table::Table;
 use crate::transaction::Transaction;
 use crate::{Result, TableRequirement, TableUpdate};
+
+/// A boxed async cleanup callback that takes before/after metadata and FileIO.
+pub type PostCommitCleanup = Box<
+    dyn FnOnce(
+            TableMetadataRef,
+            TableMetadataRef,
+            FileIO,
+        ) -> Pin<Box<dyn Future<Output = Result<()>> + Send>>
+        + Send,
+>;
 
 /// A boxed, thread-safe reference to a `TransactionAction`.
 pub(crate) type BoxedTransactionAction = Arc<dyn TransactionAction>;
@@ -81,6 +95,7 @@ impl<T: TransactionAction + 'static> ApplyTransactionAction for T {
 pub struct ActionCommit {
     updates: Vec<TableUpdate>,
     requirements: Vec<TableRequirement>,
+    post_commit_cleanup: Option<PostCommitCleanup>,
 }
 
 impl ActionCommit {
@@ -89,7 +104,14 @@ impl ActionCommit {
         Self {
             updates,
             requirements,
+            post_commit_cleanup: None,
         }
+    }
+
+    /// Sets a post-commit cleanup callback that will be executed after successful commit.
+    pub fn with_post_commit_cleanup(mut self, cleanup: PostCommitCleanup) -> Self {
+        self.post_commit_cleanup = Some(cleanup);
+        self
     }
 
     /// Consumes and returns the list of table updates.
@@ -100,6 +122,11 @@ impl ActionCommit {
     /// Consumes and returns the list of table requirements.
     pub fn take_requirements(&mut self) -> Vec<TableRequirement> {
         take(&mut self.requirements)
+    }
+
+    /// Takes the post-commit cleanup callback if one was set.
+    pub fn take_post_commit_cleanup(&mut self) -> Option<PostCommitCleanup> {
+        take(&mut self.post_commit_cleanup)
     }
 }
 

--- a/crates/iceberg/src/transaction/mod.rs
+++ b/crates/iceberg/src/transaction/mod.rs
@@ -135,6 +135,7 @@ impl Transaction {
         mut action_commit: ActionCommit,
         existing_updates: &mut Vec<TableUpdate>,
         existing_requirements: &mut Vec<TableRequirement>,
+        post_commit_cleanups: &mut Vec<PostCommitCleanup>,
     ) -> Result<Table> {
         let updates = action_commit.take_updates();
         let requirements = action_commit.take_requirements();
@@ -147,6 +148,10 @@ impl Transaction {
 
         existing_updates.extend(updates);
         existing_requirements.extend(requirements);
+
+        if let Some(cleanup) = action_commit.take_post_commit_cleanup() {
+            post_commit_cleanups.push(cleanup);
+        }
 
         Ok(updated_table)
     }
@@ -255,9 +260,13 @@ impl Transaction {
             self.table = refreshed.clone();
         }
 
+        let before_metadata = self.table.metadata_ref();
+        let file_io = self.table.file_io().clone();
+
         let mut current_table = self.table.clone();
         let mut existing_updates: Vec<TableUpdate> = vec![];
         let mut existing_requirements: Vec<TableRequirement> = vec![];
+        let mut post_commit_cleanups: Vec<PostCommitCleanup> = vec![];
 
         for action in &self.actions {
             let action_commit = Arc::clone(action).commit(&current_table).await?;
@@ -267,6 +276,7 @@ impl Transaction {
                 action_commit,
                 &mut existing_updates,
                 &mut existing_requirements,
+                &mut post_commit_cleanups,
             )?;
         }
 
@@ -276,7 +286,15 @@ impl Transaction {
             .requirements(existing_requirements)
             .build();
 
-        catalog.update_table(table_commit).await
+        let committed_table = catalog.update_table(table_commit).await?;
+
+        // Execute post-commit cleanup callbacks (e.g., file deletion for expired snapshots)
+        let after_metadata = committed_table.metadata_ref();
+        for cleanup in post_commit_cleanups {
+            cleanup(before_metadata.clone(), after_metadata.clone(), file_io.clone()).await?;
+        }
+
+        Ok(committed_table)
     }
 }
 

--- a/crates/iceberg/src/transaction/remove_snapshots.rs
+++ b/crates/iceberg/src/transaction/remove_snapshots.rs
@@ -27,7 +27,7 @@ use crate::error::Result;
 use crate::spec::{MAIN_BRANCH, SnapshotReference, SnapshotRetention, TableMetadataRef};
 use crate::table::Table;
 use crate::transaction::{ActionCommit, TransactionAction};
-use crate::utils::ancestors_of;
+use crate::utils::{ReachableFileCleanupStrategy, ancestors_of};
 use crate::{Error, ErrorKind, TableRequirement, TableUpdate};
 
 /// Default value for max snapshot age in milliseconds.
@@ -382,7 +382,22 @@ impl TransactionAction for RemoveSnapshotAction {
             snapshot_id: table_meta.current_snapshot_id(),
         });
 
-        Ok(ActionCommit::new(updates, requirements))
+        let mut action_commit = ActionCommit::new(updates, requirements);
+
+        if self.clear_expire_files {
+            action_commit = action_commit.with_post_commit_cleanup(Box::new(
+                |before_metadata, after_metadata, file_io| {
+                    Box::pin(async move {
+                        let cleanup_strategy = ReachableFileCleanupStrategy::new(file_io);
+                        cleanup_strategy
+                            .clean_files(&before_metadata, &after_metadata)
+                            .await
+                    })
+                },
+            ));
+        }
+
+        Ok(action_commit)
     }
 }
 

--- a/crates/iceberg/src/utils.rs
+++ b/crates/iceberg/src/utils.rs
@@ -318,12 +318,12 @@ impl ReachableFileCleanupStrategy {
         }
     }
 
-    fn collect_expired_snapshots<'a>(
-        &'a self,
-        before_expiration: &'a TableMetadataRef,
-        after_expiration: &'a TableMetadataRef,
-    ) -> (Vec<SnapshotRef>, HashSet<&'a str>) {
-        let mut manifest_lists_to_delete: HashSet<&str> = HashSet::default();
+    fn collect_expired_snapshots(
+        &self,
+        before_expiration: &TableMetadataRef,
+        after_expiration: &TableMetadataRef,
+    ) -> (Vec<SnapshotRef>, HashSet<String>) {
+        let mut manifest_lists_to_delete: HashSet<String> = HashSet::default();
         let mut expired_snapshots = Vec::default();
 
         for snapshot in before_expiration.snapshots() {
@@ -332,7 +332,7 @@ impl ReachableFileCleanupStrategy {
                 .is_none()
             {
                 expired_snapshots.push(snapshot.clone());
-                manifest_lists_to_delete.insert(snapshot.manifest_list());
+                manifest_lists_to_delete.insert(snapshot.manifest_list().to_string());
             }
         }
 
@@ -416,8 +416,7 @@ impl ReachableFileCleanupStrategy {
             }
         }
 
-        self.delete_files(manifest_lists_to_delete.into_iter().map(|s| s.to_string()))
-            .await?;
+        self.delete_files(manifest_lists_to_delete).await?;
 
         Ok(())
     }


### PR DESCRIPTION
Problem: clear_expire_files exists but never called.

 Add a PostCommitCleanup callback mechanism to ActionCommit that allows
  transaction actions to register cleanup operations executed after successful
  commit. This enables the RemoveSnapshotAction to safely delete expired
  snapshot files only after the metadata update has been committed.

## Which issue does this PR close?

- Closes https://github.com/risingwavelabs/iceberg-rust/issues/120.

## What changes are included in this PR?


  - Add PostCommitCleanup type for async cleanup callbacks
  - Extend ActionCommit with optional post-commit cleanup support
  - Collect and execute cleanup callbacks in Transaction::commit()
  - Wire up ReachableFileCleanupStrategy in RemoveSnapshotAction
  - Fix lifetime issues in collect_expired_snapshots by using owned Strings
