### PR TITLE
test: add compile test for cleanup_expired_files HRTB limitation

### DIFF
--- a/crates/iceberg/tests/cleanup_expired_files_hrtb.rs
+++ b/crates/iceberg/tests/cleanup_expired_files_hrtb.rs
@@ -1,0 +1,25 @@
+// This test verifies that `cleanup_expired_files` cannot be used with
+// higher-ranked trait bounds (HRTB) where Fn (not FnOnce) is required.
+// This is a known limitation that should cause CI to fail.
+
+use std::future::Future;
+use std::sync::Arc;
+
+use iceberg::spec::TableMetadata;
+use iceberg::table::Table;
+
+// Using Fn instead of FnOnce - the closure must be callable multiple times
+fn with_hrtb_fn<F, Fut>(f: F)
+where
+    F: for<'a> Fn(&'a Table, &'a Arc<TableMetadata>) -> Fut,
+    Fut: Future<Output = ()>,
+{
+    let _ = f;
+}
+
+#[tokio::test]
+async fn cleanup_expired_files_hrtb() {
+    with_hrtb_fn(|table, before_metadata| async move {
+        let _ = table.cleanup_expired_files(before_metadata).await;
+    });
+}


### PR DESCRIPTION
  Add a test that demonstrates the higher-ranked trait bounds (HRTB)
  limitation when using cleanup_expired_files with async closures
  that require Fn bounds. This test intentionally fails to compile
  to document this known limitation.