### PR TITLE
fix: normalize nested field names in RecordBatchTransformer

### DIFF
--- a/crates/iceberg/src/arrow/record_batch_transformer.rs
+++ b/crates/iceberg/src/arrow/record_batch_transformer.rs
@@ -371,6 +371,10 @@ impl RecordBatchTransformer {
             .iter()
             .zip(target_schema.fields().iter())
         {
+            // DataType equality (==) is recursive and includes nested field names
+            // and metadata, so e.g. List(Field("item", Int32)) != List(Field("element", Int32)).
+            // This correctly routes nested-field-name mismatches to SchemaComparison::Different,
+            // which triggers generate_transform_operations where they are handled via cast.
             if source_field.data_type() != target_field.data_type()
                 || source_field.is_nullable() != target_field.is_nullable()
             {
@@ -437,11 +441,17 @@ impl RecordBatchTransformer {
                 // No conflict detection needed - schema resolution happened in reader.rs.
                 let field_by_id = field_id_to_source_schema_map.get(field_id).map(
                     |(source_field, source_index)| {
-                        if source_field.data_type().equals_datatype(target_type) {
+                        if source_field.data_type() == target_type {
+                            // Exact match: data type including nested field names are identical,
+                            // so the column can be used as-is.
                             ColumnSource::PassThrough {
                                 source_index: *source_index,
                             }
                         } else {
+                            // Covers both field-name normalization (e.g., Parquet's List inner
+                            // field "item" → Iceberg's "element", or Map's "entries" →
+                            // "key_value") and actual type promotion (e.g., Int32 → Int64).
+                            // Arrow's cast() handles both correctly.
                             ColumnSource::Promote {
                                 target_type: target_type.clone(),
                                 source_index: *source_index,
@@ -834,14 +844,12 @@ mod test {
                     NestedField::optional(
                         3,
                         "struct_col",
-                        Type::Struct(crate::spec::StructType::new(vec![
-                            NestedField::optional(
-                                100,
-                                "inner_field",
-                                Type::Primitive(PrimitiveType::String),
-                            )
-                            .into(),
-                        ])),
+                        Type::Struct(crate::spec::StructType::new(vec![NestedField::optional(
+                            100,
+                            "inner_field",
+                            Type::Primitive(PrimitiveType::String),
+                        )
+                        .into()])),
                     )
                     .into(),
                 ])
@@ -1594,5 +1602,367 @@ mod test {
             .unwrap();
         assert!(notes_column.is_null(0));
         assert!(notes_column.is_null(1));
+    }
+
+    // -----------------------------------------------------------------------
+    // Helpers for List / Map field-name normalization tests
+    // -----------------------------------------------------------------------
+
+    /// Build an Iceberg schema that contains a single `list<int>` column
+    /// with nullable elements.
+    fn iceberg_schema_with_list() -> Schema {
+        Schema::builder()
+            .with_schema_id(1)
+            .with_fields(vec![
+                NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
+                NestedField::optional(
+                    2,
+                    "tags",
+                    Type::List(crate::spec::ListType {
+                        element_field: NestedField::list_element(
+                            3,
+                            Type::Primitive(PrimitiveType::Int),
+                            false, // optional (nullable) elements
+                        )
+                        .into(),
+                    }),
+                )
+                .into(),
+            ])
+            .build()
+            .unwrap()
+    }
+
+    /// Build a Parquet-style Arrow schema + `RecordBatch` where the list inner
+    /// field is named `inner_name` (e.g. `"item"` for Parquet, `"element"` for
+    /// Iceberg).
+    fn parquet_batch_with_list_field_name(
+        inner_name: &str,
+        id_values: Vec<i32>,
+        list_values: Vec<i32>,
+        offsets: Vec<usize>,
+    ) -> RecordBatch {
+        use arrow_array::ListArray;
+        use arrow_buffer::OffsetBuffer;
+
+        let inner_field = Arc::new(Field::new(inner_name, DataType::Int32, true).with_metadata(
+            HashMap::from([(PARQUET_FIELD_ID_META_KEY.to_string(), "3".to_string())]),
+        ));
+        let schema = Arc::new(ArrowSchema::new(vec![
+            simple_field("id", DataType::Int32, false, "1"),
+            Field::new("tags", DataType::List(inner_field.clone()), true).with_metadata(
+                HashMap::from([(PARQUET_FIELD_ID_META_KEY.to_string(), "2".to_string())]),
+            ),
+        ]));
+
+        let values = Int32Array::from(list_values);
+        let offset_buf = OffsetBuffer::from_lengths(offsets);
+        let list_array = ListArray::new(inner_field, offset_buf, Arc::new(values), None);
+
+        RecordBatch::try_new(schema, vec![
+            Arc::new(Int32Array::from(id_values)),
+            Arc::new(list_array),
+        ])
+        .unwrap()
+    }
+
+    /// Assert that every column in `batch` has a data type that exactly matches
+    /// the corresponding schema field (strict `==`, the same check that
+    /// `RecordBatch::try_new` / `concat_batches` performs).
+    fn assert_strict_schema_match(batch: &RecordBatch) {
+        let schema = batch.schema();
+        for (i, field) in schema.fields().iter().enumerate() {
+            assert_eq!(
+                batch.column(i).data_type(),
+                field.data_type(),
+                "column {} data type does not strictly match schema field '{}'",
+                i,
+                field.name(),
+            );
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Tests
+    // -----------------------------------------------------------------------
+
+    /// Parquet files store list inner fields as `"item"` while Iceberg uses
+    /// `"element"`. The transformer must cast the column so that the output
+    /// data type exactly matches the target schema, including nested field
+    /// names. Without this, downstream consumers that use strict schema
+    /// validation (e.g. DataFusion's `concat_batches` → `RecordBatch::try_new`)
+    /// fail with "column types must match schema types".
+    #[test]
+    fn list_field_name_normalized_from_item_to_element() {
+        let snapshot_schema = Arc::new(iceberg_schema_with_list());
+        let projected = [1, 2];
+        let mut transformer =
+            RecordBatchTransformerBuilder::new(snapshot_schema, &projected).build();
+
+        let file_batch =
+            parquet_batch_with_list_field_name("item", vec![1, 2], vec![10, 20, 30], vec![2, 1]);
+
+        let result = transformer.process_record_batch(file_batch).unwrap();
+
+        assert_eq!(result.num_columns(), 2);
+        assert_eq!(result.num_rows(), 2);
+        assert_strict_schema_match(&result);
+
+        // Schema-level check
+        let list_dt = result.schema().field(1).data_type().clone();
+        match &list_dt {
+            DataType::List(f) => assert_eq!(f.name(), "element"),
+            other => panic!("expected List, got {other:?}"),
+        }
+
+        // Column-level check (the actual array, not just the schema wrapper)
+        match result.column(1).data_type() {
+            DataType::List(f) => assert_eq!(f.name(), "element"),
+            other => panic!("expected List, got {other:?}"),
+        }
+
+        // Must survive strict RecordBatch::try_new (same validation concat_batches uses)
+        RecordBatch::try_new(result.schema(), result.columns().to_vec())
+            .expect("result batch must pass strict schema validation");
+    }
+
+    /// When the Parquet file already uses `"element"` (matching Iceberg), the
+    /// transformer must take the `PassThrough` path — no cast needed. We verify
+    /// by checking the output is identical to the input.
+    #[test]
+    fn list_field_name_already_matching_uses_passthrough() {
+        let snapshot_schema = Arc::new(iceberg_schema_with_list());
+        let projected = [1, 2];
+        let mut transformer =
+            RecordBatchTransformerBuilder::new(snapshot_schema, &projected).build();
+
+        let file_batch =
+            parquet_batch_with_list_field_name("element", vec![1, 2], vec![10, 20, 30], vec![2, 1]);
+
+        let result = transformer.process_record_batch(file_batch).unwrap();
+
+        assert_eq!(result.num_columns(), 2);
+        assert_eq!(result.num_rows(), 2);
+        assert_strict_schema_match(&result);
+
+        // Data must be identical — no unnecessary cast
+        assert_eq!(
+            result
+                .column(0)
+                .as_any()
+                .downcast_ref::<Int32Array>()
+                .unwrap()
+                .values(),
+            &[1, 2],
+        );
+        let list_col = result
+            .column(1)
+            .as_any()
+            .downcast_ref::<arrow_array::ListArray>()
+            .unwrap();
+        // first row: [10,20], second row: [30]
+        assert_eq!(list_col.value(0).len(), 2);
+        assert_eq!(list_col.value(1).len(), 1);
+    }
+
+    /// Verify that list data values survive the cast-based normalization
+    /// intact, including nulls.
+    #[test]
+    fn list_field_name_normalization_preserves_data() {
+        use arrow_array::ListArray;
+        use arrow_buffer::OffsetBuffer;
+
+        let snapshot_schema = Arc::new(iceberg_schema_with_list());
+        let projected = [1, 2];
+        let mut transformer =
+            RecordBatchTransformerBuilder::new(snapshot_schema, &projected).build();
+
+        let inner_field = Arc::new(Field::new("item", DataType::Int32, true).with_metadata(
+            HashMap::from([(PARQUET_FIELD_ID_META_KEY.to_string(), "3".to_string())]),
+        ));
+        let schema = Arc::new(ArrowSchema::new(vec![
+            simple_field("id", DataType::Int32, false, "1"),
+            Field::new("tags", DataType::List(inner_field.clone()), true).with_metadata(
+                HashMap::from([(PARQUET_FIELD_ID_META_KEY.to_string(), "2".to_string())]),
+            ),
+        ]));
+
+        // Row 0: [10, null, 30]   Row 1: []   Row 2: null (whole list null)
+        let values = Int32Array::from(vec![Some(10), None, Some(30)]);
+        let offsets = OffsetBuffer::from_lengths([3, 0, 0]);
+        let nulls = arrow_buffer::NullBuffer::from(vec![true, true, false]);
+        let list_array = ListArray::new(inner_field, offsets, Arc::new(values), Some(nulls));
+
+        let file_batch = RecordBatch::try_new(schema, vec![
+            Arc::new(Int32Array::from(vec![1, 2, 3])),
+            Arc::new(list_array),
+        ])
+        .unwrap();
+
+        let result = transformer.process_record_batch(file_batch).unwrap();
+
+        assert_eq!(result.num_rows(), 3);
+        assert_strict_schema_match(&result);
+
+        let list_col = result
+            .column(1)
+            .as_any()
+            .downcast_ref::<ListArray>()
+            .unwrap();
+
+        // Row 0: [10, null, 30]
+        assert!(!list_col.is_null(0));
+        let row0 = list_col.value(0);
+        let row0_ints = row0.as_any().downcast_ref::<Int32Array>().unwrap();
+        assert_eq!(row0_ints.len(), 3);
+        assert_eq!(row0_ints.value(0), 10);
+        assert!(row0_ints.is_null(1));
+        assert_eq!(row0_ints.value(2), 30);
+
+        // Row 1: []
+        assert!(!list_col.is_null(1));
+        assert_eq!(list_col.value(1).len(), 0);
+
+        // Row 2: null
+        assert!(list_col.is_null(2));
+    }
+
+    /// Processing multiple batches through the same transformer must work.
+    /// The `BatchTransform` is lazily initialized on the first batch, so
+    /// subsequent batches reuse the same transform. Both must produce
+    /// normalized output.
+    #[test]
+    fn list_field_name_normalization_multiple_batches() {
+        let snapshot_schema = Arc::new(iceberg_schema_with_list());
+        let projected = [1, 2];
+        let mut transformer =
+            RecordBatchTransformerBuilder::new(snapshot_schema, &projected).build();
+
+        let batch1 =
+            parquet_batch_with_list_field_name("item", vec![1, 2], vec![10, 20, 30], vec![2, 1]);
+        let batch2 = parquet_batch_with_list_field_name("item", vec![3], vec![40, 50], vec![2]);
+
+        let result1 = transformer.process_record_batch(batch1).unwrap();
+        let result2 = transformer.process_record_batch(batch2).unwrap();
+
+        for (i, result) in [&result1, &result2].iter().enumerate() {
+            assert_strict_schema_match(result);
+            match result.column(1).data_type() {
+                DataType::List(f) => assert_eq!(
+                    f.name(),
+                    "element",
+                    "batch {i}: inner field should be 'element'"
+                ),
+                other => panic!("batch {i}: expected List, got {other:?}"),
+            }
+        }
+
+        // Verify concat_batches would work (it uses RecordBatch::try_new internally)
+        let schema = result1.schema();
+        let concat = arrow_select::concat::concat_batches(&schema, [&result1, &result2]);
+        assert!(
+            concat.is_ok(),
+            "concat_batches must succeed after normalization: {:?}",
+            concat.err()
+        );
+        assert_eq!(concat.unwrap().num_rows(), 3);
+    }
+
+    /// Map type: Parquet may store the map entries struct field with a
+    /// different name than Iceberg's `"key_value"`. Verify that the
+    /// transformer normalizes the struct field names inside the map.
+    #[test]
+    fn map_field_name_normalized() {
+        use arrow_array::MapArray;
+        use arrow_buffer::OffsetBuffer;
+
+        let snapshot_schema = Arc::new(
+            Schema::builder()
+                .with_schema_id(1)
+                .with_fields(vec![
+                    NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
+                    NestedField::optional(
+                        2,
+                        "props",
+                        Type::Map(crate::spec::MapType::new(
+                            NestedField::map_key_element(3, Type::Primitive(PrimitiveType::String))
+                                .into(),
+                            NestedField::map_value_element(
+                                4,
+                                Type::Primitive(PrimitiveType::String),
+                                true,
+                            )
+                            .into(),
+                        )),
+                    )
+                    .into(),
+                ])
+                .build()
+                .unwrap(),
+        );
+        let projected = [1, 2];
+        let mut transformer =
+            RecordBatchTransformerBuilder::new(snapshot_schema, &projected).build();
+
+        // Parquet uses "entries" for the struct field and "key"/"value" for children.
+        // Iceberg's schema_to_arrow_schema uses "key_value" and "key"/"value".
+        let key_field = Arc::new(Field::new("key", DataType::Utf8, false).with_metadata(
+            HashMap::from([(PARQUET_FIELD_ID_META_KEY.to_string(), "3".to_string())]),
+        ));
+        let value_field = Arc::new(Field::new("value", DataType::Utf8, true).with_metadata(
+            HashMap::from([(PARQUET_FIELD_ID_META_KEY.to_string(), "4".to_string())]),
+        ));
+        // Parquet standard uses "entries"; Iceberg uses "key_value"
+        let entries_field = Arc::new(Field::new(
+            "entries",
+            DataType::Struct(vec![key_field.clone(), value_field.clone()].into()),
+            false,
+        ));
+        let file_schema = Arc::new(ArrowSchema::new(vec![
+            simple_field("id", DataType::Int32, false, "1"),
+            Field::new("props", DataType::Map(entries_field.clone(), false), true).with_metadata(
+                HashMap::from([(PARQUET_FIELD_ID_META_KEY.to_string(), "2".to_string())]),
+            ),
+        ]));
+
+        // Build a MapArray directly: row 0 → {"a":"1"}, row 1 → {} (empty)
+        let keys = StringArray::from(vec!["a"]);
+        let values = StringArray::from(vec![Some("1")]);
+        let struct_array = arrow_array::StructArray::new(
+            vec![key_field.clone(), value_field.clone()].into(),
+            vec![Arc::new(keys) as _, Arc::new(values) as _],
+            None,
+        );
+        let offsets = OffsetBuffer::from_lengths([1, 0]); // row0: 1 entry, row1: 0 entries
+        let map_array = MapArray::new(entries_field, offsets, struct_array, None, false);
+
+        let file_batch = RecordBatch::try_new(file_schema, vec![
+            Arc::new(Int32Array::from(vec![1, 2])),
+            Arc::new(map_array),
+        ])
+        .unwrap();
+
+        let result = transformer.process_record_batch(file_batch).unwrap();
+
+        assert_eq!(result.num_columns(), 2);
+        assert_eq!(result.num_rows(), 2);
+        assert_strict_schema_match(&result);
+
+        // Verify the map struct field is normalized to "key_value"
+        match result.column(1).data_type() {
+            DataType::Map(entries, _) => {
+                assert_eq!(
+                    entries.name(),
+                    "key_value",
+                    "Map entries field should be 'key_value', got '{}'",
+                    entries.name(),
+                );
+            }
+            other => panic!("expected Map, got {other:?}"),
+        }
+
+        // Must survive strict RecordBatch::try_new
+        RecordBatch::try_new(result.schema(), result.columns().to_vec())
+            .expect("result batch must pass strict schema validation");
     }
 }

--- a/crates/iceberg/src/arrow/record_batch_transformer.rs
+++ b/crates/iceberg/src/arrow/record_batch_transformer.rs
@@ -844,12 +844,14 @@ mod test {
                     NestedField::optional(
                         3,
                         "struct_col",
-                        Type::Struct(crate::spec::StructType::new(vec![NestedField::optional(
-                            100,
-                            "inner_field",
-                            Type::Primitive(PrimitiveType::String),
-                        )
-                        .into()])),
+                        Type::Struct(crate::spec::StructType::new(vec![
+                            NestedField::optional(
+                                100,
+                                "inner_field",
+                                Type::Primitive(PrimitiveType::String),
+                            )
+                            .into(),
+                        ])),
                     )
                     .into(),
                 ])

--- a/crates/iceberg/src/writer/file_writer/parquet_writer.rs
+++ b/crates/iceberg/src/writer/file_writer/parquet_writer.rs
@@ -24,9 +24,9 @@ use arrow_schema::SchemaRef as ArrowSchemaRef;
 use bytes::Bytes;
 use futures::future::BoxFuture;
 use itertools::Itertools;
+use parquet::arrow::AsyncArrowWriter;
 use parquet::arrow::async_reader::AsyncFileReader;
 use parquet::arrow::async_writer::AsyncFileWriter as ArrowAsyncFileWriter;
-use parquet::arrow::AsyncArrowWriter;
 use parquet::file::metadata::{KeyValue, ParquetMetaData, ParquetMetaDataReader};
 use parquet::file::properties::WriterProperties;
 use parquet::file::statistics::Statistics;
@@ -36,14 +36,14 @@ use thrift::protocol::TOutputProtocol;
 
 use super::{FileWriter, FileWriterBuilder};
 use crate::arrow::{
-    get_parquet_stat_max_as_datum, get_parquet_stat_min_as_datum, ArrowFileReader, FieldMatchMode,
-    NanValueCountVisitor, DEFAULT_MAP_FIELD_NAME,
+    ArrowFileReader, DEFAULT_MAP_FIELD_NAME, FieldMatchMode, NanValueCountVisitor,
+    get_parquet_stat_max_as_datum, get_parquet_stat_min_as_datum,
 };
 use crate::io::{FileIO, FileWrite, OutputFile};
 use crate::spec::{
-    visit_schema, DataContentType, DataFileBuilder, DataFileFormat, Datum, ListType, Literal,
-    MapType, NestedFieldRef, PartitionSpec, PrimitiveType, Schema, SchemaRef, SchemaVisitor,
-    Struct, StructType, TableMetadata, Type,
+    DataContentType, DataFileBuilder, DataFileFormat, Datum, ListType, Literal, MapType,
+    NestedFieldRef, PartitionSpec, PrimitiveType, Schema, SchemaRef, SchemaVisitor, Struct,
+    StructType, TableMetadata, Type, visit_schema,
 };
 use crate::transform::create_transform_function;
 use crate::writer::{CurrentFileStatus, DataFile};
@@ -784,17 +784,21 @@ mod tests {
                 NestedField::required(
                     4,
                     "col4",
-                    Type::Struct(StructType::new(vec![NestedField::required(
-                        8,
-                        "col_4_8",
-                        Type::Struct(StructType::new(vec![NestedField::required(
-                            9,
-                            "col_4_8_9",
-                            Type::Primitive(PrimitiveType::Long),
+                    Type::Struct(StructType::new(vec![
+                        NestedField::required(
+                            8,
+                            "col_4_8",
+                            Type::Struct(StructType::new(vec![
+                                NestedField::required(
+                                    9,
+                                    "col_4_8_9",
+                                    Type::Primitive(PrimitiveType::Long),
+                                )
+                                .into(),
+                            ])),
                         )
-                        .into()])),
-                    )
-                    .into()])),
+                        .into(),
+                    ])),
                 )
                 .into(),
                 NestedField::required(
@@ -1063,10 +1067,9 @@ mod tests {
                 ordered,
             )
         }) as ArrayRef;
-        let to_write = RecordBatch::try_new(
-            arrow_schema.clone(),
-            vec![col0, col1, col2, col3, col4, col5],
-        )
+        let to_write = RecordBatch::try_new(arrow_schema.clone(), vec![
+            col0, col1, col2, col3, col4, col5,
+        ])
         .unwrap();
         let output_file = file_io.new_output(
             location_gen.generate_location(None, &file_name_gen.generate_file_name()),
@@ -1253,13 +1256,10 @@ mod tests {
                 .with_precision_and_scale(38, 5)
                 .unwrap(),
         ) as ArrayRef;
-        let to_write = RecordBatch::try_new(
-            arrow_schema.clone(),
-            vec![
-                col0, col1, col2, col3, col4, col5, col6, col7, col8, col9, col10, col11, col12,
-                col13, col14, col15, col16,
-            ],
-        )
+        let to_write = RecordBatch::try_new(arrow_schema.clone(), vec![
+            col0, col1, col2, col3, col4, col5, col6, col7, col8, col9, col10, col11, col12, col13,
+            col14, col15, col16,
+        ])
         .unwrap();
         let output_file = file_io.new_output(
             location_gen.generate_location(None, &file_name_gen.generate_file_name()),
@@ -1287,10 +1287,12 @@ mod tests {
         // check data file
         assert_eq!(data_file.record_count(), 4);
         assert!(data_file.value_counts().iter().all(|(_, &v)| { v == 4 }));
-        assert!(data_file
-            .null_value_counts()
-            .iter()
-            .all(|(_, &v)| { v == 1 }));
+        assert!(
+            data_file
+                .null_value_counts()
+                .iter()
+                .all(|(_, &v)| { v == 1 })
+        );
         assert_eq!(
             *data_file.lower_bounds(),
             HashMap::from([
@@ -1394,15 +1396,17 @@ mod tests {
         // test 1.1 and 2.2
         let schema = Arc::new(
             Schema::builder()
-                .with_fields(vec![NestedField::optional(
-                    0,
-                    "decimal",
-                    Type::Primitive(PrimitiveType::Decimal {
-                        precision: 28,
-                        scale: 10,
-                    }),
-                )
-                .into()])
+                .with_fields(vec![
+                    NestedField::optional(
+                        0,
+                        "decimal",
+                        Type::Primitive(PrimitiveType::Decimal {
+                            precision: 28,
+                            scale: 10,
+                        }),
+                    )
+                    .into(),
+                ])
                 .build()
                 .unwrap(),
         );
@@ -1444,15 +1448,17 @@ mod tests {
         // test -1.1 and -2.2
         let schema = Arc::new(
             Schema::builder()
-                .with_fields(vec![NestedField::optional(
-                    0,
-                    "decimal",
-                    Type::Primitive(PrimitiveType::Decimal {
-                        precision: 28,
-                        scale: 10,
-                    }),
-                )
-                .into()])
+                .with_fields(vec![
+                    NestedField::optional(
+                        0,
+                        "decimal",
+                        Type::Primitive(PrimitiveType::Decimal {
+                            precision: 28,
+                            scale: 10,
+                        }),
+                    )
+                    .into(),
+                ])
                 .build()
                 .unwrap(),
         );
@@ -1497,15 +1503,17 @@ mod tests {
         assert_eq!(decimal_max.scale(), decimal_min.scale());
         let schema = Arc::new(
             Schema::builder()
-                .with_fields(vec![NestedField::optional(
-                    0,
-                    "decimal",
-                    Type::Primitive(PrimitiveType::Decimal {
-                        precision: 38,
-                        scale: decimal_max.scale(),
-                    }),
-                )
-                .into()])
+                .with_fields(vec![
+                    NestedField::optional(
+                        0,
+                        "decimal",
+                        Type::Primitive(PrimitiveType::Decimal {
+                            precision: 38,
+                            scale: decimal_max.scale(),
+                        }),
+                    )
+                    .into(),
+                ])
                 .build()
                 .unwrap(),
         );
@@ -1765,29 +1773,31 @@ mod tests {
         let file_name_gen =
             DefaultFileNameGenerator::new("test".to_string(), None, DataFileFormat::Parquet);
 
-        let schema_struct_float_fields =
-            Fields::from(vec![Field::new("col4", DataType::Float32, false)
-                .with_metadata(HashMap::from([(
-                    PARQUET_FIELD_ID_META_KEY.to_string(),
-                    "4".to_string(),
-                )]))]);
+        let schema_struct_float_fields = Fields::from(vec![
+            Field::new("col4", DataType::Float32, false).with_metadata(HashMap::from([(
+                PARQUET_FIELD_ID_META_KEY.to_string(),
+                "4".to_string(),
+            )])),
+        ]);
 
-        let schema_struct_nested_float_fields =
-            Fields::from(vec![Field::new("col7", DataType::Float32, false)
-                .with_metadata(HashMap::from([(
-                    PARQUET_FIELD_ID_META_KEY.to_string(),
-                    "7".to_string(),
-                )]))]);
+        let schema_struct_nested_float_fields = Fields::from(vec![
+            Field::new("col7", DataType::Float32, false).with_metadata(HashMap::from([(
+                PARQUET_FIELD_ID_META_KEY.to_string(),
+                "7".to_string(),
+            )])),
+        ]);
 
-        let schema_struct_nested_fields = Fields::from(vec![Field::new(
-            "col6",
-            arrow_schema::DataType::Struct(schema_struct_nested_float_fields.clone()),
-            false,
-        )
-        .with_metadata(HashMap::from([(
-            PARQUET_FIELD_ID_META_KEY.to_string(),
-            "6".to_string(),
-        )]))]);
+        let schema_struct_nested_fields = Fields::from(vec![
+            Field::new(
+                "col6",
+                arrow_schema::DataType::Struct(schema_struct_nested_float_fields.clone()),
+                false,
+            )
+            .with_metadata(HashMap::from([(
+                PARQUET_FIELD_ID_META_KEY.to_string(),
+                "6".to_string(),
+            )])),
+        ]);
 
         // prepare data
         let arrow_schema = {
@@ -1835,10 +1845,10 @@ mod tests {
             None,
         )) as ArrayRef;
 
-        let to_write = RecordBatch::try_new(
-            arrow_schema.clone(),
-            vec![struct_float_field_col, struct_nested_float_field_col],
-        )
+        let to_write = RecordBatch::try_new(arrow_schema.clone(), vec![
+            struct_float_field_col,
+            struct_nested_float_field_col,
+        ])
         .unwrap();
         let output_file = file_io.new_output(
             location_gen.generate_location(None, &file_name_gen.generate_file_name()),
@@ -1913,15 +1923,11 @@ mod tests {
                 "4".to_string(),
             )]));
 
-        let schema_struct_list_field = Fields::from(vec![Field::new_list(
-            "col2",
-            schema_struct_list_float_field.clone(),
-            true,
-        )
-        .with_metadata(HashMap::from([(
-            PARQUET_FIELD_ID_META_KEY.to_string(),
-            "3".to_string(),
-        )]))]);
+        let schema_struct_list_field = Fields::from(vec![
+            Field::new_list("col2", schema_struct_list_float_field.clone(), true).with_metadata(
+                HashMap::from([(PARQUET_FIELD_ID_META_KEY.to_string(), "3".to_string())]),
+            ),
+        ]);
 
         let arrow_schema = {
             let fields = vec![
@@ -1997,14 +2003,11 @@ mod tests {
             None,
         )) as ArrayRef;
 
-        let to_write = RecordBatch::try_new(
-            arrow_schema.clone(),
-            vec![
-                list_float_field_col,
-                struct_list_float_field_col,
-                // large_list_float_field_col,
-            ],
-        )
+        let to_write = RecordBatch::try_new(arrow_schema.clone(), vec![
+            list_float_field_col,
+            struct_list_float_field_col,
+            // large_list_float_field_col,
+        ])
         .expect("Could not form record batch");
         let output_file = file_io.new_output(
             location_gen.generate_location(None, &file_name_gen.generate_file_name()),
@@ -2132,18 +2135,20 @@ mod tests {
                 [(PARQUET_FIELD_ID_META_KEY.to_string(), "7".to_string())],
             ));
 
-        let schema_struct_map_field = Fields::from(vec![Field::new_map(
-            "col3",
-            DEFAULT_MAP_FIELD_NAME,
-            struct_map_key_field_schema.clone(),
-            struct_map_value_field_schema.clone(),
-            false,
-            false,
-        )
-        .with_metadata(HashMap::from([(
-            PARQUET_FIELD_ID_META_KEY.to_string(),
-            "5".to_string(),
-        )]))]);
+        let schema_struct_map_field = Fields::from(vec![
+            Field::new_map(
+                "col3",
+                DEFAULT_MAP_FIELD_NAME,
+                struct_map_key_field_schema.clone(),
+                struct_map_value_field_schema.clone(),
+                false,
+                false,
+            )
+            .with_metadata(HashMap::from([(
+                PARQUET_FIELD_ID_META_KEY.to_string(),
+                "5".to_string(),
+            )])),
+        ]);
 
         let arrow_schema = {
             let fields = vec![
@@ -2180,10 +2185,10 @@ mod tests {
             None,
         )) as ArrayRef;
 
-        let to_write = RecordBatch::try_new(
-            arrow_schema.clone(),
-            vec![map_array, struct_list_float_field_col],
-        )
+        let to_write = RecordBatch::try_new(arrow_schema.clone(), vec![
+            map_array,
+            struct_list_float_field_col,
+        ])
         .expect("Could not form record batch");
         let output_file = file_io.new_output(
             location_gen.generate_location(None, &file_name_gen.generate_file_name()),
@@ -2275,13 +2280,11 @@ mod tests {
             Arc::new(
                 Schema::builder()
                     .with_schema_id(1)
-                    .with_fields(vec![NestedField::required(
-                        0,
-                        "col",
-                        Type::Primitive(PrimitiveType::Long),
-                    )
-                    .with_id(0)
-                    .into()])
+                    .with_fields(vec![
+                        NestedField::required(0, "col", Type::Primitive(PrimitiveType::Long))
+                            .with_id(0)
+                            .into(),
+                    ])
                     .build()
                     .expect("Failed to create schema"),
             ),
@@ -2302,13 +2305,11 @@ mod tests {
         let schema = Arc::new(
             Schema::builder()
                 .with_schema_id(1)
-                .with_fields(vec![NestedField::required(
-                    0,
-                    "col",
-                    Type::Primitive(PrimitiveType::Int),
-                )
-                .with_id(0)
-                .into()])
+                .with_fields(vec![
+                    NestedField::required(0, "col", Type::Primitive(PrimitiveType::Int))
+                        .with_id(0)
+                        .into(),
+                ])
                 .build()
                 .expect("Failed to create schema"),
         );


### PR DESCRIPTION
## Which issue does this PR close?

Parquet files use "item" as the List inner field name (Parquet spec) while Iceberg uses "element" (Iceberg spec). Similarly, Parquet uses "entries" for Map inner fields while Iceberg uses "key_value".

Closes #110

## What changes are included in this PR?

The RecordBatchTransformer previously used equals_datatype() (which ignores field names) to decide between PassThrough and Promote. This meant columns with mismatched nested field names were passed through unchanged, causing downstream consumers that use strict schema validation (like DataFusion's concat_batches) to fail with: "column types must match schema types, expected List(Field { name: element ..."

Fix: use a 3-way comparison in generate_transform_operations:
1. Strict == match → PassThrough (no cast needed)
2. equals_datatype() but != (field names differ) → Promote (cast to normalize names)
3. Neither → Promote (actual type promotion)

## Are these changes tested?

Unit tests