### PR TITLE
fix: update rust toolchain to nightly-2025-10-27 and apply cargo fmt

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -20,5 +20,5 @@
 #
 # The channel is exactly same day for our MSRV.
 [toolchain]
-channel = "nightly-2025-03-28"
+channel = "nightly-2025-10-27"
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
## Which issue does this PR close?
- N/A — maintenance change to align toolchain with upstream apache/iceberg-rust.

## What changes are included in this PR?
- Update rust-toolchain.toml from older nightly to nightly-2025-10-27 to match upstream apache/iceberg-rust.
- No source code changes needed — existing code already passes cargo fmt --check with the new nightly.

## Are these changes tested?
- Verified cargo fmt --all -- --check passes with the updated nightly toolchain.
- Verified cargo check -p iceberg builds successfully.
- No new tests needed as this is a toolchain-only change with no impact on runtime behavior.