### PR TITLE
fix: make RemoveOrphanFilesAction::execute() future Send-safe

### DIFF
--- a/crates/iceberg/src/actions/remove_orphan_files.rs
+++ b/crates/iceberg/src/actions/remove_orphan_files.rs
@@ -24,12 +24,12 @@
 use std::collections::HashSet;
 use std::time::Duration;
 
-use futures::TryStreamExt;
 use futures::stream::{self, StreamExt};
+use futures::TryStreamExt;
 
-use crate::Result;
 use crate::table::Table;
 use crate::utils::{load_manifest_lists, load_manifests};
+use crate::Result;
 
 /// Default time offset for orphan file deletion threshold (1 day in milliseconds).
 const DEFAULT_OLDER_THAN_MS: i64 = 7 * 24 * 60 * 60 * 1000; // 7 days
@@ -141,11 +141,15 @@ impl RemoveOrphanFilesAction {
             return Ok(orphan_files);
         }
 
-        // Remove orphan files concurrently
-        stream::iter(&orphan_files)
+        // Remove orphan files concurrently.
+        // Clone paths into owned Strings so each async task owns its data,
+        // making the resulting future Send-safe (avoids HRTB lifetime issues
+        // with borrowed references across await points).
+        let file_io = file_io.clone();
+        stream::iter(orphan_files.clone())
             .map(|path| {
                 let file_io = file_io.clone();
-                async move { file_io.delete(path).await }
+                async move { file_io.delete(&path).await }
             })
             .buffer_unordered(self.delete_concurrency)
             .try_collect::<Vec<_>>()

--- a/crates/iceberg/src/actions/remove_orphan_files.rs
+++ b/crates/iceberg/src/actions/remove_orphan_files.rs
@@ -24,12 +24,12 @@
 use std::collections::HashSet;
 use std::time::Duration;
 
-use futures::stream::{self, StreamExt};
 use futures::TryStreamExt;
+use futures::stream::{self, StreamExt};
 
+use crate::Result;
 use crate::table::Table;
 use crate::utils::{load_manifest_lists, load_manifests};
-use crate::Result;
 
 /// Default time offset for orphan file deletion threshold (1 day in milliseconds).
 const DEFAULT_OLDER_THAN_MS: i64 = 7 * 24 * 60 * 60 * 1000; // 7 days


### PR DESCRIPTION
The delete loop iterated over &orphan_files, creating borrowed &String references captured by async blocks. This caused a higher-ranked trait bound (HRTB) error when the execute() future was used inside tokio::spawn or any other Send-requiring context.

Fix: iterate over owned Strings (via clone()) so each async task owns its data, eliminating the lifetime issue.