### PR TITLE
feat: Variant Support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4733,6 +4733,9 @@ dependencies = [
  "num-integer",
  "num-traits",
  "object_store",
+ "parquet-variant",
+ "parquet-variant-compute",
+ "parquet-variant-json",
  "paste",
  "ring",
  "seq-macro",
@@ -4742,6 +4745,51 @@ dependencies = [
  "tokio",
  "twox-hash",
  "zstd",
+]
+
+[[package]]
+name = "parquet-variant"
+version = "58.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bf493f3c9ddd984d0efb019f67343e4aa4bab893931f6a14b82083065dc3d28"
+dependencies = [
+ "arrow-schema",
+ "chrono",
+ "half",
+ "indexmap 2.14.0",
+ "simdutf8",
+ "uuid",
+]
+
+[[package]]
+name = "parquet-variant-compute"
+version = "58.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ac038d46a503a7d563b4f5df5802c4315d5343d009feab195d15ac512b4cb27"
+dependencies = [
+ "arrow",
+ "arrow-schema",
+ "chrono",
+ "half",
+ "indexmap 2.14.0",
+ "parquet-variant",
+ "parquet-variant-json",
+ "serde_json",
+ "uuid",
+]
+
+[[package]]
+name = "parquet-variant-json"
+version = "58.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "015a09c2ffe5108766c7c1235c307b8a3c2ea64eca38455ba1a7f3a7f32f16e2"
+dependencies = [
+ "arrow-schema",
+ "base64",
+ "chrono",
+ "parquet-variant",
+ "serde_json",
+ "uuid",
 ]
 
 [[package]]

--- a/crates/catalog/glue/src/schema.rs
+++ b/crates/catalog/glue/src/schema.rs
@@ -182,6 +182,13 @@ impl SchemaVisitor for GlueSchemaBuilder {
 
         Ok(glue_type)
     }
+
+    fn variant(&mut self, _v: &iceberg::spec::VariantType) -> Result<Self::T> {
+        Err(Error::new(
+            ErrorKind::FeatureUnsupported,
+            "Conversion from VariantType is not supported for Glue",
+        ))
+    }
 }
 
 #[cfg(test)]

--- a/crates/catalog/glue/src/schema.rs
+++ b/crates/catalog/glue/src/schema.rs
@@ -25,7 +25,7 @@ pub(crate) const ICEBERG_FIELD_CURRENT: &str = "iceberg.field.current";
 use std::collections::HashMap;
 
 use aws_sdk_glue::types::Column;
-use iceberg::spec::{PrimitiveType, SchemaVisitor, TableMetadata, visit_schema};
+use iceberg::spec::{PrimitiveType, SchemaVisitor, TableMetadata, VariantType, visit_schema};
 use iceberg::{Error, ErrorKind, Result};
 
 use crate::error::from_aws_build_error;
@@ -183,26 +183,31 @@ impl SchemaVisitor for GlueSchemaBuilder {
         Ok(glue_type)
     }
 
-    fn variant(&mut self, _v: &iceberg::spec::VariantType) -> Result<Self::T> {
-        Err(Error::new(
-            ErrorKind::FeatureUnsupported,
-            "Conversion from VariantType is not supported for Glue",
-        ))
+    fn variant(&mut self, _v: &VariantType) -> Result<Self::T> {
+        Ok("variant".to_string())
     }
 }
 
 #[cfg(test)]
 mod tests {
     use iceberg::TableCreation;
-    use iceberg::spec::{Schema, TableMetadataBuilder};
+    use iceberg::spec::{FormatVersion, Schema, TableMetadataBuilder};
 
     use super::*;
 
     fn create_metadata(schema: Schema) -> Result<TableMetadata> {
+        create_metadata_with_format_version(schema, FormatVersion::V2)
+    }
+
+    fn create_metadata_with_format_version(
+        schema: Schema,
+        format_version: FormatVersion,
+    ) -> Result<TableMetadata> {
         let table_creation = TableCreation::builder()
             .name("my_table".to_string())
             .location("my_location".to_string())
             .schema(schema)
+            .format_version(format_version)
             .build();
         let metadata = TableMetadataBuilder::from_table_creation(table_creation)?
             .build()?
@@ -526,6 +531,33 @@ mod tests {
             create_column("required_field", "string", "1", false)?,
             create_column("optional_field", "int", "2", true)?,
         ];
+
+        assert_eq!(result, expected);
+        Ok(())
+    }
+
+    #[test]
+    fn test_schema_with_variant() -> Result<()> {
+        let record = r#"{
+            "type": "struct",
+            "schema-id": 1,
+            "fields": [
+                {
+                    "id": 1,
+                    "name": "v",
+                    "required": true,
+                    "type": "variant"
+                }
+            ]
+        }"#;
+
+        let schema = serde_json::from_str::<Schema>(record)?;
+        // Variant requires format version 3.
+        let metadata = create_metadata_with_format_version(schema, FormatVersion::V3)?;
+
+        let result = GlueSchemaBuilder::from_iceberg(&metadata)?.build();
+
+        let expected = vec![create_column("v", "variant", "1", false)?];
 
         assert_eq!(result, expected);
         Ok(())

--- a/crates/catalog/hms/src/schema.rs
+++ b/crates/catalog/hms/src/schema.rs
@@ -139,6 +139,13 @@ impl SchemaVisitor for HiveSchemaBuilder {
 
         Ok(hive_type)
     }
+
+    fn variant(&mut self, _v: &iceberg::spec::VariantType) -> Result<Self::T> {
+        Err(Error::new(
+            ErrorKind::FeatureUnsupported,
+            "Conversion from VariantType is not supported for HMS",
+        ))
+    }
 }
 
 #[cfg(test)]

--- a/crates/catalog/hms/src/schema.rs
+++ b/crates/catalog/hms/src/schema.rs
@@ -16,7 +16,7 @@
 // under the License.
 
 use hive_metastore::FieldSchema;
-use iceberg::spec::{PrimitiveType, Schema, SchemaVisitor, visit_schema};
+use iceberg::spec::{PrimitiveType, Schema, SchemaVisitor, VariantType, visit_schema};
 use iceberg::{Error, ErrorKind, Result};
 
 type HiveSchema = Vec<FieldSchema>;
@@ -140,11 +140,10 @@ impl SchemaVisitor for HiveSchemaBuilder {
         Ok(hive_type)
     }
 
-    fn variant(&mut self, _v: &iceberg::spec::VariantType) -> Result<Self::T> {
-        Err(Error::new(
-            ErrorKind::FeatureUnsupported,
-            "Conversion from VariantType is not supported for HMS",
-        ))
+    fn variant(&mut self, _v: &VariantType) -> Result<Self::T> {
+        // Match iceberg-java's HiveSchemaUtil, which maps VARIANT to "unknown"
+        // (apache/iceberg#15964).
+        Ok("unknown".to_string())
     }
 }
 
@@ -458,6 +457,38 @@ mod tests {
                 comment: None,
             },
         ];
+
+        assert_eq!(result, expected);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_schema_with_variant() -> Result<()> {
+        // VARIANT maps to Hive "unknown", matching iceberg-java's HiveSchemaUtil
+        // (apache/iceberg#15964).
+        let record = r#"{
+            "type": "struct",
+            "schema-id": 1,
+            "fields": [
+                {
+                    "id": 1,
+                    "name": "v",
+                    "required": true,
+                    "type": "variant"
+                }
+            ]
+        }"#;
+
+        let schema = serde_json::from_str::<Schema>(record)?;
+
+        let result = HiveSchemaBuilder::from_iceberg(&schema)?.build();
+
+        let expected = vec![FieldSchema {
+            name: Some("v".into()),
+            r#type: Some("unknown".into()),
+            comment: None,
+        }];
 
         assert_eq!(result, expected);
 

--- a/crates/iceberg/Cargo.toml
+++ b/crates/iceberg/Cargo.toml
@@ -73,7 +73,7 @@ murmur3 = { workspace = true }
 once_cell = { workspace = true }
 opendal = { workspace = true }
 ordered-float = { workspace = true }
-parquet = { workspace = true, features = ["async"] }
+parquet = { workspace = true, features = ["async", "variant_experimental"] }
 rand = { workspace = true }
 reqsign = { version = "0.16.3", optional = true, default-features = false }
 reqwest = { workspace = true }

--- a/crates/iceberg/src/arrow/caching_delete_file_loader.rs
+++ b/crates/iceberg/src/arrow/caching_delete_file_loader.rs
@@ -35,7 +35,7 @@ use crate::scan::{ArrowRecordBatchStream, FileScanTask};
 use crate::spec::{
     DataContentType, DataFileFormat, Datum, ListType, MapType, NestedField, NestedFieldRef,
     PartnerAccessor, PrimitiveType, Schema, SchemaRef, SchemaWithPartnerVisitor, StructType, Type,
-    visit_schema_with_partner,
+    VariantType, visit_schema_with_partner,
 };
 use crate::{Error, ErrorKind, Result};
 
@@ -606,6 +606,10 @@ impl SchemaWithPartnerVisitor<ArrayRef> for EqDelColumnProcessor<'_> {
     }
 
     fn primitive(&mut self, _primitive: &PrimitiveType, _partner: &ArrayRef) -> Result<()> {
+        Ok(())
+    }
+
+    fn variant(&mut self, _v: &VariantType, _partner: &ArrayRef) -> Result<()> {
         Ok(())
     }
 }

--- a/crates/iceberg/src/arrow/caching_delete_file_loader.rs
+++ b/crates/iceberg/src/arrow/caching_delete_file_loader.rs
@@ -36,7 +36,7 @@ use crate::scan::{ArrowRecordBatchStream, FileScanTask};
 use crate::spec::{
     DataContentType, DataFileFormat, Datum, ListType, MapType, NestedField, NestedFieldRef,
     PartnerAccessor, PrimitiveType, Schema, SchemaRef, SchemaWithPartnerVisitor, StructType, Type,
-    visit_schema_with_partner,
+    VariantType, visit_schema_with_partner,
 };
 use crate::{Error, ErrorKind, Result};
 
@@ -647,6 +647,10 @@ impl SchemaWithPartnerVisitor<ArrayRef> for EqDelColumnProcessor<'_> {
     }
 
     fn primitive(&mut self, _primitive: &PrimitiveType, _partner: &ArrayRef) -> Result<()> {
+        Ok(())
+    }
+
+    fn variant(&mut self, _v: &VariantType, _partner: &ArrayRef) -> Result<()> {
         Ok(())
     }
 }

--- a/crates/iceberg/src/arrow/nan_val_cnt_visitor.rs
+++ b/crates/iceberg/src/arrow/nan_val_cnt_visitor.rs
@@ -28,7 +28,7 @@ use crate::Result;
 use crate::arrow::{ArrowArrayAccessor, FieldMatchMode};
 use crate::spec::{
     ListType, MapType, NestedFieldRef, PrimitiveType, Schema, SchemaRef, SchemaWithPartnerVisitor,
-    StructType, visit_struct_with_partner,
+    StructType, VariantType, visit_struct_with_partner,
 };
 
 macro_rules! cast_and_update_cnt_map {
@@ -119,6 +119,10 @@ impl SchemaWithPartnerVisitor<ArrayRef> for NanValueCountVisitor {
     }
 
     fn primitive(&mut self, _p: &PrimitiveType, _col: &ArrayRef) -> Result<Self::T> {
+        Ok(())
+    }
+
+    fn variant(&mut self, _v: &VariantType, _col: &ArrayRef) -> Result<Self::T> {
         Ok(())
     }
 

--- a/crates/iceberg/src/arrow/reader.rs
+++ b/crates/iceberg/src/arrow/reader.rs
@@ -689,6 +689,10 @@ impl ArrowReader {
                 Self::include_leaf_field_id(&map_type.key_field, field_ids);
                 Self::include_leaf_field_id(&map_type.value_field, field_ids);
             }
+            // Variant is a leaf type for Parquet projection purposes (like a primitive).
+            Type::Variant(_) => {
+                field_ids.push(field.id);
+            }
         }
     }
 
@@ -761,8 +765,46 @@ impl ArrowReader {
         arrow_schema: &ArrowSchemaRef,
         type_promotion_is_valid: fn(Option<&PrimitiveType>, Option<&PrimitiveType>) -> bool,
     ) -> Result<ProjectionMask> {
-        let mut column_map = HashMap::new();
+        // Maps field_id → leaf column indices. Vec because variant contributes two
+        // leaves (metadata + value) under a single field ID.
+        let mut column_map: HashMap<i32, Vec<usize>> = HashMap::new();
         let fields = arrow_schema.fields();
+        // HashSet for O(1) membership checks instead of O(n) slice scans.
+        let leaf_field_id_set: HashSet<i32> = leaf_field_ids.iter().copied().collect();
+
+        // Variant fields are an Iceberg leaf type but a Parquet GROUP.  Their
+        // sub-fields (metadata, value) carry no embedded field IDs — only the
+        // parent group has the field ID. filter_leaves therefore never finds
+        // them via the standard field-ID scan below.
+        //
+        // Java's PruneColumns.variant() simply returns the group as-is with no
+        // type-compatibility check (isStruct() also short-circuits on isVariantType()).
+        // We replicate that here: pre-scan top-level Arrow struct fields whose
+        // field ID resolves to Type::Variant and record all their sub-fields so
+        // the second filter_leaves can include them directly.
+        let mut variant_sub_fields: HashMap<FieldRef, i32> = HashMap::new();
+        for top_field in fields.iter() {
+            let Some(field_id) = top_field
+                .metadata()
+                .get(PARQUET_FIELD_ID_META_KEY)
+                .and_then(|s| i32::from_str(s).ok())
+            else {
+                continue;
+            };
+            if !leaf_field_id_set.contains(&field_id) {
+                continue;
+            }
+            let Some(iceberg_field) = iceberg_schema_of_task.field_by_id(field_id) else {
+                continue;
+            };
+            if let Type::Variant(_) = iceberg_field.field_type.as_ref()
+                && let DataType::Struct(sub_fields) = top_field.data_type()
+            {
+                for sub_field in sub_fields {
+                    variant_sub_fields.insert(sub_field.clone(), field_id);
+                }
+            }
+        }
 
         // Pre-project only the fields that have been selected, possibly avoiding converting
         // some Arrow types that are not yet supported.
@@ -774,7 +816,7 @@ impl ArrowReader {
                     .and_then(|field_id| i32::from_str(field_id).ok())
                     .is_some_and(|field_id| {
                         projected_fields.insert((*f).clone(), field_id);
-                        leaf_field_ids.contains(&field_id)
+                        leaf_field_id_set.contains(&field_id)
                     })
             }),
             arrow_schema.metadata().clone(),
@@ -782,6 +824,14 @@ impl ArrowReader {
         let iceberg_schema = arrow_schema_to_schema(&projected_arrow_schema)?;
 
         fields.filter_leaves(|idx, field| {
+            // Variant sub-fields: parent group carries the field ID, not the leaf.
+            // Skip type-promotion check — Type::Variant is not a primitive type
+            // (matches Java's PruneColumns.variant() which returns the group unchanged).
+            if let Some(&variant_field_id) = variant_sub_fields.get(field) {
+                column_map.entry(variant_field_id).or_default().push(idx);
+                return true;
+            }
+
             let Some(field_id) = projected_fields.get(field).cloned() else {
                 return false;
             };
@@ -803,7 +853,7 @@ impl ArrowReader {
                 return false;
             }
 
-            column_map.insert(field_id, idx);
+            column_map.entry(field_id).or_default().push(idx);
             true
         });
 
@@ -811,8 +861,8 @@ impl ArrowReader {
         // We only project existing columns; RecordBatchTransformer adds default/NULL values.
         let mut indices = vec![];
         for field_id in leaf_field_ids {
-            if let Some(col_idx) = column_map.get(field_id) {
-                indices.push(*col_idx);
+            if let Some(col_indices) = column_map.get(field_id) {
+                indices.extend_from_slice(col_indices);
             }
         }
 
@@ -1864,7 +1914,8 @@ mod tests {
     use crate::io::FileIO;
     use crate::scan::{FileScanTask, FileScanTaskStream};
     use crate::spec::{
-        DataContentType, DataFileFormat, Datum, NestedField, PrimitiveType, Schema, SchemaRef, Type,
+        DataContentType, DataFileFormat, Datum, NestedField, PrimitiveType, Schema, SchemaRef,
+        Type, VariantType,
     };
 
     fn table_schema_simple() -> SchemaRef {
@@ -2045,6 +2096,100 @@ message schema {
         )
         .expect("Some ProjectionMask");
         assert_eq!(mask, ProjectionMask::leaves(&parquet_schema, vec![0]));
+    }
+
+    /// Variant fields are an Iceberg leaf type but a Parquet GROUP whose sub-fields carry
+    /// no embedded field IDs.  The projection mask must include both metadata and value
+    /// leaves when the variant field ID is requested, and must not drop the variant when
+    /// it is projected alongside ordinary primitive columns.
+    #[test]
+    fn test_arrow_projection_mask_variant() {
+        // Iceberg schema: c1 (String, id=1) + v (Variant, id=2)
+        let schema = Arc::new(
+            Schema::builder()
+                .with_schema_id(1)
+                .with_fields(vec![
+                    NestedField::required(1, "c1", Type::Primitive(PrimitiveType::String)).into(),
+                    NestedField::required(2, "v", Type::Variant(VariantType)).into(),
+                ])
+                .build()
+                .unwrap(),
+        );
+
+        // Arrow schema: c1 with field ID 1; v as Struct(metadata: Binary, value: Binary)
+        // with field ID 2 on the struct but NO field IDs on the sub-fields — that is the
+        // Parquet variant wire format.
+        let arrow_schema = Arc::new(ArrowSchema::new(vec![
+            Field::new("c1", DataType::Utf8, false).with_metadata(HashMap::from([(
+                PARQUET_FIELD_ID_META_KEY.to_string(),
+                "1".to_string(),
+            )])),
+            Field::new(
+                "v",
+                DataType::Struct(arrow_schema::Fields::from(vec![
+                    Arc::new(Field::new("metadata", DataType::Binary, false)),
+                    Arc::new(Field::new("value", DataType::Binary, false)),
+                ])),
+                false,
+            )
+            .with_metadata(HashMap::from([(
+                PARQUET_FIELD_ID_META_KEY.to_string(),
+                "2".to_string(),
+            )])),
+        ]));
+
+        // Parquet message: c1 is leaf 0; variant sub-fields metadata=leaf 1, value=leaf 2.
+        // No field IDs on sub-leaves — matching the real Iceberg/Spark-written variant format.
+        let message_type = "
+message schema {
+  required binary c1 (STRING) = 1;
+  required group v = 2 {
+    required binary metadata;
+    required binary value;
+  }
+}
+";
+        let parquet_type = parse_message_type(message_type).expect("should parse schema");
+        let parquet_schema = SchemaDescriptor::new(Arc::new(parquet_type));
+
+        // Both fields: all three leaves must be included.
+        let mask = ArrowReader::get_arrow_projection_mask(
+            &[1, 2],
+            &schema,
+            &parquet_schema,
+            &arrow_schema,
+            false,
+        )
+        .expect("projection mask for c1 + v");
+        assert_eq!(mask, ProjectionMask::leaves(&parquet_schema, vec![0, 1, 2]));
+
+        // Variant only: leaves 1 (metadata) and 2 (value) must be included.
+        let mask_variant_only = ArrowReader::get_arrow_projection_mask(
+            &[2],
+            &schema,
+            &parquet_schema,
+            &arrow_schema,
+            false,
+        )
+        .expect("projection mask for v only");
+        assert_eq!(
+            mask_variant_only,
+            ProjectionMask::leaves(&parquet_schema, vec![1, 2]),
+        );
+
+        // Primitive only: leaf 0 (c1) must be included; variant NOT included.
+        let mask_primitive_only = ArrowReader::get_arrow_projection_mask(
+            &[1],
+            &schema,
+            &parquet_schema,
+            &arrow_schema,
+            false,
+        )
+        .expect("projection mask for c1 only");
+        assert_eq!(
+            mask_primitive_only,
+            ProjectionMask::leaves(&parquet_schema, vec![0]),
+        );
     }
 
     #[tokio::test]

--- a/crates/iceberg/src/arrow/reader.rs
+++ b/crates/iceberg/src/arrow/reader.rs
@@ -2449,6 +2449,82 @@ message schema {
         assert_eq!(mask, ProjectionMask::leaves(&parquet_schema, vec![0, 1, 2]));
     }
 
+    /// Files written by Spark/iceberg-java annotate variant groups with the Parquet
+    /// VARIANT logical type but embed no Arrow schema, so the Arrow schema is derived
+    /// from the Parquet schema at read time. The derivation (parquet's
+    /// `variant_experimental` feature) must attach the variant extension metadata,
+    /// otherwise `arrow_schema_to_schema` recurses into the id-less variant sub-fields
+    /// and fails with "Field id not found in metadata".
+    #[test]
+    fn test_arrow_projection_mask_variant_schema_derived_from_parquet() {
+        use parquet::basic::{LogicalType, Repetition, Type as PhysicalType};
+        use parquet::schema::types::Type as ParquetSchemaType;
+
+        let schema = Arc::new(
+            Schema::builder()
+                .with_schema_id(1)
+                .with_fields(vec![
+                    NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
+                    NestedField::required(2, "v", Type::Variant(VariantType)).into(),
+                ])
+                .build()
+                .unwrap(),
+        );
+
+        let id_field = ParquetSchemaType::primitive_type_builder("id", PhysicalType::INT32)
+            .with_repetition(Repetition::REQUIRED)
+            .with_id(Some(1))
+            .build()
+            .unwrap();
+        let metadata_field =
+            ParquetSchemaType::primitive_type_builder("metadata", PhysicalType::BYTE_ARRAY)
+                .with_repetition(Repetition::REQUIRED)
+                .build()
+                .unwrap();
+        let value_field =
+            ParquetSchemaType::primitive_type_builder("value", PhysicalType::BYTE_ARRAY)
+                .with_repetition(Repetition::REQUIRED)
+                .build()
+                .unwrap();
+        let variant_group = ParquetSchemaType::group_type_builder("v")
+            .with_repetition(Repetition::REQUIRED)
+            .with_logical_type(Some(LogicalType::Variant {
+                specification_version: None,
+            }))
+            .with_id(Some(2))
+            .with_fields(vec![metadata_field.into(), value_field.into()])
+            .build()
+            .unwrap();
+        let message = ParquetSchemaType::group_type_builder("schema")
+            .with_fields(vec![id_field.into(), variant_group.into()])
+            .build()
+            .unwrap();
+        let parquet_schema = SchemaDescriptor::new(Arc::new(message));
+
+        let arrow_schema =
+            Arc::new(parquet::arrow::parquet_to_arrow_schema(&parquet_schema, None).unwrap());
+        assert_eq!(
+            arrow_schema
+                .field_with_name("v")
+                .unwrap()
+                .metadata()
+                .get(EXTENSION_TYPE_NAME_KEY)
+                .map(String::as_str),
+            Some("arrow.parquet.variant"),
+            "derived Arrow schema must carry the variant extension metadata"
+        );
+
+        let mask = ArrowReader::get_arrow_projection_mask(
+            &[1, 2],
+            &schema,
+            &parquet_schema,
+            &arrow_schema,
+            false,
+        )
+        .expect("projection mask for parquet-derived variant schema");
+        assert_eq!(mask, ProjectionMask::leaves(&parquet_schema, vec![0, 1, 2]));
+    }
+
     #[test]
     fn test_arrow_projection_mask_dictionary_wrapped_variant() {
         let schema = Arc::new(

--- a/crates/iceberg/src/arrow/reader.rs
+++ b/crates/iceberg/src/arrow/reader.rs
@@ -698,7 +698,7 @@ impl ArrowReader {
         fields: &arrow_schema::Fields,
         iceberg_schema_of_task: &Schema,
         selected_leaf_field_ids: &HashSet<i32>,
-    ) -> HashMap<usize, i32> {
+    ) -> Result<HashMap<usize, i32>> {
         let mut variant_leaf_indices = HashMap::new();
         let mut next_leaf_idx = 0;
 
@@ -710,10 +710,10 @@ impl ArrowReader {
                 None,
                 &mut next_leaf_idx,
                 &mut variant_leaf_indices,
-            );
+            )?;
         }
 
-        variant_leaf_indices
+        Ok(variant_leaf_indices)
     }
 
     fn collect_variant_leaf_indices_for_field(
@@ -723,7 +723,8 @@ impl ArrowReader {
         current_variant_field_id: Option<i32>,
         next_leaf_idx: &mut usize,
         variant_leaf_indices: &mut HashMap<usize, i32>,
-    ) {
+    ) -> Result<()> {
+        let entering_variant = current_variant_field_id.is_none();
         let variant_field_id = field
             .metadata()
             .get(PARQUET_FIELD_ID_META_KEY)
@@ -745,6 +746,22 @@ impl ArrowReader {
             other => other,
         };
 
+        // Reject shredded variants: a `typed_value` sub-field means the payload is
+        // shredded, which we can't reconstruct yet. Projecting only metadata/value
+        // would silently drop it, so fail loudly instead.
+        if entering_variant
+            && variant_field_id.is_some()
+            && let DataType::Struct(sub) = data_type
+            && sub.iter().any(|f| f.name() == "typed_value")
+        {
+            return Err(Error::new(
+                ErrorKind::FeatureUnsupported,
+                "Reading shredded variant columns is not supported yet: found a \
+                 `typed_value` sub-field. Only unshredded variants (metadata + value) \
+                 can be read.",
+            ));
+        }
+
         match data_type {
             DataType::Struct(fields) => {
                 for child in fields {
@@ -755,7 +772,7 @@ impl ArrowReader {
                         variant_field_id,
                         next_leaf_idx,
                         variant_leaf_indices,
-                    );
+                    )?;
                 }
             }
             DataType::List(field)
@@ -769,7 +786,7 @@ impl ArrowReader {
                     variant_field_id,
                     next_leaf_idx,
                     variant_leaf_indices,
-                );
+                )?;
             }
             DataType::Union(fields, _) => {
                 for (_type_id, child) in fields.iter() {
@@ -780,7 +797,7 @@ impl ArrowReader {
                         variant_field_id,
                         next_leaf_idx,
                         variant_leaf_indices,
-                    );
+                    )?;
                 }
             }
             _ => {
@@ -790,6 +807,7 @@ impl ArrowReader {
                 *next_leaf_idx += 1;
             }
         }
+        Ok(())
     }
 
     fn get_arrow_projection_mask(
@@ -868,13 +886,19 @@ impl ArrowReader {
         // HashSet for O(1) membership checks instead of O(n) slice scans.
         let leaf_field_id_set: HashSet<i32> = leaf_field_ids.iter().copied().collect();
         let variant_leaf_indices =
-            Self::collect_variant_leaf_indices(fields, iceberg_schema_of_task, &leaf_field_id_set);
+            Self::collect_variant_leaf_indices(fields, iceberg_schema_of_task, &leaf_field_id_set)?;
 
         // Pre-project only the fields that have been selected, possibly avoiding converting
         // some Arrow types that are not yet supported.
         let mut projected_field_ids: HashMap<usize, i32> = HashMap::new();
         let projected_arrow_schema = ArrowSchema::new_with_metadata(
             fields.filter_leaves(|idx, field| {
+                // Variant sub-leaves must stay in the pre-projected schema even though
+                // they carry no field ids: dropping them would structurally truncate
+                // their containers (e.g. map<string, variant> would lose its value
+                // field and no longer be a valid map). `arrow_schema_to_schema` relies
+                // on the variant group's extension metadata to short-circuit before
+                // inspecting these sub-fields.
                 if let Some(&field_id) = variant_leaf_indices.get(&idx) {
                     projected_field_ids.insert(idx, field_id);
                     return true;
@@ -2267,6 +2291,66 @@ message schema {
         assert_eq!(
             mask_primitive_only,
             ProjectionMask::leaves(&parquet_schema, vec![0]),
+        );
+    }
+
+    /// A shredded variant (a `typed_value` sub-field) cannot be reconstructed yet;
+    /// projecting only metadata/value would silently drop data, so it must fail loudly.
+    #[test]
+    fn test_arrow_projection_mask_shredded_variant_is_rejected() {
+        let schema = Arc::new(
+            Schema::builder()
+                .with_schema_id(1)
+                .with_fields(vec![
+                    NestedField::required(1, "v", Type::Variant(VariantType)).into(),
+                ])
+                .build()
+                .unwrap(),
+        );
+
+        let arrow_schema = Arc::new(ArrowSchema::new(vec![
+            Field::new(
+                "v",
+                DataType::Struct(arrow_schema::Fields::from(vec![
+                    Arc::new(Field::new("metadata", DataType::Binary, false)),
+                    Arc::new(Field::new("value", DataType::Binary, true)),
+                    Arc::new(Field::new("typed_value", DataType::Int64, true)),
+                ])),
+                false,
+            )
+            .with_metadata(HashMap::from([
+                (PARQUET_FIELD_ID_META_KEY.to_string(), "1".to_string()),
+                (
+                    EXTENSION_TYPE_NAME_KEY.to_string(),
+                    "arrow.parquet.variant".to_string(),
+                ),
+            ])),
+        ]));
+
+        let message_type = "
+message schema {
+  required group v = 1 {
+    required binary metadata;
+    optional binary value;
+    optional int64 typed_value;
+  }
+}
+";
+        let parquet_type = parse_message_type(message_type).expect("should parse schema");
+        let parquet_schema = SchemaDescriptor::new(Arc::new(parquet_type));
+
+        let err = ArrowReader::get_arrow_projection_mask(
+            &[1],
+            &schema,
+            &parquet_schema,
+            &arrow_schema,
+            false,
+        )
+        .expect_err("shredded variant must be rejected");
+        assert_eq!(err.kind(), ErrorKind::FeatureUnsupported);
+        assert!(
+            err.to_string().contains("shredded variant"),
+            "unexpected error: {err}"
         );
     }
 

--- a/crates/iceberg/src/arrow/reader.rs
+++ b/crates/iceberg/src/arrow/reader.rs
@@ -26,9 +26,7 @@ use arrow_arith::boolean::{and, and_kleene, is_not_null, is_null, not, or, or_kl
 use arrow_array::{Array, ArrayRef, BooleanArray, Datum as ArrowDatum, RecordBatch, Scalar};
 use arrow_cast::cast::cast;
 use arrow_ord::cmp::{eq, gt, gt_eq, lt, lt_eq, neq};
-use arrow_schema::{
-    ArrowError, DataType, FieldRef, Schema as ArrowSchema, SchemaRef as ArrowSchemaRef,
-};
+use arrow_schema::{ArrowError, DataType, Schema as ArrowSchema, SchemaRef as ArrowSchemaRef};
 use arrow_string::like::starts_with;
 use bytes::Bytes;
 use fnv::FnvHashSet;
@@ -696,6 +694,104 @@ impl ArrowReader {
         }
     }
 
+    fn collect_variant_leaf_indices(
+        fields: &arrow_schema::Fields,
+        iceberg_schema_of_task: &Schema,
+        selected_leaf_field_ids: &HashSet<i32>,
+    ) -> HashMap<usize, i32> {
+        let mut variant_leaf_indices = HashMap::new();
+        let mut next_leaf_idx = 0;
+
+        for field in fields {
+            Self::collect_variant_leaf_indices_for_field(
+                field,
+                iceberg_schema_of_task,
+                selected_leaf_field_ids,
+                None,
+                &mut next_leaf_idx,
+                &mut variant_leaf_indices,
+            );
+        }
+
+        variant_leaf_indices
+    }
+
+    fn collect_variant_leaf_indices_for_field(
+        field: &arrow_schema::FieldRef,
+        iceberg_schema_of_task: &Schema,
+        selected_leaf_field_ids: &HashSet<i32>,
+        current_variant_field_id: Option<i32>,
+        next_leaf_idx: &mut usize,
+        variant_leaf_indices: &mut HashMap<usize, i32>,
+    ) {
+        let variant_field_id = field
+            .metadata()
+            .get(PARQUET_FIELD_ID_META_KEY)
+            .and_then(|field_id| i32::from_str(field_id).ok())
+            .filter(|field_id| selected_leaf_field_ids.contains(field_id))
+            .and_then(|field_id| {
+                iceberg_schema_of_task
+                    .field_by_id(field_id)
+                    .filter(|field| matches!(field.field_type.as_ref(), Type::Variant(_)))
+                    .map(|_| field_id)
+            })
+            .or(current_variant_field_id);
+
+        // Keep this traversal in lock-step with `arrow_schema::Fields::filter_leaves`, which
+        // defines the leaf indices used by Arrow projection masks.
+        let data_type = match field.data_type() {
+            DataType::Dictionary(_, value_type) => value_type.as_ref(),
+            DataType::RunEndEncoded(_, values_field) => values_field.data_type(),
+            other => other,
+        };
+
+        match data_type {
+            DataType::Struct(fields) => {
+                for child in fields {
+                    Self::collect_variant_leaf_indices_for_field(
+                        child,
+                        iceberg_schema_of_task,
+                        selected_leaf_field_ids,
+                        variant_field_id,
+                        next_leaf_idx,
+                        variant_leaf_indices,
+                    );
+                }
+            }
+            DataType::List(field)
+            | DataType::LargeList(field)
+            | DataType::FixedSizeList(field, _)
+            | DataType::Map(field, _) => {
+                Self::collect_variant_leaf_indices_for_field(
+                    field,
+                    iceberg_schema_of_task,
+                    selected_leaf_field_ids,
+                    variant_field_id,
+                    next_leaf_idx,
+                    variant_leaf_indices,
+                );
+            }
+            DataType::Union(fields, _) => {
+                for (_type_id, child) in fields.iter() {
+                    Self::collect_variant_leaf_indices_for_field(
+                        child,
+                        iceberg_schema_of_task,
+                        selected_leaf_field_ids,
+                        variant_field_id,
+                        next_leaf_idx,
+                        variant_leaf_indices,
+                    );
+                }
+            }
+            _ => {
+                if let Some(variant_field_id) = variant_field_id {
+                    variant_leaf_indices.insert(*next_leaf_idx, variant_field_id);
+                }
+                *next_leaf_idx += 1;
+            }
+        }
+    }
+
     fn get_arrow_projection_mask(
         field_ids: &[i32],
         iceberg_schema_of_task: &Schema,
@@ -771,68 +867,46 @@ impl ArrowReader {
         let fields = arrow_schema.fields();
         // HashSet for O(1) membership checks instead of O(n) slice scans.
         let leaf_field_id_set: HashSet<i32> = leaf_field_ids.iter().copied().collect();
-
-        // Variant fields are an Iceberg leaf type but a Parquet GROUP.  Their
-        // sub-fields (metadata, value) carry no embedded field IDs — only the
-        // parent group has the field ID. filter_leaves therefore never finds
-        // them via the standard field-ID scan below.
-        //
-        // Java's PruneColumns.variant() simply returns the group as-is with no
-        // type-compatibility check (isStruct() also short-circuits on isVariantType()).
-        // We replicate that here: pre-scan top-level Arrow struct fields whose
-        // field ID resolves to Type::Variant and record all their sub-fields so
-        // the second filter_leaves can include them directly.
-        let mut variant_sub_fields: HashMap<FieldRef, i32> = HashMap::new();
-        for top_field in fields.iter() {
-            let Some(field_id) = top_field
-                .metadata()
-                .get(PARQUET_FIELD_ID_META_KEY)
-                .and_then(|s| i32::from_str(s).ok())
-            else {
-                continue;
-            };
-            if !leaf_field_id_set.contains(&field_id) {
-                continue;
-            }
-            let Some(iceberg_field) = iceberg_schema_of_task.field_by_id(field_id) else {
-                continue;
-            };
-            if let Type::Variant(_) = iceberg_field.field_type.as_ref()
-                && let DataType::Struct(sub_fields) = top_field.data_type()
-            {
-                for sub_field in sub_fields {
-                    variant_sub_fields.insert(sub_field.clone(), field_id);
-                }
-            }
-        }
+        let variant_leaf_indices =
+            Self::collect_variant_leaf_indices(fields, iceberg_schema_of_task, &leaf_field_id_set);
 
         // Pre-project only the fields that have been selected, possibly avoiding converting
         // some Arrow types that are not yet supported.
-        let mut projected_fields: HashMap<FieldRef, i32> = HashMap::new();
+        let mut projected_field_ids: HashMap<usize, i32> = HashMap::new();
         let projected_arrow_schema = ArrowSchema::new_with_metadata(
-            fields.filter_leaves(|_, f| {
-                f.metadata()
+            fields.filter_leaves(|idx, field| {
+                if let Some(&field_id) = variant_leaf_indices.get(&idx) {
+                    projected_field_ids.insert(idx, field_id);
+                    return true;
+                }
+
+                field
+                    .metadata()
                     .get(PARQUET_FIELD_ID_META_KEY)
                     .and_then(|field_id| i32::from_str(field_id).ok())
                     .is_some_and(|field_id| {
-                        projected_fields.insert((*f).clone(), field_id);
-                        leaf_field_id_set.contains(&field_id)
+                        if leaf_field_id_set.contains(&field_id) {
+                            projected_field_ids.insert(idx, field_id);
+                            true
+                        } else {
+                            false
+                        }
                     })
             }),
             arrow_schema.metadata().clone(),
         );
         let iceberg_schema = arrow_schema_to_schema(&projected_arrow_schema)?;
 
-        fields.filter_leaves(|idx, field| {
-            // Variant sub-fields: parent group carries the field ID, not the leaf.
-            // Skip type-promotion check — Type::Variant is not a primitive type
-            // (matches Java's PruneColumns.variant() which returns the group unchanged).
-            if let Some(&variant_field_id) = variant_sub_fields.get(field) {
+        fields.filter_leaves(|idx, _field| {
+            // Variant fields are treated as leaf projections in Iceberg Java. Their Parquet
+            // sub-fields do not carry field IDs, so any leaf under a selected variant group must
+            // be projected without applying primitive type promotion checks.
+            if let Some(&variant_field_id) = variant_leaf_indices.get(&idx) {
                 column_map.entry(variant_field_id).or_default().push(idx);
                 return true;
             }
 
-            let Some(field_id) = projected_fields.get(field).cloned() else {
+            let Some(field_id) = projected_field_ids.get(&idx).copied() else {
                 return false;
             };
 
@@ -1893,6 +1967,7 @@ mod tests {
 
     use arrow_array::cast::AsArray;
     use arrow_array::{ArrayRef, LargeStringArray, RecordBatch, StringArray};
+    use arrow_schema::extension::EXTENSION_TYPE_NAME_KEY;
     use arrow_schema::{DataType, Field, Schema as ArrowSchema, TimeUnit};
     use futures::TryStreamExt;
     use parquet::arrow::arrow_reader::{RowSelection, RowSelector};
@@ -1914,8 +1989,8 @@ mod tests {
     use crate::io::FileIO;
     use crate::scan::{FileScanTask, FileScanTaskStream};
     use crate::spec::{
-        DataContentType, DataFileFormat, Datum, NestedField, PrimitiveType, Schema, SchemaRef,
-        Type, VariantType,
+        DataContentType, DataFileFormat, Datum, MapType, NestedField, PrimitiveType, Schema,
+        SchemaRef, Type, VariantType,
     };
 
     fn table_schema_simple() -> SchemaRef {
@@ -2132,10 +2207,13 @@ message schema {
                 ])),
                 false,
             )
-            .with_metadata(HashMap::from([(
-                PARQUET_FIELD_ID_META_KEY.to_string(),
-                "2".to_string(),
-            )])),
+            .with_metadata(HashMap::from([
+                (PARQUET_FIELD_ID_META_KEY.to_string(), "2".to_string()),
+                (
+                    EXTENSION_TYPE_NAME_KEY.to_string(),
+                    "arrow.parquet.variant".to_string(),
+                ),
+            ])),
         ]));
 
         // Parquet message: c1 is leaf 0; variant sub-fields metadata=leaf 1, value=leaf 2.
@@ -2190,6 +2268,156 @@ message schema {
             mask_primitive_only,
             ProjectionMask::leaves(&parquet_schema, vec![0]),
         );
+    }
+
+    /// Nested variant values inside Parquet maps must project the entire variant group instead of
+    /// selecting only the map key leaf. Otherwise Parquet will reject the partial MapArray
+    /// projection.
+    #[test]
+    fn test_arrow_projection_mask_map_with_variant_value() {
+        let schema = Arc::new(
+            Schema::builder()
+                .with_schema_id(1)
+                .with_fields(vec![
+                    NestedField::required(
+                        1,
+                        "m",
+                        Type::Map(MapType::new(
+                            NestedField::map_key_element(2, Type::Primitive(PrimitiveType::String))
+                                .into(),
+                            NestedField::map_value_element(3, Type::Variant(VariantType), true)
+                                .into(),
+                        )),
+                    )
+                    .into(),
+                ])
+                .build()
+                .unwrap(),
+        );
+
+        let arrow_schema = Arc::new(ArrowSchema::new(vec![
+            Field::new(
+                "m",
+                DataType::Map(
+                    Arc::new(Field::new(
+                        "key_value",
+                        DataType::Struct(arrow_schema::Fields::from(vec![
+                            Arc::new(Field::new("key", DataType::Utf8, false).with_metadata(
+                                HashMap::from([(
+                                    PARQUET_FIELD_ID_META_KEY.to_string(),
+                                    "2".to_string(),
+                                )]),
+                            )),
+                            Arc::new(
+                                Field::new(
+                                    "value",
+                                    DataType::Struct(arrow_schema::Fields::from(vec![
+                                        Arc::new(Field::new("metadata", DataType::Binary, false)),
+                                        Arc::new(Field::new("value", DataType::Binary, false)),
+                                    ])),
+                                    true,
+                                )
+                                .with_metadata(HashMap::from([
+                                    (PARQUET_FIELD_ID_META_KEY.to_string(), "3".to_string()),
+                                    (
+                                        EXTENSION_TYPE_NAME_KEY.to_string(),
+                                        "arrow.parquet.variant".to_string(),
+                                    ),
+                                ])),
+                            ),
+                        ])),
+                        false,
+                    )),
+                    false,
+                ),
+                false,
+            )
+            .with_metadata(HashMap::from([(
+                PARQUET_FIELD_ID_META_KEY.to_string(),
+                "1".to_string(),
+            )])),
+        ]));
+
+        let message_type = "
+message schema {
+  required group m (MAP) = 1 {
+    repeated group key_value {
+      required binary key (STRING) = 2;
+      optional group value = 3 {
+        required binary metadata;
+        required binary value;
+      }
+    }
+  }
+}
+";
+        let parquet_type = parse_message_type(message_type).expect("should parse schema");
+        let parquet_schema = SchemaDescriptor::new(Arc::new(parquet_type));
+
+        let mask = ArrowReader::get_arrow_projection_mask(
+            &[1],
+            &schema,
+            &parquet_schema,
+            &arrow_schema,
+            false,
+        )
+        .expect("projection mask for map<string, variant>");
+        assert_eq!(mask, ProjectionMask::leaves(&parquet_schema, vec![0, 1, 2]));
+    }
+
+    #[test]
+    fn test_arrow_projection_mask_dictionary_wrapped_variant() {
+        let schema = Arc::new(
+            Schema::builder()
+                .with_schema_id(1)
+                .with_fields(vec![
+                    NestedField::required(1, "v", Type::Variant(VariantType)).into(),
+                ])
+                .build()
+                .unwrap(),
+        );
+
+        let arrow_schema = Arc::new(ArrowSchema::new(vec![
+            Field::new(
+                "v",
+                DataType::Dictionary(
+                    Box::new(DataType::Int32),
+                    Box::new(DataType::Struct(arrow_schema::Fields::from(vec![
+                        Arc::new(Field::new("metadata", DataType::Binary, false)),
+                        Arc::new(Field::new("value", DataType::Binary, false)),
+                    ]))),
+                ),
+                false,
+            )
+            .with_metadata(HashMap::from([
+                (PARQUET_FIELD_ID_META_KEY.to_string(), "1".to_string()),
+                (
+                    EXTENSION_TYPE_NAME_KEY.to_string(),
+                    "arrow.parquet.variant".to_string(),
+                ),
+            ])),
+        ]));
+
+        let message_type = "
+message schema {
+  required group v = 1 {
+    required binary metadata;
+    required binary value;
+  }
+}
+";
+        let parquet_type = parse_message_type(message_type).expect("should parse schema");
+        let parquet_schema = SchemaDescriptor::new(Arc::new(parquet_type));
+
+        let mask = ArrowReader::get_arrow_projection_mask(
+            &[1],
+            &schema,
+            &parquet_schema,
+            &arrow_schema,
+            false,
+        )
+        .expect("projection mask for dictionary-wrapped variant");
+        assert_eq!(mask, ProjectionMask::leaves(&parquet_schema, vec![0, 1]));
     }
 
     #[tokio::test]

--- a/crates/iceberg/src/arrow/schema.rs
+++ b/crates/iceberg/src/arrow/schema.rs
@@ -275,6 +275,9 @@ struct ArrowSchemaConverter {
     /// Required because `ReassignFieldIds` builds an old-to-new ID mapping
     /// that expects unique input IDs.
     next_field_id: i32,
+    /// Tracks the current Arrow field being visited so extension metadata can influence
+    /// type conversion for nested fields like variant values in lists and maps.
+    field_stack: Vec<Field>,
 }
 
 impl ArrowSchemaConverter {
@@ -282,6 +285,7 @@ impl ArrowSchemaConverter {
         Self {
             reassign_field_ids_from: None,
             next_field_id: 0,
+            field_stack: Vec::new(),
         }
     }
 
@@ -289,6 +293,7 @@ impl ArrowSchemaConverter {
         Self {
             reassign_field_ids_from: Some(start_from),
             next_field_id: 0,
+            field_stack: Vec::new(),
         }
     }
 
@@ -330,11 +335,65 @@ impl ArrowSchemaConverter {
         }
         Ok(results)
     }
+
+    fn current_field_is_variant(&self) -> bool {
+        self.field_stack
+            .last()
+            .and_then(|field| field.metadata().get(EXTENSION_TYPE_NAME_KEY))
+            .is_some_and(|extension_name| extension_name == PARQUET_VARIANT_EXTENSION_NAME)
+    }
+
+    fn push_field(&mut self, field: &Field) {
+        self.field_stack.push(field.clone());
+    }
+
+    fn pop_field(&mut self) -> Result<()> {
+        self.field_stack
+            .pop()
+            .map(|_| ())
+            .ok_or_else(|| Error::new(ErrorKind::Unexpected, "Field stack underflow"))
+    }
 }
 
 impl ArrowSchemaVisitor for ArrowSchemaConverter {
     type T = Type;
     type U = Schema;
+
+    fn before_field(&mut self, field: &Field) -> Result<()> {
+        self.push_field(field);
+        Ok(())
+    }
+
+    fn after_field(&mut self, _field: &Field) -> Result<()> {
+        self.pop_field()
+    }
+
+    fn before_list_element(&mut self, field: &Field) -> Result<()> {
+        self.push_field(field);
+        Ok(())
+    }
+
+    fn after_list_element(&mut self, _field: &Field) -> Result<()> {
+        self.pop_field()
+    }
+
+    fn before_map_key(&mut self, field: &Field) -> Result<()> {
+        self.push_field(field);
+        Ok(())
+    }
+
+    fn after_map_key(&mut self, _field: &Field) -> Result<()> {
+        self.pop_field()
+    }
+
+    fn before_map_value(&mut self, field: &Field) -> Result<()> {
+        self.push_field(field);
+        Ok(())
+    }
+
+    fn after_map_value(&mut self, _field: &Field) -> Result<()> {
+        self.pop_field()
+    }
 
     fn schema(&mut self, schema: &ArrowSchema, values: Vec<Self::T>) -> Result<Self::U> {
         let fields = self.convert_fields(schema.fields(), &values)?;
@@ -346,6 +405,10 @@ impl ArrowSchemaVisitor for ArrowSchemaConverter {
     }
 
     fn r#struct(&mut self, fields: &Fields, results: Vec<Self::T>) -> Result<Self::T> {
+        if self.current_field_is_variant() {
+            return Ok(Type::Variant(VariantType));
+        }
+
         let fields = self.convert_fields(fields, &results)?;
         Ok(Type::Struct(StructType::new(fields)))
     }

--- a/crates/iceberg/src/arrow/schema.rs
+++ b/crates/iceberg/src/arrow/schema.rs
@@ -26,6 +26,7 @@ use arrow_array::{
     FixedSizeBinaryArray, Float32Array, Float64Array, Int32Array, Int64Array, Scalar, StringArray,
     TimestampMicrosecondArray, TimestampNanosecondArray,
 };
+use arrow_schema::extension::EXTENSION_TYPE_NAME_KEY;
 use arrow_schema::{DataType, Field, Fields, Schema as ArrowSchema, TimeUnit};
 use parquet::arrow::PARQUET_FIELD_ID_META_KEY;
 use parquet::file::statistics::Statistics;
@@ -240,6 +241,7 @@ pub fn arrow_type_to_type(ty: &DataType) -> Result<Type> {
 }
 
 const ARROW_FIELD_DOC_KEY: &str = "doc";
+const PARQUET_VARIANT_EXTENSION_NAME: &str = "arrow.parquet.variant";
 
 pub(super) fn get_field_id_from_metadata(field: &Field) -> Result<i32> {
     if let Some(value) = field.metadata().get(PARQUET_FIELD_ID_META_KEY) {
@@ -493,6 +495,24 @@ enum ArrowSchemaOrFieldOrType {
     Schema(ArrowSchema),
     Field(Field),
     Type(DataType),
+    TypeWithMetadata(DataType, HashMap<String, String>),
+}
+
+impl ArrowSchemaOrFieldOrType {
+    fn into_field(self) -> Field {
+        match self {
+            ArrowSchemaOrFieldOrType::Field(field) => field,
+            _ => unreachable!(),
+        }
+    }
+
+    fn into_type(self) -> (DataType, HashMap<String, String>) {
+        match self {
+            ArrowSchemaOrFieldOrType::Type(ty) => (ty, HashMap::new()),
+            ArrowSchemaOrFieldOrType::TypeWithMetadata(ty, metadata) => (ty, metadata),
+            _ => unreachable!(),
+        }
+    }
 }
 
 impl SchemaVisitor for ToArrowSchemaConverter {
@@ -503,8 +523,15 @@ impl SchemaVisitor for ToArrowSchemaConverter {
         _schema: &crate::spec::Schema,
         value: ArrowSchemaOrFieldOrType,
     ) -> crate::Result<ArrowSchemaOrFieldOrType> {
-        let struct_type = match value {
-            ArrowSchemaOrFieldOrType::Type(DataType::Struct(fields)) => fields,
+        let (data_type, metadata) = value.into_type();
+        if !metadata.is_empty() {
+            return Err(Error::new(
+                ErrorKind::DataInvalid,
+                "Top-level Arrow schema type must not carry field metadata",
+            ));
+        }
+        let struct_type = match data_type {
+            DataType::Struct(fields) => fields,
             _ => unreachable!(),
         };
         Ok(ArrowSchemaOrFieldOrType::Schema(ArrowSchema::new(
@@ -517,11 +544,8 @@ impl SchemaVisitor for ToArrowSchemaConverter {
         field: &crate::spec::NestedFieldRef,
         value: ArrowSchemaOrFieldOrType,
     ) -> crate::Result<ArrowSchemaOrFieldOrType> {
-        let ty = match value {
-            ArrowSchemaOrFieldOrType::Type(ty) => ty,
-            _ => unreachable!(),
-        };
-        let metadata = if let Some(doc) = &field.doc {
+        let (ty, type_metadata) = value.into_type();
+        let mut metadata = if let Some(doc) = &field.doc {
             HashMap::from([
                 (PARQUET_FIELD_ID_META_KEY.to_string(), field.id.to_string()),
                 (ARROW_FIELD_DOC_KEY.to_string(), doc.clone()),
@@ -529,6 +553,7 @@ impl SchemaVisitor for ToArrowSchemaConverter {
         } else {
             HashMap::from([(PARQUET_FIELD_ID_META_KEY.to_string(), field.id.to_string())])
         };
+        metadata.extend(type_metadata);
         Ok(ArrowSchemaOrFieldOrType::Field(
             Field::new(field.name.clone(), ty, !field.required).with_metadata(metadata),
         ))
@@ -541,10 +566,7 @@ impl SchemaVisitor for ToArrowSchemaConverter {
     ) -> crate::Result<ArrowSchemaOrFieldOrType> {
         let fields = results
             .into_iter()
-            .map(|result| match result {
-                ArrowSchemaOrFieldOrType::Field(field) => field,
-                _ => unreachable!(),
-            })
+            .map(ArrowSchemaOrFieldOrType::into_field)
             .collect();
         Ok(ArrowSchemaOrFieldOrType::Type(DataType::Struct(fields)))
     }
@@ -554,25 +576,7 @@ impl SchemaVisitor for ToArrowSchemaConverter {
         list: &crate::spec::ListType,
         value: ArrowSchemaOrFieldOrType,
     ) -> crate::Result<Self::T> {
-        let field = match self.field(&list.element_field, value)? {
-            ArrowSchemaOrFieldOrType::Field(field) => field,
-            _ => unreachable!(),
-        };
-        let meta = if let Some(doc) = &list.element_field.doc {
-            HashMap::from([
-                (
-                    PARQUET_FIELD_ID_META_KEY.to_string(),
-                    list.element_field.id.to_string(),
-                ),
-                (ARROW_FIELD_DOC_KEY.to_string(), doc.clone()),
-            ])
-        } else {
-            HashMap::from([(
-                PARQUET_FIELD_ID_META_KEY.to_string(),
-                list.element_field.id.to_string(),
-            )])
-        };
-        let field = field.with_metadata(meta);
+        let field = self.field(&list.element_field, value)?.into_field();
         Ok(ArrowSchemaOrFieldOrType::Type(DataType::List(Arc::new(
             field,
         ))))
@@ -584,14 +588,8 @@ impl SchemaVisitor for ToArrowSchemaConverter {
         key_value: ArrowSchemaOrFieldOrType,
         value: ArrowSchemaOrFieldOrType,
     ) -> crate::Result<ArrowSchemaOrFieldOrType> {
-        let key_field = match self.field(&map.key_field, key_value)? {
-            ArrowSchemaOrFieldOrType::Field(field) => field,
-            _ => unreachable!(),
-        };
-        let value_field = match self.field(&map.value_field, value)? {
-            ArrowSchemaOrFieldOrType::Field(field) => field,
-            _ => unreachable!(),
-        };
+        let key_field = self.field(&map.key_field, key_value)?.into_field();
+        let value_field = self.field(&map.value_field, value)?.into_field();
         let field = Field::new(
             DEFAULT_MAP_FIELD_NAME,
             DataType::Struct(vec![key_field, value_field].into()),
@@ -695,9 +693,13 @@ impl SchemaVisitor for ToArrowSchemaConverter {
         // Uses Binary (not LargeBinary) matching the Parquet BINARY primitive directly.
         let metadata_field = Field::new("metadata", DataType::Binary, false);
         let value_field = Field::new("value", DataType::Binary, false);
-        Ok(ArrowSchemaOrFieldOrType::Type(DataType::Struct(
-            vec![metadata_field, value_field].into(),
-        )))
+        Ok(ArrowSchemaOrFieldOrType::TypeWithMetadata(
+            DataType::Struct(vec![metadata_field, value_field].into()),
+            HashMap::from([(
+                EXTENSION_TYPE_NAME_KEY.to_string(),
+                PARQUET_VARIANT_EXTENSION_NAME.to_string(),
+            )]),
+        ))
     }
 }
 
@@ -714,7 +716,9 @@ pub fn schema_to_arrow_schema(schema: &crate::spec::Schema) -> crate::Result<Arr
 pub fn type_to_arrow_type(ty: &crate::spec::Type) -> crate::Result<DataType> {
     let mut converter = ToArrowSchemaConverter;
     match crate::spec::visit_type(ty, &mut converter)? {
-        ArrowSchemaOrFieldOrType::Type(ty) => Ok(ty),
+        ArrowSchemaOrFieldOrType::Type(ty) | ArrowSchemaOrFieldOrType::TypeWithMetadata(ty, _) => {
+            Ok(ty)
+        }
         _ => unreachable!(),
     }
 }
@@ -1322,6 +1326,19 @@ mod tests {
         )]))
     }
 
+    fn simple_field_with_metadata(
+        name: &str,
+        ty: DataType,
+        nullable: bool,
+        value: &str,
+        extra_metadata: impl IntoIterator<Item = (String, String)>,
+    ) -> Field {
+        let mut metadata =
+            HashMap::from([(PARQUET_FIELD_ID_META_KEY.to_string(), value.to_string())]);
+        metadata.extend(extra_metadata);
+        Field::new(name, ty, nullable).with_metadata(metadata)
+    }
+
     fn arrow_schema_for_arrow_schema_to_schema_test() -> ArrowSchema {
         let fields = Fields::from(vec![
             simple_field("key", DataType::Int32, false, "28"),
@@ -1707,7 +1724,7 @@ mod tests {
             simple_field("map", map, false, "16"),
             simple_field("struct", r#struct, false, "17"),
             simple_field("uuid", DataType::FixedSizeBinary(16), false, "30"),
-            simple_field(
+            simple_field_with_metadata(
                 "v",
                 DataType::Struct(Fields::from(vec![
                     Field::new("metadata", DataType::Binary, false),
@@ -1715,6 +1732,10 @@ mod tests {
                 ])),
                 true,
                 "31",
+                [(
+                    EXTENSION_TYPE_NAME_KEY.to_string(),
+                    PARQUET_VARIANT_EXTENSION_NAME.to_string(),
+                )],
             ),
         ])
     }
@@ -1920,6 +1941,52 @@ mod tests {
         let schema = iceberg_schema_for_schema_to_arrow_schema();
         let converted_arrow_schema = schema_to_arrow_schema(&schema).unwrap();
         assert_eq!(converted_arrow_schema, arrow_schema);
+        assert_eq!(
+            converted_arrow_schema
+                .field_with_name("v")
+                .unwrap()
+                .metadata()
+                .get(EXTENSION_TYPE_NAME_KEY)
+                .map(String::as_str),
+            Some(PARQUET_VARIANT_EXTENSION_NAME)
+        );
+    }
+
+    #[test]
+    fn test_schema_to_arrow_schema_nested_variant_metadata() {
+        let schema_json = r#"{
+            "type":"struct",
+            "schema-id":0,
+            "fields":[
+                {
+                    "id":1,
+                    "name":"variants",
+                    "required":false,
+                    "type":{
+                        "type":"list",
+                        "element-id":2,
+                        "element":"variant",
+                        "element-required":true
+                    }
+                }
+            ],
+            "identifier-field-ids":[]
+        }"#;
+
+        let schema: Schema = serde_json::from_str(schema_json).unwrap();
+        let converted_arrow_schema = schema_to_arrow_schema(&schema).unwrap();
+        let field = converted_arrow_schema.field_with_name("variants").unwrap();
+        let DataType::List(element) = field.data_type() else {
+            panic!("Expected list field, got {:?}", field.data_type());
+        };
+
+        assert_eq!(
+            element
+                .metadata()
+                .get(EXTENSION_TYPE_NAME_KEY)
+                .map(String::as_str),
+            Some(PARQUET_VARIANT_EXTENSION_NAME)
+        );
     }
 
     #[test]

--- a/crates/iceberg/src/arrow/schema.rs
+++ b/crates/iceberg/src/arrow/schema.rs
@@ -2053,6 +2053,20 @@ mod tests {
     }
 
     #[test]
+    fn test_variant_type_to_arrow_type() {
+        // Variant maps to a struct of two required binary fields {metadata, value},
+        // with no field ids on the sub-fields, matching the Parquet BINARY layout.
+        let arrow_type = type_to_arrow_type(&Type::Variant(VariantType)).unwrap();
+        assert_eq!(
+            arrow_type,
+            DataType::Struct(Fields::from(vec![
+                Field::new("metadata", DataType::Binary, false),
+                Field::new("value", DataType::Binary, false),
+            ]))
+        );
+    }
+
+    #[test]
     fn test_type_conversion() {
         // test primitive type
         {

--- a/crates/iceberg/src/arrow/value.rs
+++ b/crates/iceberg/src/arrow/value.rs
@@ -30,7 +30,7 @@ use uuid::Uuid;
 use super::get_field_id_from_metadata;
 use crate::spec::{
     ListType, Literal, Map, MapType, NestedField, PartnerAccessor, PrimitiveLiteral, PrimitiveType,
-    SchemaWithPartnerVisitor, Struct, StructType, Type, visit_struct_with_partner,
+    SchemaWithPartnerVisitor, Struct, StructType, Type, VariantType, visit_struct_with_partner,
     visit_type_with_partner,
 };
 use crate::{Error, ErrorKind, Result};
@@ -425,6 +425,13 @@ impl SchemaWithPartnerVisitor<ArrayRef> for ArrowArrayToIcebergStructConverter {
                 }
             }
         }
+    }
+
+    fn variant(&mut self, _v: &VariantType, _partner: &ArrayRef) -> Result<Vec<Option<Literal>>> {
+        Err(Error::new(
+            ErrorKind::FeatureUnsupported,
+            "Converting variant Arrow array to Iceberg literal is not supported yet",
+        ))
     }
 }
 

--- a/crates/iceberg/src/arrow/value.rs
+++ b/crates/iceberg/src/arrow/value.rs
@@ -1496,6 +1496,43 @@ mod test {
     }
 
     #[test]
+    fn test_arrow_variant_to_literal_is_unsupported() {
+        // Converting a variant Arrow array back to an Iceberg literal is not implemented;
+        // the visitor must reject it rather than silently decode it incorrectly.
+        let variant_child = Arc::new(StructArray::from(vec![
+            (
+                Arc::new(Field::new("metadata", DataType::Binary, false)),
+                Arc::new(BinaryArray::from(vec![Some(b"m".as_ref())])) as ArrayRef,
+            ),
+            (
+                Arc::new(Field::new("value", DataType::Binary, false)),
+                Arc::new(BinaryArray::from(vec![Some(b"v".as_ref())])) as ArrayRef,
+            ),
+        ])) as ArrayRef;
+
+        let struct_array = Arc::new(StructArray::from(vec![(
+            Arc::new(
+                Field::new("v", variant_child.data_type().clone(), false).with_metadata(
+                    HashMap::from([(PARQUET_FIELD_ID_META_KEY.to_string(), "1".to_string())]),
+                ),
+            ),
+            variant_child,
+        )])) as ArrayRef;
+
+        let ty = StructType::new(vec![
+            NestedField::required(1, "v", Type::Variant(VariantType)).into(),
+        ]);
+
+        let err = arrow_struct_to_literal(&struct_array, &ty).unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::FeatureUnsupported);
+        assert!(
+            err.to_string()
+                .contains("Converting variant Arrow array to Iceberg literal is not supported yet"),
+            "{err}"
+        );
+    }
+
+    #[test]
     fn test_find_field_by_id() {
         // Create Arrow arrays for the nested structure
         let field_a_array = Int32Array::from(vec![Some(42), Some(43), None]);

--- a/crates/iceberg/src/avro/schema.rs
+++ b/crates/iceberg/src/avro/schema.rs
@@ -43,12 +43,55 @@ const LOGICAL_TYPE: &str = "logicalType";
 
 struct SchemaToAvroSchema {
     schema: String,
+    // Stack of enclosing field ids, used to derive unique record names for
+    // structural types (e.g. variant) — mirrors Java TypeToSchema.fieldIds.
+    field_ids: Vec<i32>,
 }
 
 type AvroSchemaOrField = Either<AvroSchema, AvroRecordField>;
 
 impl SchemaVisitor for SchemaToAvroSchema {
     type T = AvroSchemaOrField;
+
+    fn before_struct_field(&mut self, field: &NestedFieldRef) -> Result<()> {
+        self.field_ids.push(field.id);
+        Ok(())
+    }
+
+    fn after_struct_field(&mut self, _field: &NestedFieldRef) -> Result<()> {
+        self.field_ids.pop();
+        Ok(())
+    }
+
+    fn before_list_element(&mut self, field: &NestedFieldRef) -> Result<()> {
+        self.field_ids.push(field.id);
+        Ok(())
+    }
+
+    fn after_list_element(&mut self, _field: &NestedFieldRef) -> Result<()> {
+        self.field_ids.pop();
+        Ok(())
+    }
+
+    fn before_map_key(&mut self, field: &NestedFieldRef) -> Result<()> {
+        self.field_ids.push(field.id);
+        Ok(())
+    }
+
+    fn after_map_key(&mut self, _field: &NestedFieldRef) -> Result<()> {
+        self.field_ids.pop();
+        Ok(())
+    }
+
+    fn before_map_value(&mut self, field: &NestedFieldRef) -> Result<()> {
+        self.field_ids.push(field.id);
+        Ok(())
+    }
+
+    fn after_map_value(&mut self, _field: &NestedFieldRef) -> Result<()> {
+        self.field_ids.pop();
+        Ok(())
+    }
 
     fn schema(&mut self, _schema: &Schema, value: AvroSchemaOrField) -> Result<AvroSchemaOrField> {
         let mut avro_schema = value.unwrap_left();
@@ -244,13 +287,21 @@ impl SchemaVisitor for SchemaToAvroSchema {
                 custom_attributes: Default::default(),
             },
         ];
-        let mut schema = avro_record_schema(VARIANT_LOGICAL_TYPE, fields)?;
-        if let AvroSchema::Record(record) = &mut schema {
-            record.attributes.insert(
-                LOGICAL_TYPE.to_string(),
-                Value::String(VARIANT_LOGICAL_TYPE.to_string()),
-            );
-        }
+        // Avro record names must be unique within a schema. Derive the name from the
+        // enclosing field id.
+        let record_name = match self.field_ids.last() {
+            Some(id) => format!("r{id}"),
+            // falling back to "variant" when no enclosing id is set.
+            None => VARIANT_LOGICAL_TYPE.to_string(),
+        };
+        let mut schema = avro_record_schema(&record_name, fields)?;
+        let AvroSchema::Record(record) = &mut schema else {
+            unreachable!("avro_record_schema must return AvroSchema::Record");
+        };
+        record.attributes.insert(
+            LOGICAL_TYPE.to_string(),
+            Value::String(VARIANT_LOGICAL_TYPE.to_string()),
+        );
         Ok(Either::Left(schema))
     }
 
@@ -283,6 +334,7 @@ impl SchemaVisitor for SchemaToAvroSchema {
 pub(crate) fn schema_to_avro_schema(name: impl ToString, schema: &Schema) -> Result<AvroSchema> {
     let mut converter = SchemaToAvroSchema {
         schema: name.to_string(),
+        field_ids: Vec::new(),
     };
 
     visit_schema(schema, &mut converter).map(Either::unwrap_left)
@@ -1347,5 +1399,71 @@ mod tests {
             .unwrap();
 
         check_schema_conversion(avro_schema, iceberg_schema);
+    }
+
+    /// Regression: two variant columns nested inside a struct must produce unique
+    /// Avro record names (`r{field_id}`).
+    #[test]
+    fn test_multiple_variants_in_struct_have_unique_record_names() {
+        let iceberg_schema = Schema::builder()
+            .with_fields(vec![
+                NestedField::required(
+                    1,
+                    "nested",
+                    Type::Struct(StructType::new(vec![
+                        NestedField::required(2, "v1", Type::Variant(VariantType)).into(),
+                        NestedField::required(3, "v2", Type::Variant(VariantType)).into(),
+                    ])),
+                )
+                .into(),
+            ])
+            .build()
+            .unwrap();
+
+        let avro_schema = schema_to_avro_schema("test", &iceberg_schema).unwrap();
+
+        // Collect every variant record's name from the resulting Avro schema
+        // and assert they are unique and match the enclosing field ids.
+        let json = serde_json::to_value(&avro_schema).unwrap();
+        fn walk(v: &Value, out: &mut Vec<String>) {
+            match v {
+                Value::Object(map) => {
+                    if map.get("logicalType").and_then(Value::as_str) == Some("variant")
+                        && let Some(name) = map.get("name").and_then(Value::as_str)
+                    {
+                        out.push(name.to_string());
+                    }
+                    for (_k, child) in map {
+                        walk(child, out);
+                    }
+                }
+                Value::Array(arr) => {
+                    for child in arr {
+                        walk(child, out);
+                    }
+                }
+                _ => {}
+            }
+        }
+        let mut variant_record_names: Vec<String> = Vec::new();
+        walk(&json, &mut variant_record_names);
+
+        assert_eq!(
+            variant_record_names.len(),
+            2,
+            "expected two variant records, got {variant_record_names:?}"
+        );
+        assert!(
+            variant_record_names.contains(&"r2".to_string()),
+            "expected variant record 'r2' (field id 2), got {variant_record_names:?}"
+        );
+        assert!(
+            variant_record_names.contains(&"r3".to_string()),
+            "expected variant record 'r3' (field id 3), got {variant_record_names:?}"
+        );
+
+        // Round-trips back to the same Iceberg schema.
+        let roundtrip = avro_schema_to_schema(&avro_schema).unwrap();
+        assert_eq!(iceberg_schema, roundtrip);
     }
 }

--- a/crates/iceberg/src/spec/partition.rs
+++ b/crates/iceberg/src/spec/partition.rs
@@ -1399,6 +1399,33 @@ mod tests {
     }
 
     #[test]
+    fn test_builder_disallows_variant_source() {
+        let schema = Schema::builder()
+            .with_fields(vec![
+                NestedField::required(1, "id", Type::Primitive(crate::spec::PrimitiveType::Int))
+                    .into(),
+                NestedField::optional(2, "v", Type::Variant(crate::spec::VariantType)).into(),
+            ])
+            .build()
+            .unwrap();
+
+        let err = PartitionSpec::builder(schema)
+            .with_spec_id(1)
+            .add_unbound_fields(vec![UnboundPartitionField {
+                source_id: 2,
+                field_id: None,
+                name: "v_part".to_string(),
+                transform: Transform::Identity,
+            }])
+            .expect_err("variant must not be allowed as a partition source");
+
+        assert_eq!(
+            err.message(),
+            "Cannot partition by non-primitive source field: 'variant'."
+        );
+    }
+
+    #[test]
     fn test_builder_disallows_redundant() {
         let err = UnboundPartitionSpec::builder()
             .with_spec_id(1)

--- a/crates/iceberg/src/spec/schema/id_reassigner.rs
+++ b/crates/iceberg/src/spec/schema/id_reassigner.rs
@@ -102,6 +102,7 @@ impl ReassignFieldIds {
                     value_field: Arc::new(value_field),
                 }))
             }
+            Type::Variant(v) => Ok(Type::Variant(v)),
         }
     }
 

--- a/crates/iceberg/src/spec/schema/id_reassigner.rs
+++ b/crates/iceberg/src/spec/schema/id_reassigner.rs
@@ -194,6 +194,37 @@ mod tests {
     }
 
     #[test]
+    fn test_reassign_ids_variant() {
+        use crate::spec::VariantType;
+
+        let schema = Schema::builder()
+            .with_fields(vec![
+                NestedField::required(5, "id", Type::Primitive(PrimitiveType::Int)).into(),
+                NestedField::optional(3, "data", Type::Variant(VariantType)).into(),
+            ])
+            .build()
+            .unwrap();
+
+        let reassigned = schema
+            .into_builder()
+            .with_reassigned_field_ids(0)
+            .build()
+            .unwrap();
+
+        // Variant has no sub-fields, so it survives reassignment unchanged; only the
+        // top-level field ids shift (id → 0, data → 1).
+        let expected = Schema::builder()
+            .with_fields(vec![
+                NestedField::required(0, "id", Type::Primitive(PrimitiveType::Int)).into(),
+                NestedField::optional(1, "data", Type::Variant(VariantType)).into(),
+            ])
+            .build()
+            .unwrap();
+
+        pretty_assertions::assert_eq!(expected, reassigned);
+    }
+
+    #[test]
     fn test_reassigned_ids_nested() {
         let schema = table_schema_nested();
         let reassigned_schema = schema

--- a/crates/iceberg/src/spec/schema/index.rs
+++ b/crates/iceberg/src/spec/schema/index.rs
@@ -53,6 +53,10 @@ pub fn index_by_id(r#struct: &StructType) -> Result<HashMap<i32, NestedFieldRef>
         fn primitive(&mut self, _: &PrimitiveType) -> Result<Self::T> {
             Ok(())
         }
+
+        fn variant(&mut self, _v: &crate::spec::VariantType) -> Result<Self::T> {
+            Ok(())
+        }
     }
 
     let mut index = IndexById(HashMap::new());
@@ -143,6 +147,10 @@ pub fn index_parents(r#struct: &StructType) -> Result<HashMap<i32, i32>> {
         }
 
         fn primitive(&mut self, _p: &PrimitiveType) -> Result<Self::T> {
+            Ok(())
+        }
+
+        fn variant(&mut self, _v: &crate::spec::VariantType) -> Result<Self::T> {
             Ok(())
         }
     }
@@ -291,6 +299,10 @@ impl SchemaVisitor for IndexByName {
     }
 
     fn primitive(&mut self, _p: &PrimitiveType) -> Result<Self::T> {
+        Ok(())
+    }
+
+    fn variant(&mut self, _v: &crate::spec::VariantType) -> Result<Self::T> {
         Ok(())
     }
 }

--- a/crates/iceberg/src/spec/schema/index.rs
+++ b/crates/iceberg/src/spec/schema/index.rs
@@ -17,6 +17,7 @@
 
 use super::utils::try_insert_field;
 use super::*;
+use crate::spec::VariantType;
 
 /// Creates a field id to field map.
 pub fn index_by_id(r#struct: &StructType) -> Result<HashMap<i32, NestedFieldRef>> {
@@ -54,7 +55,7 @@ pub fn index_by_id(r#struct: &StructType) -> Result<HashMap<i32, NestedFieldRef>
             Ok(())
         }
 
-        fn variant(&mut self, _v: &crate::spec::VariantType) -> Result<Self::T> {
+        fn variant(&mut self, _v: &VariantType) -> Result<Self::T> {
             Ok(())
         }
     }
@@ -150,7 +151,7 @@ pub fn index_parents(r#struct: &StructType) -> Result<HashMap<i32, i32>> {
             Ok(())
         }
 
-        fn variant(&mut self, _v: &crate::spec::VariantType) -> Result<Self::T> {
+        fn variant(&mut self, _v: &VariantType) -> Result<Self::T> {
             Ok(())
         }
     }
@@ -302,7 +303,7 @@ impl SchemaVisitor for IndexByName {
         Ok(())
     }
 
-    fn variant(&mut self, _v: &crate::spec::VariantType) -> Result<Self::T> {
+    fn variant(&mut self, _v: &VariantType) -> Result<Self::T> {
         Ok(())
     }
 }
@@ -326,5 +327,41 @@ mod tests {
         assert_eq!(result.get(&14).unwrap(), &12);
         assert_eq!(result.get(&16).unwrap(), &15);
         assert_eq!(result.get(&17).unwrap(), &15);
+    }
+
+    #[test]
+    fn test_index_variant_by_id_and_name() {
+        // A variant is indexed like a leaf: by id and by full (dotted) name, both at the
+        // top level and nested inside a struct. Mirrors Java's TestTypeUtil index-by-id /
+        // index-name-by-id coverage for variant.
+        let s = StructType::new(vec![
+            NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
+            NestedField::optional(2, "v", Type::Variant(VariantType)).into(),
+            NestedField::required(
+                3,
+                "nested",
+                Type::Struct(StructType::new(vec![
+                    NestedField::optional(4, "inner_v", Type::Variant(VariantType)).into(),
+                ])),
+            )
+            .into(),
+        ]);
+
+        let by_id = index_by_id(&s).unwrap();
+        // All four fields (id, v, nested, nested.inner_v) are indexed exactly once.
+        assert_eq!(by_id.len(), 4);
+        assert!(by_id[&2].field_type.is_variant());
+        assert!(by_id[&4].field_type.is_variant());
+
+        let (name_to_id, id_to_name) = {
+            let mut index = IndexByName::default();
+            visit_struct(&s, &mut index).unwrap();
+            index.indexes()
+        };
+        assert_eq!(id_to_name.len(), 4);
+        assert_eq!(id_to_name[&2], "v");
+        assert_eq!(id_to_name[&4], "nested.inner_v");
+        assert_eq!(name_to_id["v"], 2);
+        assert_eq!(name_to_id["nested.inner_v"], 4);
     }
 }

--- a/crates/iceberg/src/spec/schema/mod.rs
+++ b/crates/iceberg/src/spec/schema/mod.rs
@@ -52,6 +52,9 @@ pub type SchemaId = i32;
 pub type SchemaRef = Arc<Schema>;
 /// Default schema id.
 pub const DEFAULT_SCHEMA_ID: SchemaId = 0;
+/// Minimum format version that allows non-null field default values.
+/// Mirrors Java's `Schema.DEFAULT_VALUES_MIN_FORMAT_VERSION`.
+pub(crate) const DEFAULT_VALUES_MIN_FORMAT_VERSION: FormatVersion = FormatVersion::V3;
 
 /// Defines schema in iceberg.
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -421,42 +424,88 @@ impl Schema {
         &self.id_to_field
     }
 
-    /// Check that all types in this schema are supported by the given format version.
+    /// Minimum [`FormatVersion`] required to represent all *types* in this schema.
     ///
-    /// Mirrors Java's `Schema.checkCompatibility()`. Returns an error listing every
-    /// incompatible field if any are found.
-    ///
-    /// Types with a minimum format version:
-    /// - `TimestampNs` / `TimestamptzNs` → v3+
-    /// - `Variant` → v3+
-    pub fn check_format_compatibility(&self, format_version: FormatVersion) -> Result<()> {
-        let mut problems: Vec<String> = Vec::new();
+    /// Walks the whole schema — every field, nested ones included — and returns the
+    /// highest per-type floor, so this is O(fields) rather than a cheap field read.
+    /// Types only; for initial-default version floors see [`Schema::check_format_compatibility`].
+    pub fn calc_min_compatible_format(&self) -> FormatVersion {
+        // `id_to_field` is flattened, so the max over all fields covers nested ones too.
+        self.id_to_field
+            .values()
+            .map(|f| f.field_type.min_format_version())
+            .max()
+            .unwrap_or(FormatVersion::V1)
+    }
 
+    /// Returns an error listing every field incompatible with `format_version`.
+    /// Mirrors Java's `Schema.checkCompatibility()`. Two checks per field:
+    ///
+    /// - **Type** — minimum format version required to support that type, without
+    ///   taking nested field types into account.
+    /// - **Initial default** — a non-null `initial_default` backfills pre-existing rows,
+    ///   so it requires `DEFAULT_VALUES_MIN_FORMAT_VERSION`; `write_default` is not
+    ///   checked, as it only affects newly written rows (read identically at any version).
+    pub fn check_format_compatibility(&self, format_version: FormatVersion) -> Result<()> {
+        // (field id, message); sorted by id below for a deterministic error.
+        let mut problems: Vec<(i32, String)> = Vec::new();
+
+        // `id_to_field` is flattened, so checking each field by its own type keeps the
+        // blame on the offending leaf, not its container (mirrors Java's `lazyIdToField`).
         for field in self.id_to_field.values() {
             let min_version = field.field_type.min_format_version();
-
             if format_version < min_version {
-                let name = self
-                    .name_by_field_id(field.id)
-                    .unwrap_or(field.name.as_str());
-                problems.push(format!(
-                    "Invalid type for {name}: {} is not supported until v{min_version} but format version is v{format_version}.",
+                // Every id in `id_to_field` is also indexed in `id_to_name`; a miss means
+                // the schema's indexes are inconsistent (a bug), so surface it rather than
+                // guessing an unqualified name.
+                let name = self.name_by_field_id(field.id).ok_or_else(|| {
+                    Error::new(
+                        ErrorKind::Unexpected,
+                        format!(
+                            "Field id {} is missing from the schema's name index",
+                            field.id
+                        ),
+                    )
+                })?;
+                problems.push((field.id, format!(
+                    "Invalid type for {name}: {} is not supported until {min_version} but format version is {format_version}.",
                     field.field_type,
-                ));
+                )));
+            }
+
+            if let Some(default) = &field.initial_default
+                && format_version < DEFAULT_VALUES_MIN_FORMAT_VERSION
+            {
+                let name = self.name_by_field_id(field.id).ok_or_else(|| {
+                    Error::new(
+                        ErrorKind::Unexpected,
+                        format!(
+                            "Field id {} is missing from the schema's name index",
+                            field.id
+                        ),
+                    )
+                })?;
+                problems.push((field.id, format!(
+                    "Invalid initial default for {name}: non-null default ({default:?}) is not supported until {DEFAULT_VALUES_MIN_FORMAT_VERSION} but format version is {format_version}."
+                )));
             }
         }
 
         if problems.is_empty() {
-            Ok(())
-        } else {
-            Err(Error::new(
-                ErrorKind::DataInvalid,
-                format!(
-                    "Invalid schema for v{format_version}:\n- {}",
-                    problems.join("\n- ")
-                ),
-            ))
+            return Ok(());
         }
+
+        // Stable sort by id: HashMap order is nondeterministic, and stability keeps a
+        // field's type problem before its default problem (matches Java's TreeMap order).
+        let message = problems
+            .into_iter()
+            .sorted_by_key(|(id, _)| *id)
+            .map(|(_, msg)| msg)
+            .join("\n- ");
+        Err(Error::new(
+            ErrorKind::DataInvalid,
+            format!("Invalid schema for {format_version}:\n- {message}"),
+        ))
     }
 }
 
@@ -483,6 +532,180 @@ mod tests {
     use crate::spec::schema::Schema;
     use crate::spec::values::Map as MapValue;
     use crate::spec::{Datum, Literal};
+
+    #[test]
+    fn test_check_format_compatibility() {
+        use crate::spec::{FormatVersion, PrimitiveLiteral, VariantType};
+
+        fn schema_with(fields: Vec<NestedFieldRef>) -> Schema {
+            Schema::builder().with_fields(fields).build().unwrap()
+        }
+
+        // Variant type requires v3.
+        let variant = schema_with(vec![
+            NestedField::optional(1, "v", Type::Variant(VariantType)).into(),
+        ]);
+        assert!(
+            variant
+                .check_format_compatibility(FormatVersion::V2)
+                .is_err()
+        );
+        assert!(
+            variant
+                .check_format_compatibility(FormatVersion::V3)
+                .is_ok()
+        );
+
+        // A non-null initial default requires v3, even for a v1-compatible type.
+        let with_default = schema_with(vec![
+            NestedField::optional(1, "a", Type::Primitive(PrimitiveType::Int))
+                .with_initial_default(Literal::Primitive(PrimitiveLiteral::Int(1)))
+                .into(),
+        ]);
+        let err = with_default
+            .check_format_compatibility(FormatVersion::V2)
+            .unwrap_err();
+        assert!(
+            err.message().contains("Invalid initial default for a"),
+            "{err}"
+        );
+        assert!(
+            with_default
+                .check_format_compatibility(FormatVersion::V3)
+                .is_ok()
+        );
+
+        // No default is fine at any version (an absent/null default never trips).
+        let no_default = schema_with(vec![
+            NestedField::optional(1, "a", Type::Primitive(PrimitiveType::Int)).into(),
+        ]);
+        assert!(
+            no_default
+                .check_format_compatibility(FormatVersion::V1)
+                .is_ok()
+        );
+
+        // Recursion: a default on a field nested inside a struct is caught.
+        let nested = schema_with(vec![
+            NestedField::required(
+                1,
+                "s",
+                Type::Struct(StructType::new(vec![
+                    NestedField::optional(2, "inner", Type::Primitive(PrimitiveType::Long))
+                        .with_initial_default(Literal::Primitive(PrimitiveLiteral::Long(7)))
+                        .into(),
+                ])),
+            )
+            .into(),
+        ]);
+        let err = nested
+            .check_format_compatibility(FormatVersion::V2)
+            .unwrap_err();
+        assert!(err.message().contains("inner"), "{err}");
+
+        // A v3-only type nested in a container blames the leaf, never the container.
+        let nested_variant = schema_with(vec![
+            NestedField::required(
+                1,
+                "container",
+                Type::Struct(StructType::new(vec![
+                    NestedField::optional(2, "v", Type::Variant(VariantType)).into(),
+                ])),
+            )
+            .into(),
+        ]);
+        let err = nested_variant
+            .check_format_compatibility(FormatVersion::V2)
+            .unwrap_err();
+        assert!(err.message().contains("container.v"), "{err}");
+        assert!(
+            !err.message().contains("Invalid type for container:"),
+            "container must not be blamed: {err}"
+        );
+    }
+
+    #[test]
+    fn test_calc_min_compatible_format() {
+        use crate::spec::{FormatVersion, VariantType};
+
+        fn schema_with(fields: Vec<NestedFieldRef>) -> Schema {
+            Schema::builder().with_fields(fields).build().unwrap()
+        }
+
+        // All v1-compatible types → V1.
+        let v1 = schema_with(vec![
+            NestedField::required(1, "a", Type::Primitive(PrimitiveType::Int)).into(),
+            NestedField::optional(2, "b", Type::Primitive(PrimitiveType::String)).into(),
+        ]);
+        assert_eq!(v1.calc_min_compatible_format(), FormatVersion::V1);
+
+        // A top-level variant → V3.
+        let variant = schema_with(vec![
+            NestedField::optional(1, "v", Type::Variant(VariantType)).into(),
+        ]);
+        assert_eq!(variant.calc_min_compatible_format(), FormatVersion::V3);
+
+        // A v3-only type nested inside a list inside a struct → V3 (flattened fields).
+        let nested = schema_with(vec![
+            NestedField::required(
+                1,
+                "s",
+                Type::Struct(StructType::new(vec![
+                    NestedField::optional(
+                        2,
+                        "l",
+                        Type::List(ListType::new(
+                            NestedField::required(
+                                3,
+                                "element",
+                                Type::Primitive(PrimitiveType::TimestampNs),
+                            )
+                            .into(),
+                        )),
+                    )
+                    .into(),
+                ])),
+            )
+            .into(),
+        ]);
+        assert_eq!(nested.calc_min_compatible_format(), FormatVersion::V3);
+    }
+
+    #[test]
+    fn test_check_format_compatibility_message_order() {
+        use crate::spec::{FormatVersion, PrimitiveLiteral, VariantType};
+
+        // Fields declared out of id order; field 2 fails both checks (ts_ns type
+        // AND a non-null initial default). The error must list problems by field id,
+        // with the type problem before the initial-default problem for field 2.
+        let schema = Schema::builder()
+            .with_fields(vec![
+                NestedField::optional(3, "c", Type::Variant(VariantType)).into(),
+                NestedField::optional(2, "b", Type::Primitive(PrimitiveType::TimestampNs))
+                    .with_initial_default(Literal::Primitive(PrimitiveLiteral::Long(0)))
+                    .into(),
+                NestedField::required(1, "a", Type::Primitive(PrimitiveType::Int)).into(),
+            ])
+            .build()
+            .unwrap();
+
+        let message = schema
+            .check_format_compatibility(FormatVersion::V2)
+            .unwrap_err()
+            .message()
+            .to_string();
+
+        let lines: Vec<&str> = message.lines().skip(1).collect();
+        assert_eq!(
+            lines,
+            vec![
+                "- Invalid type for b: timestamp_ns is not supported until v3 but format version is v2.",
+                "- Invalid initial default for b: non-null default (Primitive(Long(0))) is not supported until v3 but format version is v2.",
+                "- Invalid type for c: variant is not supported until v3 but format version is v2.",
+            ],
+            "{message}"
+        );
+    }
 
     #[test]
     fn test_construct_schema() {

--- a/crates/iceberg/src/spec/schema/prune_columns.rs
+++ b/crates/iceberg/src/spec/schema/prune_columns.rs
@@ -238,6 +238,10 @@ impl SchemaVisitor for PruneColumn {
     fn primitive(&mut self, _p: &PrimitiveType) -> Result<Option<Type>> {
         Ok(None)
     }
+
+    fn variant(&mut self, _v: &crate::spec::VariantType) -> Result<Self::T> {
+        Ok(None)
+    }
 }
 
 #[cfg(test)]

--- a/crates/iceberg/src/spec/schema/prune_columns.rs
+++ b/crates/iceberg/src/spec/schema/prune_columns.rs
@@ -16,6 +16,7 @@
 // under the License.
 
 use super::*;
+use crate::spec::VariantType;
 
 struct PruneColumn {
     selected: HashSet<i32>,
@@ -239,7 +240,7 @@ impl SchemaVisitor for PruneColumn {
         Ok(None)
     }
 
-    fn variant(&mut self, _v: &crate::spec::VariantType) -> Result<Self::T> {
+    fn variant(&mut self, _v: &VariantType) -> Result<Self::T> {
         Ok(None)
     }
 }
@@ -763,5 +764,34 @@ mod tests {
         let result = prune_columns(&schema, selected, true);
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), Type::Struct(schema.as_struct().clone()));
+    }
+
+    #[test]
+    fn test_prune_columns_variant() {
+        // foo (String, id=1) + v (Variant, id=2).
+        let schema = Schema::builder()
+            .with_fields(vec![
+                NestedField::optional(1, "foo", Type::Primitive(PrimitiveType::String)).into(),
+                NestedField::optional(2, "v", Type::Variant(VariantType)).into(),
+            ])
+            .build()
+            .unwrap();
+
+        // A variant is a leaf (like a primitive): selecting it keeps it, the same way
+        // for select_full_types true and false.
+        let only_variant = Type::Struct(StructType::new(vec![
+            NestedField::optional(2, "v", Type::Variant(VariantType)).into(),
+        ]));
+        for full in [false, true] {
+            let result = prune_columns(&schema, HashSet::from([2]), full).unwrap();
+            assert_eq!(result, only_variant, "select_full_types={full}");
+        }
+
+        // Selecting a sibling prunes the variant out.
+        let only_foo = Type::Struct(StructType::new(vec![
+            NestedField::optional(1, "foo", Type::Primitive(PrimitiveType::String)).into(),
+        ]));
+        let result = prune_columns(&schema, HashSet::from([1]), false).unwrap();
+        assert_eq!(result, only_foo);
     }
 }

--- a/crates/iceberg/src/spec/schema/visitor.rs
+++ b/crates/iceberg/src/spec/schema/visitor.rs
@@ -16,6 +16,7 @@
 // under the License.
 
 use super::*;
+use crate::spec::VariantType;
 
 /// A post order schema visitor.
 ///
@@ -69,6 +70,9 @@ pub trait SchemaVisitor {
     fn map(&mut self, map: &MapType, key_value: Self::T, value: Self::T) -> Result<Self::T>;
     /// Called when see a primitive type.
     fn primitive(&mut self, p: &PrimitiveType) -> Result<Self::T>;
+
+    /// Called when see a variant type.
+    fn variant(&mut self, _v: &VariantType) -> Result<Self::T>;
 }
 
 /// Visiting a type in post order.
@@ -99,6 +103,7 @@ pub(crate) fn visit_type<V: SchemaVisitor>(r#type: &Type, visitor: &mut V) -> Re
             visitor.map(map, key_result, value_result)
         }
         Type::Struct(s) => visit_struct(s, visitor),
+        Type::Variant(v) => visitor.variant(v),
     }
 }
 
@@ -185,6 +190,8 @@ pub trait SchemaWithPartnerVisitor<P> {
     ) -> Result<Self::T>;
     /// Called when see a primitive type.
     fn primitive(&mut self, p: &PrimitiveType, partner: &P) -> Result<Self::T>;
+    /// Called when see a variant type.
+    fn variant(&mut self, _v: &VariantType, _partner: &P) -> Result<Self::T>;
 }
 
 /// Accessor used to get child partner from parent partner.
@@ -242,6 +249,7 @@ pub(crate) fn visit_type_with_partner<P, V: SchemaWithPartnerVisitor<P>, A: Part
             visitor.map(map, partner, key_result, value_result)
         }
         Type::Struct(s) => visit_struct_with_partner(s, partner, visitor, accessor),
+        Type::Variant(v) => visitor.variant(v, partner),
     }
 }
 

--- a/crates/iceberg/src/spec/sort.rs
+++ b/crates/iceberg/src/spec/sort.rs
@@ -453,6 +453,35 @@ mod tests {
     }
 
     #[test]
+    fn test_build_should_return_err_if_source_field_is_variant() {
+        let schema = Schema::builder()
+            .with_schema_id(1)
+            .with_fields(vec![
+                NestedField::optional(1, "v", Type::Variant(crate::spec::VariantType)).into(),
+            ])
+            .build()
+            .unwrap();
+
+        let sort_order_builder_result = SortOrder::builder()
+            .with_sort_field(
+                SortField::builder()
+                    .source_id(1)
+                    .direction(SortDirection::Ascending)
+                    .null_order(NullOrder::First)
+                    .transform(Transform::Identity)
+                    .build(),
+            )
+            .build(&schema);
+
+        assert_eq!(
+            sort_order_builder_result
+                .expect_err("Expected an Err value")
+                .message(),
+            "Cannot sort by non-primitive source field: variant"
+        )
+    }
+
+    #[test]
     fn test_build_should_return_err_if_source_field_type_is_not_supported_by_transform() {
         let schema = Schema::builder()
             .with_schema_id(1)

--- a/crates/iceberg/src/spec/table_metadata.rs
+++ b/crates/iceberg/src/spec/table_metadata.rs
@@ -491,6 +491,7 @@ impl TableMetadata {
         // Normalize location (remove trailing slash)
         self.location = self.location.trim_end_matches('/').to_string();
         self.validate_snapshot_sequence_number()?;
+        self.validate_schema_format_compatibility()?;
         self.try_normalize_partition_spec()?;
         self.try_normalize_sort_order()?;
         Ok(self)
@@ -703,6 +704,15 @@ impl TableMetadata {
             }
         }
 
+        Ok(())
+    }
+
+    /// Validates that every type used across all schemas is supported by the
+    /// table's format version.  Delegates to [`Schema::check_format_compatibility`].
+    fn validate_schema_format_compatibility(&self) -> Result<()> {
+        for schema in self.schemas.values() {
+            schema.check_format_compatibility(self.format_version)?;
+        }
         Ok(())
     }
 }

--- a/crates/iceberg/src/spec/table_metadata.rs
+++ b/crates/iceberg/src/spec/table_metadata.rs
@@ -707,13 +707,11 @@ impl TableMetadata {
         Ok(())
     }
 
-    /// Validates that every type used across all schemas is supported by the
+    /// Validates that every type used in the current schema is supported by the
     /// table's format version.  Delegates to [`Schema::check_format_compatibility`].
     fn validate_schema_format_compatibility(&self) -> Result<()> {
-        for schema in self.schemas.values() {
-            schema.check_format_compatibility(self.format_version)?;
-        }
-        Ok(())
+        self.current_schema()
+            .check_format_compatibility(self.format_version)
     }
 }
 

--- a/crates/iceberg/src/spec/values/literal.rs
+++ b/crates/iceberg/src/spec/values/literal.rs
@@ -595,6 +595,10 @@ impl Literal {
                     ))
                 }
             }
+            Type::Variant(_) => Err(Error::new(
+                ErrorKind::DataInvalid,
+                "Variant type is not supported for single-value JSON serialization",
+            )),
         }
     }
 

--- a/crates/iceberg/src/writer/file_writer/parquet_writer.rs
+++ b/crates/iceberg/src/writer/file_writer/parquet_writer.rs
@@ -831,6 +831,24 @@ mod tests {
         assert_eq!(visitor.name_to_id, expect);
     }
 
+    #[test]
+    fn test_index_by_parquet_path_variant() {
+        // A variant is a leaf, so it is indexed by its column name like a primitive.
+        let schema = Schema::builder()
+            .with_fields(vec![
+                NestedField::optional(1, "id", Type::Primitive(PrimitiveType::Long)).into(),
+                NestedField::optional(2, "v", Type::Variant(VariantType)).into(),
+            ])
+            .build()
+            .unwrap();
+        let mut visitor = IndexByParquetPathName::new();
+        visit_schema(&schema, &mut visitor).unwrap();
+        assert_eq!(
+            visitor.name_to_id,
+            HashMap::from([("id".to_string(), 1), ("v".to_string(), 2)])
+        );
+    }
+
     #[tokio::test]
     async fn test_parquet_writer() -> Result<()> {
         let temp_dir = TempDir::new().unwrap();

--- a/crates/iceberg/src/writer/file_writer/parquet_writer.rs
+++ b/crates/iceberg/src/writer/file_writer/parquet_writer.rs
@@ -40,7 +40,7 @@ use crate::io::{FileIO, FileWrite, OutputFile};
 use crate::spec::{
     DataContentType, DataFileBuilder, DataFileFormat, Datum, ListType, Literal, MapType,
     NestedFieldRef, PartitionSpec, PrimitiveType, Schema, SchemaRef, SchemaVisitor, Struct,
-    StructType, TableMetadata, Type, visit_schema,
+    StructType, TableMetadata, Type, VariantType, visit_schema,
 };
 use crate::transform::create_transform_function;
 use crate::writer::{CurrentFileStatus, DataFile};
@@ -137,6 +137,22 @@ impl IndexByParquetPathName {
     pub fn get(&self, name: &str) -> Option<&i32> {
         self.name_to_id.get(name)
     }
+
+    fn insert_current_path(&mut self) -> Result<()> {
+        let full_name = self.field_names.iter().map(String::as_str).join(".");
+        let field_id = self.field_id;
+        if let Some(existing_field_id) = self.name_to_id.get(full_name.as_str()) {
+            return Err(Error::new(
+                ErrorKind::DataInvalid,
+                format!(
+                    "Invalid schema: multiple fields for name {full_name}: {field_id} and {existing_field_id}"
+                ),
+            ));
+        } else {
+            self.name_to_id.insert(full_name, field_id);
+        }
+        Ok(())
+    }
 }
 
 impl Default for IndexByParquetPathName {
@@ -215,20 +231,11 @@ impl SchemaVisitor for IndexByParquetPathName {
     }
 
     fn primitive(&mut self, _p: &PrimitiveType) -> Result<Self::T> {
-        let full_name = self.field_names.iter().map(String::as_str).join(".");
-        let field_id = self.field_id;
-        if let Some(existing_field_id) = self.name_to_id.get(full_name.as_str()) {
-            return Err(Error::new(
-                ErrorKind::DataInvalid,
-                format!(
-                    "Invalid schema: multiple fields for name {full_name}: {field_id} and {existing_field_id}"
-                ),
-            ));
-        } else {
-            self.name_to_id.insert(full_name, field_id);
-        }
+        self.insert_current_path()
+    }
 
-        Ok(())
+    fn variant(&mut self, _v: &VariantType) -> Result<Self::T> {
+        self.insert_current_path()
     }
 }
 

--- a/crates/integration_tests/tests/read_variant.rs
+++ b/crates/integration_tests/tests/read_variant.rs
@@ -1,0 +1,179 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Integration tests for variant type support.
+//!
+//! These tests require a running Docker environment seeded by `dev/spark/provision.py`.
+//! The Spark 4.0 provisioner creates `rest.default.test_variant_column` with a
+//! `VARIANT` column containing three rows of JSON data.
+
+use arrow_schema::DataType;
+use futures::TryStreamExt;
+use iceberg::spec::Type;
+use iceberg::{Catalog, CatalogBuilder, TableIdent};
+use iceberg_catalog_rest::RestCatalogBuilder;
+use iceberg_integration_tests::get_test_fixture;
+
+/// Verifies that a table written by Spark with a VARIANT column has its schema
+/// parsed into `Type::Variant` by the Rust iceberg implementation.
+#[tokio::test]
+async fn test_variant_schema_is_parsed() {
+    let fixture = get_test_fixture();
+    let rest_catalog = RestCatalogBuilder::default()
+        .load("rest", fixture.catalog_config.clone())
+        .await
+        .unwrap();
+
+    let table = rest_catalog
+        .load_table(&TableIdent::from_strs(["default", "test_variant_column"]).unwrap())
+        .await
+        .unwrap();
+
+    let schema = table.metadata().current_schema();
+    let variant_field = schema
+        .field_by_name("v")
+        .expect("field 'v' not found in schema");
+
+    assert!(
+        matches!(variant_field.field_type.as_ref(), Type::Variant(_)),
+        "Expected Type::Variant for field 'v', got {:?}",
+        variant_field.field_type,
+    );
+}
+
+/// Verifies that scanning a table with a VARIANT column produces an Arrow batch
+/// where the variant column is represented as `Struct(metadata: Binary, value: Binary)`,
+/// matching the Parquet physical layout (§3.3 of the Parquet Variant spec).
+#[tokio::test]
+async fn test_variant_arrow_schema() {
+    let fixture = get_test_fixture();
+    let rest_catalog = RestCatalogBuilder::default()
+        .load("rest", fixture.catalog_config.clone())
+        .await
+        .unwrap();
+
+    let table = rest_catalog
+        .load_table(&TableIdent::from_strs(["default", "test_variant_column"]).unwrap())
+        .await
+        .unwrap();
+
+    let scan = table.scan().build().unwrap();
+    let batch_stream = scan.to_arrow().await.unwrap();
+    let batches: Vec<_> = batch_stream.try_collect().await.unwrap();
+
+    assert!(!batches.is_empty(), "expected at least one record batch");
+
+    // Variant column must be a struct with exactly two binary sub-fields
+    let v_col = batches[0]
+        .column_by_name("v")
+        .expect("column 'v' not found in batch");
+
+    let DataType::Struct(fields) = v_col.data_type() else {
+        panic!(
+            "Expected variant column to be DataType::Struct, got {:?}",
+            v_col.data_type()
+        );
+    };
+
+    assert_eq!(
+        fields.len(),
+        2,
+        "variant struct must have exactly 2 sub-fields"
+    );
+
+    let metadata_field = fields
+        .iter()
+        .find(|f| f.name() == "metadata")
+        .expect("sub-field 'metadata' not found");
+    let value_field = fields
+        .iter()
+        .find(|f| f.name() == "value")
+        .expect("sub-field 'value' not found");
+
+    assert_eq!(
+        metadata_field.data_type(),
+        &DataType::Binary,
+        "'metadata' sub-field must be DataType::Binary"
+    );
+    assert_eq!(
+        value_field.data_type(),
+        &DataType::Binary,
+        "'value' sub-field must be DataType::Binary"
+    );
+}
+
+/// Verifies that a variant column is NOT silently dropped when it is projected
+/// alongside ordinary primitive columns (regression test for the projection bug
+/// where variant sub-fields had no embedded Parquet field IDs and were therefore
+/// excluded from `column_map`, causing the whole variant group to be omitted).
+#[tokio::test]
+async fn test_variant_projected_with_primitive_columns() {
+    let fixture = get_test_fixture();
+    let rest_catalog = RestCatalogBuilder::default()
+        .load("rest", fixture.catalog_config.clone())
+        .await
+        .unwrap();
+
+    let table = rest_catalog
+        .load_table(&TableIdent::from_strs(["default", "test_variant_column"]).unwrap())
+        .await
+        .unwrap();
+
+    // Explicitly select only the two columns — this exercises the projection path
+    // that was previously broken for variant types.
+    let scan = table.scan().select(["id", "v"]).build().unwrap();
+    let batch_stream = scan.to_arrow().await.unwrap();
+    let batches: Vec<_> = batch_stream.try_collect().await.unwrap();
+
+    assert!(!batches.is_empty(), "expected at least one record batch");
+
+    let first_batch = &batches[0];
+
+    // Both columns must be present — the variant must not be silently dropped.
+    assert!(
+        first_batch.column_by_name("id").is_some(),
+        "column 'id' not found in projected batch"
+    );
+    let v_col = first_batch
+        .column_by_name("v")
+        .expect("column 'v' was silently dropped from projected scan — projection bug regression");
+
+    // The variant column must still be a struct with the expected sub-fields.
+    let DataType::Struct(fields) = v_col.data_type() else {
+        panic!(
+            "Expected variant column to be DataType::Struct after projection, got {:?}",
+            v_col.data_type()
+        );
+    };
+    assert_eq!(
+        fields.len(),
+        2,
+        "projected variant struct must have exactly 2 sub-fields"
+    );
+    assert!(
+        fields.iter().any(|f| f.name() == "metadata"),
+        "projected variant struct must have a 'metadata' sub-field"
+    );
+    assert!(
+        fields.iter().any(|f| f.name() == "value"),
+        "projected variant struct must have a 'value' sub-field"
+    );
+
+    // All three seeded rows must be readable.
+    let total_rows: usize = batches.iter().map(|b| b.num_rows()).sum();
+    assert_eq!(total_rows, 3, "expected exactly 3 rows");
+}

--- a/crates/integration_tests/tests/read_variant.rs
+++ b/crates/integration_tests/tests/read_variant.rs
@@ -22,6 +22,7 @@
 //! `VARIANT` column containing three rows of JSON data.
 
 use arrow_schema::DataType;
+use arrow_schema::extension::EXTENSION_TYPE_NAME_KEY;
 use futures::TryStreamExt;
 use iceberg::spec::Type;
 use iceberg::{Catalog, CatalogBuilder, TableIdent};
@@ -76,6 +77,17 @@ async fn test_variant_arrow_schema() {
     let batches: Vec<_> = batch_stream.try_collect().await.unwrap();
 
     assert!(!batches.is_empty(), "expected at least one record batch");
+    assert_eq!(
+        batches[0]
+            .schema()
+            .field_with_name("v")
+            .unwrap()
+            .metadata()
+            .get(EXTENSION_TYPE_NAME_KEY)
+            .map(String::as_str),
+        Some("arrow.parquet.variant"),
+        "variant field must carry Arrow extension metadata"
+    );
 
     // Variant column must be a struct with exactly two binary sub-fields
     let v_col = batches[0]
@@ -142,6 +154,17 @@ async fn test_variant_projected_with_primitive_columns() {
     assert!(!batches.is_empty(), "expected at least one record batch");
 
     let first_batch = &batches[0];
+    assert_eq!(
+        first_batch
+            .schema()
+            .field_with_name("v")
+            .unwrap()
+            .metadata()
+            .get(EXTENSION_TYPE_NAME_KEY)
+            .map(String::as_str),
+        Some("arrow.parquet.variant"),
+        "projected variant field must carry Arrow extension metadata"
+    );
 
     // Both columns must be present — the variant must not be silently dropped.
     assert!(

--- a/crates/integration_tests/tests/read_variant.rs
+++ b/crates/integration_tests/tests/read_variant.rs
@@ -21,28 +21,85 @@
 //! The Spark 4.0 provisioner creates `rest.default.test_variant_column` with a
 //! `VARIANT` column containing three rows of JSON data.
 
+use arrow_array::RecordBatch;
 use arrow_schema::DataType;
 use arrow_schema::extension::EXTENSION_TYPE_NAME_KEY;
 use futures::TryStreamExt;
 use iceberg::spec::Type;
+use iceberg::table::Table;
 use iceberg::{Catalog, CatalogBuilder, TableIdent};
 use iceberg_catalog_rest::RestCatalogBuilder;
 use iceberg_integration_tests::get_test_fixture;
 
-/// Verifies that a table written by Spark with a VARIANT column has its schema
-/// parsed into `Type::Variant` by the Rust iceberg implementation.
-#[tokio::test]
-async fn test_variant_schema_is_parsed() {
+async fn load_variant_table() -> Table {
     let fixture = get_test_fixture();
     let rest_catalog = RestCatalogBuilder::default()
         .load("rest", fixture.catalog_config.clone())
         .await
         .unwrap();
 
-    let table = rest_catalog
+    rest_catalog
         .load_table(&TableIdent::from_strs(["default", "test_variant_column"]).unwrap())
         .await
-        .unwrap();
+        .unwrap()
+}
+
+/// Asserts that the variant field "v" in the batch carries extension metadata and
+/// has the expected `Struct(metadata: Binary, value: Binary)` layout.
+fn assert_variant_column(batch: &RecordBatch) {
+    assert_eq!(
+        batch
+            .schema()
+            .field_with_name("v")
+            .unwrap()
+            .metadata()
+            .get(EXTENSION_TYPE_NAME_KEY)
+            .map(String::as_str),
+        Some("arrow.parquet.variant"),
+        "variant field must carry Arrow extension metadata"
+    );
+
+    let v_col = batch
+        .column_by_name("v")
+        .expect("column 'v' not found in batch");
+
+    let DataType::Struct(fields) = v_col.data_type() else {
+        panic!(
+            "Expected variant column to be DataType::Struct, got {:?}",
+            v_col.data_type()
+        );
+    };
+
+    assert_eq!(
+        fields.len(),
+        2,
+        "variant struct must have exactly 2 sub-fields"
+    );
+    assert_eq!(
+        fields
+            .iter()
+            .find(|f| f.name() == "metadata")
+            .expect("sub-field 'metadata' not found")
+            .data_type(),
+        &DataType::Binary,
+        "'metadata' sub-field must be DataType::Binary"
+    );
+    assert_eq!(
+        fields
+            .iter()
+            .find(|f| f.name() == "value")
+            .expect("sub-field 'value' not found")
+            .data_type(),
+        &DataType::Binary,
+        "'value' sub-field must be DataType::Binary"
+    );
+}
+
+/// Verifies that a table written by Spark with a VARIANT column has its schema
+/// parsed into `Type::Variant` by the Rust iceberg implementation.
+#[tokio::test]
+async fn test_variant_schema_is_parsed() {
+    let table = load_variant_table().await;
 
     let schema = table.metadata().current_schema();
     let variant_field = schema
@@ -61,71 +118,14 @@ async fn test_variant_schema_is_parsed() {
 /// matching the Parquet physical layout (§3.3 of the Parquet Variant spec).
 #[tokio::test]
 async fn test_variant_arrow_schema() {
-    let fixture = get_test_fixture();
-    let rest_catalog = RestCatalogBuilder::default()
-        .load("rest", fixture.catalog_config.clone())
-        .await
-        .unwrap();
-
-    let table = rest_catalog
-        .load_table(&TableIdent::from_strs(["default", "test_variant_column"]).unwrap())
-        .await
-        .unwrap();
+    let table = load_variant_table().await;
 
     let scan = table.scan().build().unwrap();
     let batch_stream = scan.to_arrow().await.unwrap();
     let batches: Vec<_> = batch_stream.try_collect().await.unwrap();
 
     assert!(!batches.is_empty(), "expected at least one record batch");
-    assert_eq!(
-        batches[0]
-            .schema()
-            .field_with_name("v")
-            .unwrap()
-            .metadata()
-            .get(EXTENSION_TYPE_NAME_KEY)
-            .map(String::as_str),
-        Some("arrow.parquet.variant"),
-        "variant field must carry Arrow extension metadata"
-    );
-
-    // Variant column must be a struct with exactly two binary sub-fields
-    let v_col = batches[0]
-        .column_by_name("v")
-        .expect("column 'v' not found in batch");
-
-    let DataType::Struct(fields) = v_col.data_type() else {
-        panic!(
-            "Expected variant column to be DataType::Struct, got {:?}",
-            v_col.data_type()
-        );
-    };
-
-    assert_eq!(
-        fields.len(),
-        2,
-        "variant struct must have exactly 2 sub-fields"
-    );
-
-    let metadata_field = fields
-        .iter()
-        .find(|f| f.name() == "metadata")
-        .expect("sub-field 'metadata' not found");
-    let value_field = fields
-        .iter()
-        .find(|f| f.name() == "value")
-        .expect("sub-field 'value' not found");
-
-    assert_eq!(
-        metadata_field.data_type(),
-        &DataType::Binary,
-        "'metadata' sub-field must be DataType::Binary"
-    );
-    assert_eq!(
-        value_field.data_type(),
-        &DataType::Binary,
-        "'value' sub-field must be DataType::Binary"
-    );
+    assert_variant_column(&batches[0]);
 }
 
 /// Verifies that a variant column is NOT silently dropped when it is projected
@@ -134,16 +134,7 @@ async fn test_variant_arrow_schema() {
 /// excluded from `column_map`, causing the whole variant group to be omitted).
 #[tokio::test]
 async fn test_variant_projected_with_primitive_columns() {
-    let fixture = get_test_fixture();
-    let rest_catalog = RestCatalogBuilder::default()
-        .load("rest", fixture.catalog_config.clone())
-        .await
-        .unwrap();
-
-    let table = rest_catalog
-        .load_table(&TableIdent::from_strs(["default", "test_variant_column"]).unwrap())
-        .await
-        .unwrap();
+    let table = load_variant_table().await;
 
     // Explicitly select only the two columns — this exercises the projection path
     // that was previously broken for variant types.
@@ -154,46 +145,12 @@ async fn test_variant_projected_with_primitive_columns() {
     assert!(!batches.is_empty(), "expected at least one record batch");
 
     let first_batch = &batches[0];
-    assert_eq!(
-        first_batch
-            .schema()
-            .field_with_name("v")
-            .unwrap()
-            .metadata()
-            .get(EXTENSION_TYPE_NAME_KEY)
-            .map(String::as_str),
-        Some("arrow.parquet.variant"),
-        "projected variant field must carry Arrow extension metadata"
-    );
+    assert_variant_column(first_batch);
 
     // Both columns must be present — the variant must not be silently dropped.
     assert!(
         first_batch.column_by_name("id").is_some(),
         "column 'id' not found in projected batch"
-    );
-    let v_col = first_batch
-        .column_by_name("v")
-        .expect("column 'v' was silently dropped from projected scan — projection bug regression");
-
-    // The variant column must still be a struct with the expected sub-fields.
-    let DataType::Struct(fields) = v_col.data_type() else {
-        panic!(
-            "Expected variant column to be DataType::Struct after projection, got {:?}",
-            v_col.data_type()
-        );
-    };
-    assert_eq!(
-        fields.len(),
-        2,
-        "projected variant struct must have exactly 2 sub-fields"
-    );
-    assert!(
-        fields.iter().any(|f| f.name() == "metadata"),
-        "projected variant struct must have a 'metadata' sub-field"
-    );
-    assert!(
-        fields.iter().any(|f| f.name() == "value"),
-        "projected variant struct must have a 'value' sub-field"
     );
 
     // All three seeded rows must be readable.

--- a/crates/integrations/datafusion/src/schema.rs
+++ b/crates/integrations/datafusion/src/schema.rs
@@ -29,6 +29,7 @@ use futures::StreamExt;
 use futures::future::try_join_all;
 use iceberg::arrow::arrow_schema_to_schema_auto_assign_ids;
 use iceberg::inspect::MetadataTableType;
+use iceberg::spec::FormatVersion;
 use iceberg::{Catalog, Error, ErrorKind, NamespaceIdent, Result, TableCreation, TableIdent};
 
 use crate::table::IcebergTableProvider;
@@ -163,10 +164,16 @@ impl SchemaProvider for IcebergSchemaProvider {
         let iceberg_schema = arrow_schema_to_schema_auto_assign_ids(df_schema.as_ref())
             .map_err(to_datafusion_error)?;
 
+        // Use at least V2, and upgrade to V3 if the schema requires it (e.g. timestamp_ns / variant).
+        let format_version = iceberg_schema
+            .calc_min_compatible_format()
+            .max(FormatVersion::V2);
+
         // Create the table in the Iceberg catalog
         let table_creation = TableCreation::builder()
             .name(name.clone())
             .schema(iceberg_schema)
+            .format_version(format_version)
             .build();
 
         let catalog = self.catalog.clone();

--- a/dev/spark/provision.py
+++ b/dev/spark/provision.py
@@ -129,6 +129,24 @@ spark.sql("ALTER TABLE rest.default.test_promote_partition_column ALTER COLUMN b
 spark.sql("ALTER TABLE rest.default.test_promote_partition_column ALTER COLUMN baz TYPE decimal(6, 2)")
 spark.sql("INSERT INTO rest.default.test_promote_partition_column VALUES (25, 22.25, 22.25)")
 
+#  Create a table with a variant column
+spark.sql("""
+CREATE OR REPLACE TABLE rest.default.test_variant_column (
+    id     INT,
+    v      VARIANT
+)
+USING iceberg
+TBLPROPERTIES ('format-version'='3')
+""")
+
+spark.sql("""
+INSERT INTO rest.default.test_variant_column
+VALUES
+    (1, PARSE_JSON('{"a": 1, "b": "hello"}')),
+    (2, PARSE_JSON('[1, 2, 3]')),
+    (3, PARSE_JSON('42'))
+""")
+
 #  Create a table with various types
 spark.sql("""
 CREATE OR REPLACE TABLE rest.default.types_test USING ICEBERG AS 


### PR DESCRIPTION
## Which issue does this PR close?

Variant read support for the fork, consumed by risingwavelabs/risingwave#25165.

## What changes are included in this PR?

Cherry-pick of apache/iceberg-rust#2188 (feat: Variant Support) plus fork-side fixes, rebased onto `dev_rebase_main_20260303` (arrow 58).

On top of the upstream cherry-pick:

- **Preserve Arrow variant extension metadata**: `schema_to_arrow_schema` attaches `arrow.parquet.variant` (`ARROW:extension:name`) to variant fields, and the reverse Arrow→Iceberg conversion recognizes it (including variants nested in list/map). Upstream #2188 currently emits a plain `struct<metadata: binary, value: binary>` with no extension, which downstream consumers cannot distinguish from a regular struct. RisingWave's variant→jsonb decoding keys on this extension.
- **Derive the extension from the Parquet VARIANT logical type**: enable parquet's `variant_experimental` feature. Files written by Spark/iceberg-java annotate variant groups with the Parquet `VARIANT` logical type but embed no Arrow schema, so the Arrow schema used for projection is derived from the Parquet schema at read time; without the feature it came out as a bare struct and `arrow_schema_to_schema` failed on the id-less `metadata`/`value` sub-fields with "Field id not found in metadata". Covered by `test_arrow_projection_mask_variant_schema_derived_from_parquet` and verified against Spark-4.0.2/Iceberg-1.10.1-written files.
- **Fix Arrow variant projection**: variant is an Iceberg leaf but a Parquet group whose sub-fields carry no field ids; project every leaf under a selected variant group. The leaf-index traversal is kept in lock-step with `arrow_schema::Fields::filter_leaves` (incl. Dictionary/RunEndEncoded unwrapping and Union recursion, which upstream's revision misses).
- **fix(avro): unique variant record names** (ported from the current #2188 revision): fixed `"variant"` record name breaks schemas with more than one variant column; use `r{field_id}` derived from the enclosing field id, mirroring Java's `TypeToSchema`.
- **fix(reader): reject shredded variant columns** (ported from the current #2188 revision): a `typed_value` sub-field means the payload is shredded and cannot be reconstructed yet; fail loudly instead of silently dropping data.

Deliberately **not** adopted from the current #2188 revision:

- Excluding variant sub-leaves from the pre-projected schema: that truncates containers structurally (`map<string, variant>` loses its value field → "Map field must have exactly 2 fields"). Covered here by `test_arrow_projection_mask_map_with_variant_value`.

Everything else from the current #2188 revision is adopted, keeping divergence to the fixes above:

- **`check_format_compatibility` scope changes + DataFusion format-version auto-selection**: the cherry-picked metadata check broke DataFusion `CREATE TABLE` with nanosecond timestamps (DataFusion's default `TIMESTAMP`) on v2 tables — masked in CI until the `read_variant` fixes let the run reach the DataFusion SLTs. Ported `Schema::calc_min_compatible_format()` (DataFusion tables now auto-upgrade to v3 when the schema requires it), the `initial_default` floor check, id-sorted error messages (also fixing the doubled `vv2`), and current-schema-only metadata validation.
- **HMS/Glue `variant` column-type mappings** ("variant" / "unknown", matching iceberg-java's `HiveSchemaUtil`, apache/iceberg#15964) instead of rejecting with `FeatureUnsupported`, plus upstream's variant tests across partition/sort rejection, arrow value conversion, id reassignment, schema indexing, column pruning, and parquet path indexing.

Not applicable to this base (patches code the fork's base doesn't have): `transaction/update_schema.rs` variant arms, `public-api.txt`.

## Are these changes tested?

- Unit tests: `cargo test -p iceberg --lib` (1271 passed), `iceberg-catalog-glue`/`-hms` libs (15/15 passed), incl. `test_multiple_variants_in_struct_have_unique_record_names`, `test_arrow_projection_mask_shredded_variant_is_rejected`, and `test_arrow_projection_mask_variant_schema_derived_from_parquet`.
- Integration test `read_variant.rs` verifies scanning Spark-written variant tables end-to-end (extension metadata on output batches, unshredded layout).
- End-to-end via RisingWave: `e2e_test/iceberg/test_case/iceberg_source_variant.toml` reads a Spark-written v3 table (21 variant columns plus struct/list/map-nested variants, SQL NULLs, empty containers, NaN) through this rev.
