### PR TITLE
perf: avoid extra copy in `DeletionVectorWriter::write`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3130,6 +3130,11 @@ name = "hashbrown"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "hashlink"
@@ -3422,6 +3427,7 @@ dependencies = [
  "flate2",
  "fnv",
  "futures",
+ "hashbrown 0.17.0",
  "iceberg_test_utils",
  "itertools 0.13.0",
  "minijinja",

--- a/crates/iceberg/Cargo.toml
+++ b/crates/iceberg/Cargo.toml
@@ -93,6 +93,7 @@ typetag = { workspace = true }
 url = { workspace = true }
 uuid = { workspace = true }
 zstd = { workspace = true }
+hashbrown = "0.17.0"
 
 [dev-dependencies]
 expect-test = { workspace = true }

--- a/crates/iceberg/src/arrow/caching_delete_file_loader.rs
+++ b/crates/iceberg/src/arrow/caching_delete_file_loader.rs
@@ -15,12 +15,13 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 use std::ops::Not;
 use std::sync::Arc;
 
 use arrow_array::{Array, ArrayRef, Int64Array, StringArray, StructArray};
 use futures::{StreamExt, TryStreamExt};
+use hashbrown::HashMap;
 use tokio::sync::oneshot::{Receiver, channel};
 
 use super::delete_filter::{DeleteFilter, PosDelLoadAction};
@@ -385,10 +386,7 @@ impl CachingDeleteFileLoader {
                     ));
                 };
 
-                result
-                    .entry(file_path.to_string())
-                    .or_default()
-                    .insert(pos as u64);
+                result.entry_ref(file_path).or_default().insert(pos as u64);
             }
         }
 

--- a/crates/iceberg/src/arrow/record_batch_partition_splitter.rs
+++ b/crates/iceberg/src/arrow/record_batch_partition_splitter.rs
@@ -15,11 +15,11 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use std::collections::HashMap;
 use std::sync::Arc;
 
 use arrow_array::{ArrayRef, BooleanArray, RecordBatch, StructArray};
 use arrow_select::filter::filter_record_batch;
+use hashbrown::HashMap;
 
 use super::arrow_struct_to_literal;
 use super::partition_value_calculator::PartitionValueCalculator;
@@ -115,9 +115,8 @@ impl RecordBatchPartitionSplitter {
         Self::try_new(iceberg_schema, partition_spec, None)
     }
 
-    /// Split the record batch into multiple record batches based on the partition spec.
-    pub fn split(&self, batch: &RecordBatch) -> Result<Vec<(PartitionKey, RecordBatch)>> {
-        let partition_structs = if let Some(calculator) = &self.calculator {
+    fn compute_partition_structs(&self, batch: &RecordBatch) -> Result<Vec<crate::spec::Struct>> {
+        if let Some(calculator) = &self.calculator {
             // Compute partition values from source columns using calculator
             let partition_array = calculator.calculate(batch)?;
             let struct_array = arrow_struct_to_literal(&partition_array, &self.partition_type)?;
@@ -134,7 +133,7 @@ impl RecordBatchPartitionSplitter {
                         ))
                     }
                 })
-                .collect::<Result<Vec<_>>>()?
+                .collect::<Result<Vec<_>>>()
         } else {
             // Extract partition values from pre-computed partition column
             let partition_column = batch
@@ -173,17 +172,25 @@ impl RecordBatchPartitionSplitter {
                         ))
                     }
                 })
-                .collect::<Result<Vec<_>>>()?
-        };
+                .collect::<Result<Vec<_>>>()
+        }
+    }
+
+    /// Split the record batch into multiple record batches based on the partition spec.
+    ///
+    /// Returns tuples of `(partition_key, partition_batch, row_ids)` where `row_ids[i]` is the
+    /// index in the original input batch of row `i` in `partition_batch`.
+    pub fn split(
+        &self,
+        batch: &RecordBatch,
+    ) -> Result<Vec<(PartitionKey, RecordBatch, Vec<usize>)>> {
+        let partition_structs = self.compute_partition_structs(batch)?;
 
         // Group the batch by row value.
-        let mut group_ids = HashMap::new();
-        partition_structs
-            .iter()
-            .enumerate()
-            .for_each(|(row_id, row)| {
-                group_ids.entry(row.clone()).or_insert(vec![]).push(row_id);
-            });
+        let mut group_ids: HashMap<crate::spec::Struct, Vec<usize>> = HashMap::new();
+        for (row_id, row) in partition_structs.iter().enumerate() {
+            group_ids.entry_ref(row).or_default().push(row_id);
+        }
 
         // Partition the batch with same partition partition_values
         let mut partition_batches = Vec::with_capacity(group_ids.len());
@@ -191,9 +198,9 @@ impl RecordBatchPartitionSplitter {
             // generate the bool filter array from column_ids
             let filter_array: BooleanArray = {
                 let mut filter = vec![false; batch.num_rows()];
-                row_ids.into_iter().for_each(|row_id| {
+                for &row_id in &row_ids {
                     filter[row_id] = true;
-                });
+                }
                 filter.into()
             };
 
@@ -205,7 +212,11 @@ impl RecordBatchPartitionSplitter {
             );
 
             // filter the RecordBatch
-            partition_batches.push((partition_key, filter_record_batch(batch, &filter_array)?));
+            partition_batches.push((
+                partition_key,
+                filter_record_batch(batch, &filter_array)?,
+                row_ids,
+            ));
         }
 
         Ok(partition_batches)
@@ -214,6 +225,7 @@ impl RecordBatchPartitionSplitter {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
     use std::sync::Arc;
 
     use arrow_array::{Int32Array, RecordBatch, StringArray};
@@ -279,7 +291,7 @@ mod tests {
         let mut partitioned_batches = partition_splitter
             .split(&batch)
             .expect("Failed to split RecordBatch");
-        partitioned_batches.sort_by_key(|(partition_key, _)| {
+        partitioned_batches.sort_by_key(|(partition_key, _, _)| {
             if let PrimitiveLiteral::Int(i) = partition_key.data().fields()[0]
                 .as_ref()
                 .unwrap()
@@ -328,7 +340,7 @@ mod tests {
 
         let partition_values = partitioned_batches
             .iter()
-            .map(|(partition_key, _)| partition_key.data().clone())
+            .map(|(partition_key, _, _)| partition_key.data().clone())
             .collect::<Vec<_>>();
         // check partition value is struct(1), struct(2), struct(3)
         assert_eq!(partition_values, vec![
@@ -423,7 +435,7 @@ mod tests {
             .split(&batch)
             .expect("Failed to split RecordBatch");
 
-        partitioned_batches.sort_by_key(|(partition_key, _)| {
+        partitioned_batches.sort_by_key(|(partition_key, _, _)| {
             if let PrimitiveLiteral::Int(i) = partition_key.data().fields()[0]
                 .as_ref()
                 .unwrap()
@@ -457,24 +469,27 @@ mod tests {
         };
 
         // Verify partition 1: id=1, names=["a", "c", "g"]
-        let (key, batch) = &partitioned_batches[0];
+        let (key, batch, row_ids) = &partitioned_batches[0];
         assert_eq!(key.data(), &Struct::from_iter(vec![Some(Literal::int(1))]));
         let (ids, names) = extract_values(batch);
         assert_eq!(ids, vec![1, 1, 1]);
         assert_eq!(names, vec!["a", "c", "g"]);
+        assert_eq!(row_ids, &vec![0, 2, 6]);
 
         // Verify partition 2: id=2, names=["b", "e"]
-        let (key, batch) = &partitioned_batches[1];
+        let (key, batch, row_ids) = &partitioned_batches[1];
         assert_eq!(key.data(), &Struct::from_iter(vec![Some(Literal::int(2))]));
         let (ids, names) = extract_values(batch);
         assert_eq!(ids, vec![2, 2]);
         assert_eq!(names, vec!["b", "e"]);
+        assert_eq!(row_ids, &vec![1, 4]);
 
         // Verify partition 3: id=3, names=["d", "f"]
-        let (key, batch) = &partitioned_batches[2];
+        let (key, batch, row_ids) = &partitioned_batches[2];
         assert_eq!(key.data(), &Struct::from_iter(vec![Some(Literal::int(3))]));
         let (ids, names) = extract_values(batch);
         assert_eq!(ids, vec![3, 3]);
         assert_eq!(names, vec!["d", "f"]);
+        assert_eq!(row_ids, &vec![3, 5]);
     }
 }

--- a/crates/iceberg/src/delete_file_index.rs
+++ b/crates/iceberg/src/delete_file_index.rs
@@ -15,12 +15,12 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use std::collections::HashMap;
 use std::ops::Deref;
 use std::sync::{Arc, RwLock};
 
 use futures::StreamExt;
 use futures::channel::mpsc::{Sender, channel};
+use hashbrown::HashMap;
 use tokio::sync::Notify;
 
 use crate::runtime::spawn;
@@ -173,7 +173,7 @@ impl PopulatedDeleteFileIndex {
             };
 
             destination_map
-                .entry(partition.clone())
+                .entry_ref(partition)
                 .and_modify(|entry: &mut Vec<DeleteFileContextAndTask>| {
                     entry.push((arc_ctx.clone(), file_scan_task.clone()));
                 })
@@ -265,6 +265,8 @@ impl PopulatedDeleteFileIndex {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
+
     use futures::SinkExt;
     use uuid::Uuid;
 

--- a/crates/iceberg/src/writer/base_writer/data_file_writer.rs
+++ b/crates/iceberg/src/writer/base_writer/data_file_writer.rs
@@ -23,7 +23,7 @@ use crate::spec::{DataContentType, DataFile, PartitionKey};
 use crate::writer::file_writer::FileWriterBuilder;
 use crate::writer::file_writer::location_generator::{FileNameGenerator, LocationGenerator};
 use crate::writer::file_writer::rolling_writer::{RollingFileWriter, RollingFileWriterBuilder};
-use crate::writer::{CurrentFileStatus, IcebergWriter, IcebergWriterBuilder};
+use crate::writer::{CurrentFileStatus, IcebergWriter, IcebergWriterBuilder, PositionDeleteInput};
 use crate::{Error, ErrorKind, Result};
 
 /// Builder for `DataFileWriter`.
@@ -90,6 +90,22 @@ where
     async fn write(&mut self, batch: RecordBatch) -> Result<()> {
         if let Some(writer) = self.inner.as_mut() {
             writer.write(&self.partition_key, &batch).await
+        } else {
+            Err(Error::new(
+                ErrorKind::Unexpected,
+                "Writer is not initialized!",
+            ))
+        }
+    }
+
+    async fn write_with_position(
+        &mut self,
+        batch: RecordBatch,
+    ) -> Result<Vec<PositionDeleteInput>> {
+        if let Some(writer) = self.inner.as_mut() {
+            writer
+                .write_with_position(&self.partition_key, &batch)
+                .await
         } else {
             Err(Error::new(
                 ErrorKind::Unexpected,

--- a/crates/iceberg/src/writer/base_writer/deletion_vector_writer.rs
+++ b/crates/iceberg/src/writer/base_writer/deletion_vector_writer.rs
@@ -17,7 +17,9 @@
 
 //! Deletion vector writer for Iceberg V3.
 
-use std::collections::HashMap;
+use std::collections::HashMap as StdHashMap;
+
+use hashbrown::HashMap;
 
 use crate::delete_vector::{
     DELETION_VECTOR_PROPERTY_CARDINALITY, DELETION_VECTOR_PROPERTY_REFERENCED_DATA_FILE,
@@ -94,10 +96,7 @@ where
                     "deletion vector position must be non-negative".to_string(),
                 )
             })?;
-            let entry = self
-                .delete_vectors
-                .entry(delete.path.as_ref().to_string())
-                .or_default();
+            let entry = self.delete_vectors.entry_ref(&*delete.path).or_default();
             entry.insert(pos);
         }
         Ok(())
@@ -121,10 +120,10 @@ where
                 .location_generator
                 .generate_location(partition_key, &file_name);
             let output_file = self.file_io.new_output(&location)?;
-            let mut writer = PuffinWriter::new(&output_file, HashMap::new(), false).await?;
+            let mut writer = PuffinWriter::new(&output_file, StdHashMap::new(), false).await?;
 
             let cardinality = delete_vector.len();
-            let properties = HashMap::from([
+            let properties = StdHashMap::from([
                 (
                     DELETION_VECTOR_PROPERTY_CARDINALITY.to_string(),
                     cardinality.to_string(),

--- a/crates/iceberg/src/writer/file_writer/rolling_writer.rs
+++ b/crates/iceberg/src/writer/file_writer/rolling_writer.rs
@@ -16,6 +16,7 @@
 // under the License.
 
 use std::fmt::{Debug, Formatter};
+use std::sync::Arc;
 
 use arrow_array::RecordBatch;
 use futures::future::{self, BoxFuture};
@@ -23,9 +24,9 @@ use futures::future::{self, BoxFuture};
 use crate::io::{FileIO, OutputFile};
 use crate::runtime::{JoinHandle, spawn};
 use crate::spec::{DataFileBuilder, PartitionKey, TableProperties};
-use crate::writer::CurrentFileStatus;
 use crate::writer::file_writer::location_generator::{FileNameGenerator, LocationGenerator};
 use crate::writer::file_writer::{FileWriter, FileWriterBuilder};
+use crate::writer::{CurrentFileStatus, PositionDeleteInput};
 use crate::{Error, ErrorKind, Result};
 
 type CloseFuture = BoxFuture<'static, Result<Vec<DataFileBuilder>>>;
@@ -209,27 +210,11 @@ where
         Ok(())
     }
 
-    /// Writes a record batch to the current file, rolling over to a new file if necessary.
-    ///
-    /// # Parameters
-    ///
-    /// * `partition_key` - Optional partition key for the data
-    /// * `input` - The record batch to write
-    ///
-    /// # Returns
-    ///
-    /// A `Result` indicating success or failure
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if the writer is not initialized or if writing fails
-    pub async fn write(
+    async fn ensure_partition_writer(
         &mut self,
         partition_key: &Option<PartitionKey>,
-        input: &RecordBatch,
-    ) -> Result<()> {
+    ) -> Result<&mut B::R> {
         if self.inner.is_none() {
-            // initialize inner writer
             self.inner = Some(
                 self.inner_builder
                     .build(self.new_output_file(partition_key)?)
@@ -260,15 +245,77 @@ where
             }
         }
 
-        // write the input
-        if let Some(writer) = self.inner.as_mut() {
-            Ok(writer.write(input).await?)
-        } else {
-            Err(Error::new(
+        let writer = self
+            .inner
+            .as_mut()
+            .ok_or_else(|| Error::new(ErrorKind::Unexpected, "Writer is not initialized!"))?;
+        Ok(writer)
+    }
+
+    /// Writes a record batch to the current file, rolling over to a new file if necessary.
+    ///
+    /// # Parameters
+    ///
+    /// * `partition_key` - Optional partition key for the data
+    /// * `input` - The record batch to write
+    ///
+    /// # Returns
+    ///
+    /// A `Result` indicating success or failure
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the writer is not initialized or if writing fails
+    pub async fn write(
+        &mut self,
+        partition_key: &Option<PartitionKey>,
+        input: &RecordBatch,
+    ) -> Result<()> {
+        let writer = self.ensure_partition_writer(partition_key).await?;
+        writer.write(input).await
+    }
+
+    /// Writes a record batch and returns the `(file_path, pos)` position for each record.
+    ///
+    /// # Parameters
+    ///
+    /// * `partition_key` - Optional partition key for the data
+    /// * `input` - The record batch to write
+    ///
+    /// # Returns
+    ///
+    /// A `Result` containing a vector of `PositionDeleteInput` with the file path and position for each record
+    ///
+    /// # Errors
+    ///
+    /// Returns an error for the following cases:
+    /// - If the writer is not initialized
+    /// - If writing fails
+    /// - If the position exceeds `i64::MAX`, which would cause overflow in position deletes
+    pub async fn write_with_position(
+        &mut self,
+        partition_key: &Option<PartitionKey>,
+        input: &RecordBatch,
+    ) -> Result<Vec<PositionDeleteInput>> {
+        let writer = self.ensure_partition_writer(partition_key).await?;
+
+        let num_rows = input.num_rows();
+        let file_path: Arc<str> = Arc::from(writer.current_file_path());
+        let start_pos = writer.current_row_num();
+        if start_pos.saturating_add(num_rows) > i64::MAX as usize {
+            return Err(Error::new(
                 ErrorKind::Unexpected,
-                "Writer is not initialized!",
-            ))
+                "position overflow: file has more than 2^63 - 1 rows",
+            ));
         }
+
+        writer.write(input).await?;
+
+        // Generate position delete inputs for the entire batch
+        let positions = (0..num_rows)
+            .map(|i| PositionDeleteInput::new(file_path.clone(), (start_pos + i) as i64))
+            .collect();
+        Ok(positions)
     }
 
     /// Closes the writer and returns all data file builders.

--- a/crates/iceberg/src/writer/mod.rs
+++ b/crates/iceberg/src/writer/mod.rs
@@ -394,13 +394,16 @@ use arrow_array::RecordBatch;
 
 use crate::Result;
 use crate::spec::{DataFile, PartitionKey};
+pub use crate::writer::base_writer::position_delete_file_writer::PositionDeleteInput;
 
 type DefaultInput = RecordBatch;
 type DefaultOutput = Vec<DataFile>;
 
 /// The builder for iceberg writer.
 #[async_trait::async_trait]
-pub trait IcebergWriterBuilder<I = DefaultInput, O = DefaultOutput>: Send + Sync + 'static {
+pub trait IcebergWriterBuilder<I = DefaultInput, O = DefaultOutput>: Send + Sync + 'static
+where I: Send + 'static
+{
     /// The associated writer type.
     type R: IcebergWriter<I, O>;
     /// Build the iceberg writer with an optional partition key.
@@ -409,9 +412,20 @@ pub trait IcebergWriterBuilder<I = DefaultInput, O = DefaultOutput>: Send + Sync
 
 /// The iceberg writer used to write data to iceberg table.
 #[async_trait::async_trait]
-pub trait IcebergWriter<I = DefaultInput, O = DefaultOutput>: Send + 'static {
+pub trait IcebergWriter<I = DefaultInput, O = DefaultOutput>: Send + 'static
+where I: Send + 'static
+{
     /// Write data to iceberg table.
     async fn write(&mut self, input: I) -> Result<()>;
+
+    /// Write data to iceberg table and return position information for each record.
+    async fn write_with_position(&mut self, _input: I) -> Result<Vec<PositionDeleteInput>> {
+        Err(crate::Error::new(
+            crate::ErrorKind::Unexpected,
+            "write_with_position is not supported for this writer",
+        ))
+    }
+
     /// Close the writer and return the written data files.
     /// If close failed, the data written before maybe be lost. User may need to recreate the writer and rewrite the data again.
     /// # NOTE

--- a/crates/iceberg/src/writer/partitioning/clustered_writer.rs
+++ b/crates/iceberg/src/writer/partitioning/clustered_writer.rs
@@ -24,7 +24,9 @@ use async_trait::async_trait;
 
 use crate::spec::{PartitionKey, Struct};
 use crate::writer::partitioning::PartitioningWriter;
-use crate::writer::{DefaultInput, DefaultOutput, IcebergWriter, IcebergWriterBuilder};
+use crate::writer::{
+    DefaultInput, DefaultOutput, IcebergWriter, IcebergWriterBuilder, PositionDeleteInput,
+};
 use crate::{Error, ErrorKind, Result};
 
 /// A writer that writes data to a single partition at a time.
@@ -40,6 +42,7 @@ use crate::{Error, ErrorKind, Result};
 pub struct ClusteredWriter<B, I = DefaultInput, O = DefaultOutput>
 where
     B: IcebergWriterBuilder<I, O>,
+    I: Send + 'static,
     O: IntoIterator + FromIterator<<O as IntoIterator>::Item>,
     <O as IntoIterator>::Item: Clone,
 {
@@ -70,6 +73,40 @@ where
         }
     }
 
+    /// Switch to a writer for the given `partition_key`, reusing the current one if the
+    /// partition matches, creating a new one otherwise. Rejects out-of-order writes to
+    /// partitions that have already been closed.
+    async fn ensure_partition_writer(&mut self, partition_key: &PartitionKey) -> Result<()> {
+        let partition_value = partition_key.data();
+
+        if self.closed_partitions.contains(partition_value) {
+            return Err(Error::new(
+                ErrorKind::Unexpected,
+                format!(
+                    "The input is not sorted! Cannot write to partition that was previously closed: {partition_key:?}"
+                ),
+            ));
+        }
+
+        let need_new_writer = match &self.current_partition {
+            Some(current) => current != partition_value,
+            None => true,
+        };
+
+        if need_new_writer {
+            self.close_current_writer().await?;
+
+            self.current_writer = Some(
+                self.inner_builder
+                    .build(Some(partition_key.clone()))
+                    .await?,
+            );
+            self.current_partition = Some(partition_value.clone());
+        }
+
+        Ok(())
+    }
+
     /// Closes the current writer if it exists, flushes the written data to output, and record closed partition.
     async fn close_current_writer(&mut self) -> Result<()> {
         if let Some(mut writer) = self.current_writer.take() {
@@ -94,41 +131,26 @@ where
     <O as IntoIterator>::Item: Send + Clone,
 {
     async fn write(&mut self, partition_key: PartitionKey, input: I) -> Result<()> {
-        let partition_value = partition_key.data();
+        self.ensure_partition_writer(&partition_key).await?;
 
-        // Check if this partition has been closed already
-        if self.closed_partitions.contains(partition_value) {
-            return Err(Error::new(
-                ErrorKind::Unexpected,
-                format!(
-                    "The input is not sorted! Cannot write to partition that was previously closed: {partition_key:?}"
-                ),
-            ));
-        }
-
-        // Check if we need to switch to a new partition
-        let need_new_writer = match &self.current_partition {
-            Some(current) => current != partition_value,
-            None => true,
-        };
-
-        if need_new_writer {
-            self.close_current_writer().await?;
-
-            // Create a new writer for the new partition
-            self.current_writer = Some(
-                self.inner_builder
-                    .build(Some(partition_key.clone()))
-                    .await?,
-            );
-            self.current_partition = Some(partition_value.clone());
-        }
-
-        // do write
         self.current_writer
             .as_mut()
             .expect("Writer should be initialized")
             .write(input)
+            .await
+    }
+
+    async fn write_with_position(
+        &mut self,
+        partition_key: PartitionKey,
+        input: I,
+    ) -> Result<Vec<PositionDeleteInput>> {
+        self.ensure_partition_writer(&partition_key).await?;
+
+        self.current_writer
+            .as_mut()
+            .expect("Writer should be initialized")
+            .write_with_position(input)
             .await
     }
 

--- a/crates/iceberg/src/writer/partitioning/fanout_writer.rs
+++ b/crates/iceberg/src/writer/partitioning/fanout_writer.rs
@@ -24,7 +24,9 @@ use async_trait::async_trait;
 
 use crate::spec::{PartitionKey, Struct};
 use crate::writer::partitioning::PartitioningWriter;
-use crate::writer::{DefaultInput, DefaultOutput, IcebergWriter, IcebergWriterBuilder};
+use crate::writer::{
+    DefaultInput, DefaultOutput, IcebergWriter, IcebergWriterBuilder, PositionDeleteInput,
+};
 use crate::{Error, ErrorKind, Result};
 
 /// A writer that can write data to multiple partitions simultaneously.
@@ -42,6 +44,7 @@ use crate::{Error, ErrorKind, Result};
 pub struct FanoutWriter<B, I = DefaultInput, O = DefaultOutput>
 where
     B: IcebergWriterBuilder<I, O>,
+    I: Send + 'static,
     O: IntoIterator + FromIterator<<O as IntoIterator>::Item>,
     <O as IntoIterator>::Item: Clone,
 {
@@ -101,6 +104,15 @@ where
     async fn write(&mut self, partition_key: PartitionKey, input: I) -> Result<()> {
         let writer = self.get_or_create_writer(&partition_key).await?;
         writer.write(input).await
+    }
+
+    async fn write_with_position(
+        &mut self,
+        partition_key: PartitionKey,
+        input: I,
+    ) -> Result<Vec<PositionDeleteInput>> {
+        let writer = self.get_or_create_writer(&partition_key).await?;
+        writer.write_with_position(input).await
     }
 
     async fn close(mut self) -> Result<O> {

--- a/crates/iceberg/src/writer/partitioning/mod.rs
+++ b/crates/iceberg/src/writer/partitioning/mod.rs
@@ -27,14 +27,16 @@ pub mod unpartitioned_writer;
 
 use crate::Result;
 use crate::spec::PartitionKey;
-use crate::writer::{DefaultInput, DefaultOutput};
+use crate::writer::{DefaultInput, DefaultOutput, PositionDeleteInput};
 
 /// A writer that can write data to partitioned tables.
 ///
 /// This trait provides methods for writing data with partition keys and
 /// closing the writer to retrieve the output.
 #[async_trait::async_trait]
-pub trait PartitioningWriter<I = DefaultInput, O = DefaultOutput>: Send + 'static {
+pub trait PartitioningWriter<I = DefaultInput, O = DefaultOutput>: Send + 'static
+where I: Send + 'static
+{
     /// Write data with a partition key.
     ///
     /// # Parameters
@@ -46,6 +48,13 @@ pub trait PartitioningWriter<I = DefaultInput, O = DefaultOutput>: Send + 'stati
     ///
     /// `Ok(())` on success, or an error if the write operation fails.
     async fn write(&mut self, partition_key: PartitionKey, input: I) -> Result<()>;
+
+    /// Write data with a partition key and return position information for each record.
+    async fn write_with_position(
+        &mut self,
+        partition_key: PartitionKey,
+        input: I,
+    ) -> Result<Vec<PositionDeleteInput>>;
 
     /// Close the writer and return the output.
     ///

--- a/crates/iceberg/src/writer/partitioning/unpartitioned_writer.rs
+++ b/crates/iceberg/src/writer/partitioning/unpartitioned_writer.rs
@@ -20,7 +20,9 @@
 use std::marker::PhantomData;
 
 use crate::Result;
-use crate::writer::{DefaultInput, DefaultOutput, IcebergWriter, IcebergWriterBuilder};
+use crate::writer::{
+    DefaultInput, DefaultOutput, IcebergWriter, IcebergWriterBuilder, PositionDeleteInput,
+};
 
 /// A simple wrapper around `IcebergWriterBuilder` for unpartitioned tables.
 ///
@@ -35,6 +37,7 @@ use crate::writer::{DefaultInput, DefaultOutput, IcebergWriter, IcebergWriterBui
 pub struct UnpartitionedWriter<B, I = DefaultInput, O = DefaultOutput>
 where
     B: IcebergWriterBuilder<I, O>,
+    I: Send + 'static,
     O: IntoIterator + FromIterator<<O as IntoIterator>::Item>,
     <O as IntoIterator>::Item: Clone,
 {
@@ -83,6 +86,21 @@ where
             .as_mut()
             .expect("Writer should be initialized")
             .write(input)
+            .await
+    }
+
+    /// Write data to the writer and return position information for each record.
+    ///
+    /// See [`IcebergWriter::write_with_position`] for details.
+    pub async fn write_with_position(&mut self, input: I) -> Result<Vec<PositionDeleteInput>> {
+        if self.writer.is_none() {
+            self.writer = Some(self.inner_builder.build(None).await?);
+        }
+
+        self.writer
+            .as_mut()
+            .expect("Writer should be initialized")
+            .write_with_position(input)
             .await
     }
 

--- a/crates/iceberg/src/writer/task_writer.rs
+++ b/crates/iceberg/src/writer/task_writer.rs
@@ -62,7 +62,7 @@ use crate::writer::partitioning::PartitioningWriter;
 use crate::writer::partitioning::clustered_writer::ClusteredWriter;
 use crate::writer::partitioning::fanout_writer::FanoutWriter;
 use crate::writer::partitioning::unpartitioned_writer::UnpartitionedWriter;
-use crate::writer::{IcebergWriter, IcebergWriterBuilder};
+use crate::writer::{IcebergWriter, IcebergWriterBuilder, PositionDeleteInput};
 
 /// High-level writer that handles partitioning and routing of `RecordBatch` data to Iceberg tables.
 pub struct TaskWriter<B: IcebergWriterBuilder> {
@@ -152,30 +152,91 @@ impl<B: IcebergWriterBuilder> TaskWriter<B> {
         match writer {
             SupportedWriter::Unpartitioned(writer) => writer.write(batch).await,
             SupportedWriter::Fanout(writer) => {
-                if self.partition_splitter.is_none() {
-                    self.partition_splitter = Some(
-                        RecordBatchPartitionSplitter::try_new_with_precomputed_values(
-                            self.schema.clone(),
-                            self.partition_spec.clone(),
-                        )?,
-                    );
-                }
+                Self::ensure_partition_splitter(
+                    &mut self.partition_splitter,
+                    &self.schema,
+                    &self.partition_spec,
+                )?;
 
                 Self::write_partitioned_batches(writer, &self.partition_splitter, &batch).await
             }
             SupportedWriter::Clustered(writer) => {
-                if self.partition_splitter.is_none() {
-                    self.partition_splitter = Some(
-                        RecordBatchPartitionSplitter::try_new_with_precomputed_values(
-                            self.schema.clone(),
-                            self.partition_spec.clone(),
-                        )?,
-                    );
-                }
+                Self::ensure_partition_splitter(
+                    &mut self.partition_splitter,
+                    &self.schema,
+                    &self.partition_spec,
+                )?;
 
                 Self::write_partitioned_batches(writer, &self.partition_splitter, &batch).await
             }
         }
+    }
+
+    /// Write a `RecordBatch` to the `TaskWriter` and return the `(file_path, pos)` for each
+    /// input row.
+    ///
+    /// The returned [`PositionArray`] has the same length as `batch.num_rows()`, with entry `i`
+    /// describing where row `i` of the input was written. For partitioned tables, the input
+    /// is first split by partition; the positions for each partition are then gathered back
+    /// into the original input row order.
+    pub async fn write_with_position(
+        &mut self,
+        batch: RecordBatch,
+    ) -> Result<Vec<PositionDeleteInput>> {
+        let writer = self.writer.as_mut().ok_or_else(|| {
+            crate::Error::new(
+                crate::ErrorKind::Unexpected,
+                "TaskWriter has been closed and cannot be used",
+            )
+        })?;
+
+        match writer {
+            SupportedWriter::Unpartitioned(writer) => writer.write_with_position(batch).await,
+            SupportedWriter::Fanout(writer) => {
+                Self::ensure_partition_splitter(
+                    &mut self.partition_splitter,
+                    &self.schema,
+                    &self.partition_spec,
+                )?;
+
+                Self::write_partitioned_batches_with_position(
+                    writer,
+                    &self.partition_splitter,
+                    &batch,
+                )
+                .await
+            }
+            SupportedWriter::Clustered(writer) => {
+                Self::ensure_partition_splitter(
+                    &mut self.partition_splitter,
+                    &self.schema,
+                    &self.partition_spec,
+                )?;
+
+                Self::write_partitioned_batches_with_position(
+                    writer,
+                    &self.partition_splitter,
+                    &batch,
+                )
+                .await
+            }
+        }
+    }
+
+    fn ensure_partition_splitter(
+        splitter: &mut Option<RecordBatchPartitionSplitter>,
+        schema: &SchemaRef,
+        partition_spec: &PartitionSpecRef,
+    ) -> Result<()> {
+        if splitter.is_none() {
+            *splitter = Some(
+                RecordBatchPartitionSplitter::try_new_with_precomputed_values(
+                    schema.clone(),
+                    partition_spec.clone(),
+                )?,
+            );
+        }
+        Ok(())
     }
 
     /// Close the `TaskWriter` and return all written data files.
@@ -204,11 +265,57 @@ impl<B: IcebergWriterBuilder> TaskWriter<B> {
             .expect("partition splitter must be initialised before use");
         let partitioned_batches = splitter.split(batch)?;
 
-        for (partition_key, partition_batch) in partitioned_batches {
+        for (partition_key, partition_batch, _) in partitioned_batches {
             writer.write(partition_key, partition_batch).await?;
         }
 
         Ok(())
+    }
+
+    async fn write_partitioned_batches_with_position<W: PartitioningWriter>(
+        writer: &mut W,
+        partition_splitter: &Option<RecordBatchPartitionSplitter>,
+        batch: &RecordBatch,
+    ) -> Result<Vec<PositionDeleteInput>> {
+        let splitter = partition_splitter
+            .as_ref()
+            .expect("partition splitter must be initialised before use");
+        let partitioned_batches = splitter.split(batch)?;
+
+        let num_rows = batch.num_rows();
+
+        // Fast path: the batch fell into a single partition, so the inner writer's output positions
+        // are already in the correct order and can be returned directly without additional shuffling
+        if partitioned_batches.len() == 1 {
+            let [(partition_key, partition_batch, _)] = partitioned_batches.try_into().unwrap();
+            let positions = writer
+                .write_with_position(partition_key, partition_batch)
+                .await?;
+            return Ok(positions);
+        }
+
+        let mut builder: Vec<Option<PositionDeleteInput>> = vec![None; num_rows];
+        for (partition_key, partition_batch, row_ids) in partitioned_batches {
+            let positions_for_partition = writer
+                .write_with_position(partition_key, partition_batch)
+                .await?;
+            for (row_id, position) in row_ids.into_iter().zip(positions_for_partition) {
+                builder[row_id] = Some(position);
+            }
+        }
+        let positions = builder
+            .into_iter()
+            .enumerate()
+            .map(|(i, pos)| {
+                pos.ok_or_else(|| {
+                    crate::Error::new(
+                        crate::ErrorKind::Unexpected,
+                        format!("missing position for input row {i}"),
+                    )
+                })
+            })
+            .collect::<Result<Vec<PositionDeleteInput>>>()?;
+        Ok(positions)
     }
 }
 
@@ -216,6 +323,13 @@ impl<B: IcebergWriterBuilder> TaskWriter<B> {
 impl<B: IcebergWriterBuilder> IcebergWriter for TaskWriter<B> {
     async fn write(&mut self, input: RecordBatch) -> Result<()> {
         self.write(input).await
+    }
+
+    async fn write_with_position(
+        &mut self,
+        input: RecordBatch,
+    ) -> Result<Vec<PositionDeleteInput>> {
+        self.write_with_position(input).await
     }
 
     async fn close(&mut self) -> Result<Vec<DataFile>> {
@@ -481,6 +595,100 @@ mod tests {
         let partition_counts = verify_partition_files(&data_files, 4);
         assert_eq!(partition_counts.get("US"), Some(&2));
         assert_eq!(partition_counts.get("EU"), Some(&2));
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_task_writer_write_with_position_unpartitioned() -> Result<()> {
+        let temp_dir = TempDir::new()?;
+        let schema = create_test_schema()?;
+        let arrow_schema = create_arrow_schema();
+
+        let partition_spec = Arc::new(PartitionSpec::builder(schema.clone()).build()?);
+
+        let writer_builder = create_writer_builder(&temp_dir, schema.clone())?;
+        let mut task_writer = TaskWriter::new(writer_builder, false, schema, partition_spec);
+
+        let batch = RecordBatch::try_new(arrow_schema, vec![
+            Arc::new(Int32Array::from(vec![1, 2, 3])) as ArrayRef,
+            Arc::new(StringArray::from(vec!["Alice", "Bob", "Charlie"])) as ArrayRef,
+            Arc::new(StringArray::from(vec!["US", "EU", "US"])) as ArrayRef,
+        ])?;
+
+        let positions = task_writer.write_with_position(batch).await?;
+        let data_files = task_writer.close().await?;
+
+        assert_eq!(positions.len(), 3);
+        assert!(!data_files.is_empty());
+
+        let file_path = data_files[0].file_path();
+        for (i, pos) in positions.iter().enumerate() {
+            assert_eq!(&*pos.path, file_path);
+            assert_eq!(pos.pos, i as i64);
+        }
+
+        let files: Vec<&str> = data_files.iter().map(|f| f.file_path()).collect();
+        assert!(files.contains(&file_path));
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_task_writer_write_with_position_partitioned_fanout() -> Result<()> {
+        let temp_dir = TempDir::new()?;
+        let schema = create_test_schema()?;
+        let arrow_schema = create_arrow_schema_with_partition();
+
+        let partition_spec = Arc::new(
+            PartitionSpec::builder(schema.clone())
+                .with_spec_id(1)
+                .add_partition_field("region", "region", crate::spec::Transform::Identity)?
+                .build()?,
+        );
+
+        let writer_builder = create_writer_builder(&temp_dir, schema.clone())?;
+        let mut task_writer = TaskWriter::new(writer_builder, true, schema, partition_spec);
+
+        let partition_field = Field::new("region", DataType::Utf8, false).with_metadata(
+            HashMap::from([(PARQUET_FIELD_ID_META_KEY.to_string(), "1000".to_string())]),
+        );
+        let partition_values = StringArray::from(vec!["US", "EU", "US", "EU"]);
+        let partition_struct = StructArray::from(vec![(
+            Arc::new(partition_field),
+            Arc::new(partition_values) as ArrayRef,
+        )]);
+
+        let batch = RecordBatch::try_new(arrow_schema, vec![
+            Arc::new(Int32Array::from(vec![1, 2, 3, 4])) as ArrayRef,
+            Arc::new(StringArray::from(vec!["Alice", "Bob", "Charlie", "Dave"])) as ArrayRef,
+            Arc::new(StringArray::from(vec!["US", "EU", "US", "EU"])) as ArrayRef,
+            Arc::new(partition_struct) as ArrayRef,
+        ])?;
+
+        let positions = task_writer.write_with_position(batch).await?;
+        let data_files = task_writer.close().await?;
+
+        assert_eq!(positions.len(), 4, "one position per input row");
+
+        // Rows 0 and 2 go to US, rows 1 and 3 go to EU. Within each partition,
+        // positions must be contiguous starting at 0.
+        let path_us = &*positions[0].path;
+        let path_eu = &*positions[1].path;
+
+        assert_ne!(path_us, path_eu, "US and EU should land in different files");
+        assert_eq!(&*positions[2].path, path_us);
+        assert_eq!(&*positions[3].path, path_eu);
+
+        assert_eq!(positions[0].pos, 0);
+        assert_eq!(positions[1].pos, 0);
+        assert_eq!(positions[2].pos, 1);
+        assert_eq!(positions[3].pos, 1);
+
+        let file_paths: std::collections::HashSet<&str> =
+            data_files.iter().map(|f| f.file_path()).collect();
+        assert!(file_paths.contains(path_us));
+        assert!(file_paths.contains(path_eu));
 
         Ok(())
     }

--- a/crates/iceberg/src/writer/task_writer.rs
+++ b/crates/iceberg/src/writer/task_writer.rs
@@ -505,7 +505,7 @@ mod tests {
                 _ => panic!("expected string partition value"),
             };
 
-            *partition_counts.entry(region.clone()).or_insert(0) += data_file.record_count();
+            *partition_counts.entry(region).or_insert(0) += data_file.record_count();
 
             assert!(
                 data_file.file_path().contains("region="),

--- a/crates/integrations/datafusion/src/task_writer.rs
+++ b/crates/integrations/datafusion/src/task_writer.rs
@@ -417,7 +417,7 @@ mod tests {
                 _ => panic!("Expected string partition value"),
             };
 
-            *partition_counts.entry(region.clone()).or_insert(0) += data_file.record_count();
+            *partition_counts.entry(region).or_insert(0) += data_file.record_count();
 
             // Verify file path contains partition information
             assert!(

--- a/crates/integrations/datafusion/src/task_writer.rs
+++ b/crates/integrations/datafusion/src/task_writer.rs
@@ -221,7 +221,7 @@ impl<B: IcebergWriterBuilder> TaskWriter<B> {
         let partitioned_batches = splitter.split(batch)?;
 
         // Write each partition
-        for (partition_key, partition_batch) in partitioned_batches {
+        for (partition_key, partition_batch, _) in partitioned_batches {
             writer.write(partition_key, partition_batch).await?;
         }
 


### PR DESCRIPTION
## What changes are included in this PR?

Replaces `std::collections::HashMap` with `hashbrown::HashMap` in several performance-sensitive paths to reduce unnecessary heap allocations caused by string cloning when inserting entries.

Specifically:
- In `caching_delete_file_loader.rs` and `delete_file_index.rs`, `entry_ref` is used instead of `entry` to avoid cloning string keys on lookup.
- In `deletion_vector_writer.rs`, `hashbrown::HashMap` is adopted for the delete vectors map, using `entry_ref` to avoid allocating owned strings for path keys.

## Are these changes tested?

These are targeted optimizations with no behavioral changes. Existing unit and integration tests cover the affected code paths.