### PR TITLE
fix(transaction): correct previous-snapshot lookup for summary rollup

### DIFF
--- a/crates/iceberg/src/transaction/append.rs
+++ b/crates/iceberg/src/transaction/append.rs
@@ -613,4 +613,136 @@ mod tests {
                 if r#ref == branch_name)
         ));
     }
+
+    /// Regression test: when a table already has a snapshot on `main` with
+    /// cumulative totals set in its summary, the totals on the newly produced
+    /// snapshot must be rolled forward (`previous_total + added`), not recomputed
+    /// from zero.
+    ///
+    /// Before the fix, `SnapshotProducer::summary` looked up the previous
+    /// snapshot via `snapshot_by_id(self.snapshot_id)` — i.e. the new snapshot
+    /// that is not yet in `table_metadata` — so the lookup returned `None` and
+    /// `update_totals` fell back to `previous_total = 0`. That caused the new
+    /// snapshot to report only the files/records from the current commit,
+    /// losing everything already in the table. This test fails on the buggy
+    /// code path (`total-records = 10`, `total-data-files = 1`) and passes
+    /// with the fix (`total-records = 110`, `total-data-files = 6`).
+    #[tokio::test]
+    async fn test_fast_append_rolls_previous_totals_forward() {
+        use std::sync::Arc;
+
+        use crate::spec::{
+            ManifestListWriter, Operation, Snapshot, SnapshotReference, SnapshotRetention, Summary,
+        };
+
+        // Spec-stable summary keys — kept inline because the equivalent
+        // constants in `spec::snapshot_summary` are private.
+        const TOTAL_DATA_FILES_KEY: &str = "total-data-files";
+        const TOTAL_RECORDS_KEY: &str = "total-records";
+
+        // Build a V2 table whose current snapshot on `main` already reports
+        // 5 data files / 100 records. The summary totals are what the rollup
+        // must carry forward.
+        let base = make_v2_minimal_table();
+
+        const PARENT_SNAPSHOT_ID: i64 = 42;
+        const PARENT_TOTAL_DATA_FILES: u64 = 5;
+        const PARENT_TOTAL_RECORDS: u64 = 100;
+        const PARENT_MANIFEST_LIST: &str = "memory:///snap-parent-manifest-list.avro";
+
+        // FastAppend reads the parent snapshot's manifest list during commit
+        // (to carry forward existing manifests), so we must stage a real file
+        // at the path we reference on the parent snapshot. An empty V2
+        // manifest list is sufficient — the commit just needs it to deserialize.
+        let parent_manifest_list_writer = ManifestListWriter::v2(
+            base.file_io().new_output(PARENT_MANIFEST_LIST).unwrap(),
+            PARENT_SNAPSHOT_ID,
+            None,
+            1,
+        );
+        parent_manifest_list_writer.close().await.unwrap();
+
+        let parent_summary = Summary {
+            operation: Operation::Append,
+            additional_properties: HashMap::from([
+                (
+                    TOTAL_DATA_FILES_KEY.to_string(),
+                    PARENT_TOTAL_DATA_FILES.to_string(),
+                ),
+                (
+                    TOTAL_RECORDS_KEY.to_string(),
+                    PARENT_TOTAL_RECORDS.to_string(),
+                ),
+            ]),
+        };
+
+        let parent_snapshot = Snapshot::builder()
+            .with_snapshot_id(PARENT_SNAPSHOT_ID)
+            .with_timestamp_ms(base.metadata().last_updated_ms() + 1)
+            .with_sequence_number(1)
+            .with_schema_id(0)
+            .with_manifest_list(PARENT_MANIFEST_LIST)
+            .with_summary(parent_summary)
+            .build();
+
+        let metadata_with_parent = base
+            .metadata()
+            .clone()
+            .into_builder(Some("s3://bucket/test/location/metadata/v1.json".into()))
+            .add_snapshot(parent_snapshot)
+            .unwrap()
+            .set_ref(MAIN_BRANCH, SnapshotReference {
+                snapshot_id: PARENT_SNAPSHOT_ID,
+                retention: SnapshotRetention::Branch {
+                    min_snapshots_to_keep: None,
+                    max_snapshot_age_ms: None,
+                    max_ref_age_ms: None,
+                },
+            })
+            .unwrap()
+            .build()
+            .unwrap()
+            .metadata;
+        let table = base.with_metadata(Arc::new(metadata_with_parent));
+
+        // Append 1 new data file with 10 records.
+        const ADDED_RECORDS: u64 = 10;
+        let data_file = DataFileBuilder::default()
+            .partition_spec_id(table.metadata().default_partition_spec_id())
+            .content(DataContentType::Data)
+            .file_path("test/new.parquet".to_string())
+            .file_format(DataFileFormat::Parquet)
+            .file_size_in_bytes(100)
+            .record_count(ADDED_RECORDS)
+            .partition(Struct::from_iter([Some(Literal::long(300))]))
+            .build()
+            .unwrap();
+
+        let tx = Transaction::new(&table);
+        let action = tx.fast_append().add_data_files(vec![data_file]);
+        let mut action_commit = Arc::new(action).commit(&table).await.unwrap();
+        let updates = action_commit.take_updates();
+
+        let new_snapshot = match &updates[0] {
+            TableUpdate::AddSnapshot { snapshot } => snapshot,
+            _ => unreachable!("first update must be AddSnapshot"),
+        };
+
+        let props = &new_snapshot.summary().additional_properties;
+        let total_records: u64 = props.get(TOTAL_RECORDS_KEY).unwrap().parse().unwrap();
+        let total_data_files: u64 = props.get(TOTAL_DATA_FILES_KEY).unwrap().parse().unwrap();
+
+        // The key assertion: totals are rolled forward from the parent, not
+        // reset. On the buggy path these would be 10 and 1.
+        assert_eq!(
+            total_records,
+            PARENT_TOTAL_RECORDS + ADDED_RECORDS,
+            "total-records must roll forward (previous={PARENT_TOTAL_RECORDS} + added={ADDED_RECORDS})",
+        );
+        assert_eq!(
+            total_data_files,
+            PARENT_TOTAL_DATA_FILES + 1,
+            "total-data-files must roll forward (previous={PARENT_TOTAL_DATA_FILES} + added=1)",
+        );
+    }
 }

--- a/crates/iceberg/src/transaction/snapshot.rs
+++ b/crates/iceberg/src/transaction/snapshot.rs
@@ -651,10 +651,14 @@ partition_struct: {:?}, partition_type: {:?}",
             );
         }
 
-        let previous_snapshot = table_metadata
-            .snapshot_by_id(self.snapshot_id)
-            .and_then(|snapshot| snapshot.parent_snapshot_id())
-            .and_then(|parent_id| table_metadata.snapshot_by_id(parent_id));
+        // The previous snapshot for summary rollup is the current tip of the
+        // target branch — which is exactly what `commit()` below uses as the
+        // parent for the new snapshot. The earlier implementation looked up
+        // `self.snapshot_id` (the *new* snapshot that is not yet in
+        // `table_metadata`), causing the lookup to return `None` and the
+        // `total-*` fields to be recomputed from scratch (`previous_total = 0`)
+        // instead of rolled forward.
+        let previous_snapshot = table_metadata.snapshot_for_ref(&self.target_branch);
 
         let mut additional_properties = summary_collector.build();
         additional_properties.extend(self.snapshot_properties.clone());


### PR DESCRIPTION
## What changes are included in this PR?

Fixes the previous-snapshot lookup in SnapshotProducer::summary so that cumulative total-* fields in the new snapshot's summary are rolled forward instead of recomputed from zero.
Root cause. summary() resolved the previous snapshot via table_metadata.snapshot_by_id(self.snapshot_id), but self.snapshot_id is the new snapshot ID being created by this transaction — it does not yet exist in table_metadata. The lookup therefore always returned None, and None was propagated into update_snapshot_summaries as previous_summary. update_totals then fell back to previous_total = 0 and recomputed every cumulative field from scratch:
total-records          = 0 + added_records  - removed_records
total-data-files       = 0 + added_files    - removed_files
total-delete-files     = 0 + added_delete   - removed_delete
total-position-deletes = 0 + added_pos      - removed_pos
total-equality-deletes = 0 + added_eq       - removed_eq

For any snapshot past the first, this produced totals reflecting only the current commit rather than the full post-commit table state. REPLACE operations (compaction RewriteFiles, RewriteManifestsAction) and FastAppend past the first snapshot were most visibly affected: a compaction that replaced 2 of 4 files reported total-data-files = 2 / total-records = <sum of the 2 new files> in the new snapshot summary, while scans via the manifest list correctly observed all 4 files.
Impact. Table data and scan planning are unaffected — readers walk the manifest list rather than trusting the summary. Consumers that rely on the snapshot summary for accounting (dashboards, cost/size reporting, change-data tracking) observe incorrect values.

Fix. The correct previous snapshot is the current tip of the target branch, which is exactly what the companion commit() call selects ~40 lines later to write as parent_snapshot_id on the manifest list. Resolve it the same way in summary() via table_metadata.snapshot_for_ref(&self.target_branch) so both code paths agree on which snapshot is the parent, and the rollup advances the totals rather than resetting them.

## Are these changes tested?

Added test_fast_append_rolls_previous_totals_forward to crates/iceberg/src/transaction/append.rs (+132 lines).
What it proves:
- On buggy code: fails with total-records: left=10, right=110 — exactly the regression signature.
- With the fix: passes (total-records=110, total-data-files=6).