### PR TITLE
fix: Update the object_cache to accurately assess memory of objects

### DIFF
--- a/crates/iceberg/src/io/object_cache.rs
+++ b/crates/iceberg/src/io/object_cache.rs
@@ -15,16 +15,25 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use std::mem::size_of_val;
+use std::collections::HashMap;
+use std::mem::size_of;
 use std::sync::Arc;
 
 use crate::io::FileIO;
 use crate::spec::{
-    FormatVersion, Manifest, ManifestFile, ManifestList, SchemaId, SnapshotRef, TableMetadataRef,
+    DataFile, FieldSummary, FormatVersion, Manifest, ManifestEntry, ManifestFile, ManifestList,
+    SchemaId, SnapshotRef, TableMetadataRef,
 };
 use crate::{Error, ErrorKind, Result};
 
 const DEFAULT_CACHE_SIZE_BYTES: u64 = 32 * 1024 * 1024; // 32MB
+
+/// Hashbrown group width used for control byte padding in the bucket array.
+/// SSE2 uses 16; this is the common default on x86_64.
+const HASHMAP_GROUP_WIDTH: usize = 16;
+
+/// Overhead for an `Arc` heap allocation: strong count + weak count (2 × usize).
+const ARC_INNER_OVERHEAD: usize = size_of::<usize>() * 2;
 
 #[derive(Clone, Debug)]
 pub(crate) enum CachedItem {
@@ -36,6 +45,147 @@ pub(crate) enum CachedItem {
 pub(crate) enum CachedObjectKey {
     ManifestList((String, FormatVersion, SchemaId)),
     Manifest(String),
+}
+
+// ---------------------------------------------------------------------------
+// Heap size estimation helpers
+// ---------------------------------------------------------------------------
+//
+// These functions estimate the actual heap memory consumed by cached objects.
+// (as opposed to `size_of_val()`, which only returns the shallow struct size
+// (~100–200 bytes) regardless of heap allocations).
+//
+// See: https://github.com/apache/iceberg-rust/issues/1720
+
+/// Estimates the heap allocation of a [`HashMap<K, V>`].
+///
+/// Hashbrown (backing `std::collections::HashMap`) allocates:
+///   `[ctrl bytes: capacity + GROUP_WIDTH] [slots: capacity × size_of::<(K, V)>()]`
+fn estimated_hashmap_heap<K, V>(map: &HashMap<K, V>) -> usize {
+    let cap = map.capacity();
+    if cap == 0 {
+        return 0;
+    }
+    let ctrl_bytes = cap + HASHMAP_GROUP_WIDTH;
+    let slot_bytes = cap * size_of::<(K, V)>();
+    ctrl_bytes + slot_bytes
+}
+
+/// Estimates total memory for a cached [`ManifestList`], including the struct
+/// itself and all heap allocations within its [`ManifestFile`] entries.
+fn estimated_manifest_list_size(list: &ManifestList) -> usize {
+    let entries = list.entries();
+    let mut size = size_of::<ManifestList>();
+
+    // Vec<ManifestFile> heap: one ManifestFile inline per entry.
+    // We use len() as an approximation for capacity (we only have a slice).
+    size += std::mem::size_of_val(entries);
+
+    // Per-entry string and vec heap allocations
+    for entry in entries {
+        size += estimated_manifest_file_heap(entry);
+    }
+
+    size
+}
+
+/// Estimates heap allocations within a single [`ManifestFile`] beyond its
+/// inline struct size (already counted by the parent Vec allocation).
+fn estimated_manifest_file_heap(file: &ManifestFile) -> usize {
+    let mut size = 0;
+
+    // String: manifest_path
+    size += file.manifest_path.capacity();
+
+    // Option<Vec<FieldSummary>>: partitions
+    if let Some(ref partitions) = file.partitions {
+        size += partitions.len() * size_of::<FieldSummary>();
+        for summary in partitions {
+            if let Some(ref lb) = summary.lower_bound {
+                size += lb.len();
+            }
+            if let Some(ref ub) = summary.upper_bound {
+                size += ub.len();
+            }
+        }
+    }
+
+    // Option<Vec<u8>>: key_metadata
+    if let Some(ref metadata) = file.key_metadata {
+        size += metadata.capacity();
+    }
+
+    size
+}
+
+/// Estimates total memory for a cached [`Manifest`], including the struct,
+/// `Arc` overhead per entry, and all heap allocations within each [`DataFile`].
+///
+/// Note: Skips `Arc<Schema>` in [`ManifestMetadata`] because schemas are
+/// shared across manifests (also held by `TableMetadata`). Schema size is
+/// constant per table and does not scale with file count.
+fn estimated_manifest_size(manifest: &Manifest) -> usize {
+    let entries = manifest.entries();
+    let mut size = size_of::<Manifest>();
+
+    // Vec<Arc<ManifestEntry>>: one Arc pointer per entry
+    size += std::mem::size_of_val(entries);
+
+    for entry in entries {
+        // Each Arc points to a heap allocation: ArcInner overhead + ManifestEntry
+        size += ARC_INNER_OVERHEAD + size_of::<ManifestEntry>();
+        // Heap allocations within the DataFile
+        size += estimated_data_file_heap(&entry.data_file);
+    }
+
+    size
+}
+
+/// Estimates heap allocations within a single [`DataFile`].
+///
+/// This is where most of the memory lives: six `HashMap`s of per-column
+/// statistics that scale with the number of columns in the table schema.
+fn estimated_data_file_heap(df: &DataFile) -> usize {
+    let mut size = 0;
+
+    // String: file_path
+    size += df.file_path.capacity();
+
+    // Struct (partition values): Vec<Option<Literal>> heap
+    size += std::mem::size_of_val(df.partition.fields());
+
+    // 4× HashMap<i32, u64>
+    size += estimated_hashmap_heap(&df.column_sizes);
+    size += estimated_hashmap_heap(&df.value_counts);
+    size += estimated_hashmap_heap(&df.null_value_counts);
+    size += estimated_hashmap_heap(&df.nan_value_counts);
+
+    // 2× HashMap<i32, Datum>: uses flat per-Datum estimate (does not traverse
+    // into String/Binary Datum variants for heap beyond the inline enum size).
+    size += estimated_hashmap_heap(&df.lower_bounds);
+    size += estimated_hashmap_heap(&df.upper_bounds);
+
+    // Option<Vec<u8>>: key_metadata
+    if let Some(ref km) = df.key_metadata {
+        size += km.capacity();
+    }
+
+    // Option<Vec<i64>>: split_offsets
+    if let Some(ref so) = df.split_offsets {
+        size += so.capacity() * size_of::<i64>();
+    }
+
+    // Option<Vec<i32>>: equality_ids
+    if let Some(ref ei) = df.equality_ids {
+        size += ei.capacity() * size_of::<i32>();
+    }
+
+    // Option<String>: referenced_data_file
+    if let Some(ref rdf) = df.referenced_data_file {
+        size += rdf.capacity();
+    }
+
+    size
 }
 
 /// Caches metadata objects deserialized from immutable files
@@ -61,10 +211,14 @@ impl ObjectCache {
         } else {
             Self {
                 cache: moka::future::Cache::builder()
-                    .weigher(|_, val: &CachedItem| match val {
-                        CachedItem::ManifestList(item) => size_of_val(item.as_ref()),
-                        CachedItem::Manifest(item) => size_of_val(item.as_ref()),
-                    } as u32)
+                    .weigher(|_, val: &CachedItem| {
+                        let size = match val {
+                            CachedItem::ManifestList(item) => estimated_manifest_list_size(item),
+                            CachedItem::Manifest(item) => estimated_manifest_size(item),
+                        };
+                        // moka weigher returns u32; clamp to u32::MAX (~4 GiB) for safety
+                        size.min(u32::MAX as usize) as u32
+                    })
                     .max_capacity(cache_size_bytes)
                     .build(),
                 file_io,
@@ -515,5 +669,159 @@ mod tests {
 
         assert!(result.is_ok());
         assert_eq!(result.unwrap().entries().len(), 1);
+    }
+
+    #[test]
+    fn test_estimated_data_file_heap_scales_with_columns() {
+        use std::collections::HashMap;
+
+        use crate::spec::Datum;
+
+        let make_data_file = |num_columns: i32| -> DataFile {
+            let mut column_sizes = HashMap::new();
+            let mut value_counts = HashMap::new();
+            let mut null_value_counts = HashMap::new();
+            let mut nan_value_counts = HashMap::new();
+            let mut lower_bounds = HashMap::new();
+            let mut upper_bounds = HashMap::new();
+
+            for col_id in 0..num_columns {
+                column_sizes.insert(col_id, 1024);
+                value_counts.insert(col_id, 1000);
+                null_value_counts.insert(col_id, 5);
+                nan_value_counts.insert(col_id, 0);
+                lower_bounds.insert(col_id, Datum::long(0));
+                upper_bounds.insert(col_id, Datum::long(i64::MAX));
+            }
+
+            DataFileBuilder::default()
+                .content(DataContentType::Data)
+                .file_path("s3://bucket/table/data/file_0001.parquet".to_string())
+                .file_format(DataFileFormat::Parquet)
+                .file_size_in_bytes(100 * 1024 * 1024)
+                .record_count(1_000_000)
+                .partition(Struct::empty())
+                .partition_spec_id(0)
+                .column_sizes(column_sizes)
+                .value_counts(value_counts)
+                .null_value_counts(null_value_counts)
+                .nan_value_counts(nan_value_counts)
+                .lower_bounds(lower_bounds)
+                .upper_bounds(upper_bounds)
+                .build()
+                .unwrap()
+        };
+
+        let df_20_cols = make_data_file(20);
+        let df_50_cols = make_data_file(50);
+
+        let heap_20 = estimated_data_file_heap(&df_20_cols);
+        let heap_50 = estimated_data_file_heap(&df_50_cols);
+
+        // The estimate must be far larger than the shallow struct size, which
+        // is what the old broken weigher returned.
+        let shallow = std::mem::size_of_val(&df_20_cols);
+        assert!(
+            heap_20 > shallow * 3,
+            "20-col estimate ({heap_20}) should be much larger than shallow size ({shallow})"
+        );
+
+        // More columns → larger estimate (roughly proportional).
+        assert!(
+            heap_50 > heap_20,
+            "50-col estimate ({heap_50}) should exceed 20-col estimate ({heap_20})"
+        );
+
+        // Sanity: 20 columns × 6 HashMaps × ~20 entries × ~15–50 bytes/bucket > 1500 bytes.
+        assert!(
+            heap_20 > 1500,
+            "20-col estimate ({heap_20}) should be at least 1500 bytes"
+        );
+    }
+
+    #[test]
+    fn test_estimated_manifest_file_heap_accounts_for_string_and_partitions() {
+        use serde_bytes::ByteBuf;
+
+        use crate::spec::ManifestContentType;
+
+        let file = ManifestFile {
+            manifest_path:
+                "s3://my-very-long-bucket-name/warehouse/db/table/metadata/manifest_abc123.avro"
+                    .to_string(),
+            manifest_length: 4096,
+            partition_spec_id: 0,
+            content: ManifestContentType::Data,
+            sequence_number: 1,
+            min_sequence_number: 1,
+            added_snapshot_id: 100,
+            added_files_count: Some(10),
+            existing_files_count: Some(0),
+            deleted_files_count: Some(0),
+            added_rows_count: Some(1000),
+            existing_rows_count: Some(0),
+            deleted_rows_count: Some(0),
+            partitions: Some(vec![
+                FieldSummary {
+                    contains_null: false,
+                    contains_nan: None,
+                    lower_bound: Some(ByteBuf::from(vec![0u8; 8])),
+                    upper_bound: Some(ByteBuf::from(vec![0xFF; 8])),
+                },
+                FieldSummary {
+                    contains_null: true,
+                    contains_nan: Some(false),
+                    lower_bound: Some(ByteBuf::from(vec![0u8; 16])),
+                    upper_bound: Some(ByteBuf::from(vec![0xFF; 16])),
+                },
+            ]),
+            key_metadata: None,
+            first_row_id: None,
+        };
+
+        let heap = estimated_manifest_file_heap(&file);
+
+        // Should at least include the manifest_path capacity
+        assert!(
+            heap >= file.manifest_path.len(),
+            "heap estimate ({heap}) should include manifest_path length ({})",
+            file.manifest_path.len()
+        );
+
+        // Should include partition field summary bounds: 2 summaries × (8 + 8) + (16 + 16) = 48 bytes
+        assert!(
+            heap > file.manifest_path.len() + 40,
+            "heap estimate ({heap}) should include FieldSummary bound data"
+        );
+    }
+
+    #[test]
+    fn test_estimated_data_file_heap_empty_stats() {
+        // A DataFile with no column stats should still account for the file_path
+        let df = DataFileBuilder::default()
+            .content(DataContentType::Data)
+            .file_path("s3://bucket/file.parquet".to_string())
+            .file_format(DataFileFormat::Parquet)
+            .file_size_in_bytes(1024)
+            .record_count(10)
+            .partition(Struct::empty())
+            .partition_spec_id(0)
+            .build()
+            .unwrap();
+
+        let heap = estimated_data_file_heap(&df);
+
+        // At minimum, the file_path string capacity
+        assert!(
+            heap >= "s3://bucket/file.parquet".len(),
+            "heap estimate ({heap}) should include file_path"
+        );
+
+        // With no column stats, the HashMaps should be empty → 0 HashMap heap
+        // So the estimate should be relatively small
+        assert!(
+            heap < 500,
+            "empty-stats DataFile heap ({heap}) should be small"
+        );
     }
 }


### PR DESCRIPTION
## Problem

The object_cache uses moka for its cache. It stores Manifests and ManifestLists. It currently only checks the size of the values on the stack, where these datastructures point to potentially large amounts of data on the heap. This means the cache does not correctly enforce it's limit (default of 32MB). For example, an iceberg table with +100K data files can lead to large ManifestLists held in memory. The DataFiles also maintain 6 hashmaps containing column stats. If the table has a large nubmer of columns this can also increase the amount of data held on the heap.

## What changes are included in this PR?

This change adds weighing functions which traverse the datastructures to accurately estimate their size on the heap.

## Are these changes tested?

This change adds Unit Tests for the object cache.

I also tested on my local machine. I have been profiling memory, and found that this has a significant impact on reducing overall memory for tables with a high number of files and columns.
