### PR TITLE
fix: handle all Iceberg types when filling missing columns files after schema evolution

### DIFF
--- a/crates/iceberg/src/arrow/record_batch_transformer.rs
+++ b/crates/iceberg/src/arrow/record_batch_transformer.rs
@@ -674,8 +674,8 @@ mod test {
     use std::sync::Arc;
 
     use arrow_array::{
-        Array, Date32Array, Float32Array, Float64Array, Int32Array, Int64Array, RecordBatch,
-        StringArray,
+        Array, Date32Array, FixedSizeBinaryArray, Float32Array, Float64Array, Int32Array,
+        Int64Array, LargeBinaryArray, RecordBatch, StringArray, Time64MicrosecondArray,
     };
     use arrow_schema::{DataType, Field, Schema as ArrowSchema};
     use parquet::arrow::PARQUET_FIELD_ID_META_KEY;
@@ -2046,5 +2046,239 @@ mod test {
         // Must survive strict RecordBatch::try_new
         RecordBatch::try_new(result.schema(), result.columns().to_vec())
             .expect("result batch must pass strict schema validation");
+    }
+
+    /// Asserts that schema evolution correctly materializes a null-filled column when the
+    /// source Parquet file is missing the Binary column. Verifies it correctly handles the
+    /// conversion from Iceberg Binary to Arrow Binary.
+    ///
+    /// Before this was fixed, a schema evolution adding a binary column could results in
+    /// failures where the old parquet files could not be re-written due to
+    /// "Unexpected => unexpected target column type LargeBinary"
+    #[test]
+    fn schema_evolution_adds_binary_column_with_nulls() {
+        let snapshot_schema = Arc::new(
+            Schema::builder()
+                .with_schema_id(1)
+                .with_fields(vec![
+                    NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
+                    NestedField::optional(2, "name", Type::Primitive(PrimitiveType::String)).into(),
+                    NestedField::optional(3, "bin_col", Type::Primitive(PrimitiveType::Binary))
+                        .into(),
+                ])
+                .build()
+                .unwrap(),
+        );
+        let projected_iceberg_field_ids = [1, 2, 3];
+
+        let mut transformer =
+            RecordBatchTransformerBuilder::new(snapshot_schema, &projected_iceberg_field_ids)
+                .build();
+
+        let file_schema = Arc::new(ArrowSchema::new(vec![
+            simple_field("id", DataType::Int32, false, "1"),
+            simple_field("name", DataType::Utf8, true, "2"),
+        ]));
+
+        let file_batch = RecordBatch::try_new(file_schema, vec![
+            Arc::new(Int32Array::from(vec![1, 2, 3])),
+            Arc::new(StringArray::from(vec![
+                Some("Alice"),
+                Some("Bob"),
+                Some("Charlie"),
+            ])),
+        ])
+        .unwrap();
+
+        let result = transformer.process_record_batch(file_batch).unwrap();
+
+        assert_eq!(result.num_columns(), 3);
+        assert_eq!(result.num_rows(), 3);
+
+        let id_col = result
+            .column(0)
+            .as_any()
+            .downcast_ref::<Int32Array>()
+            .unwrap();
+        assert_eq!(id_col.values(), &[1, 2, 3]);
+
+        let name_col = result
+            .column(1)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        assert_eq!(name_col.value(0), "Alice");
+        assert_eq!(name_col.value(1), "Bob");
+        assert_eq!(name_col.value(2), "Charlie");
+
+        let bin_col = result
+            .column(2)
+            .as_any()
+            .downcast_ref::<LargeBinaryArray>()
+            .unwrap();
+        assert!(bin_col.is_null(0));
+        assert!(bin_col.is_null(1));
+        assert!(bin_col.is_null(2));
+    }
+
+    /// Asserts that schema evolution correctly materializes a null-filled column when the
+    /// source Parquet file is missing the Time column. Verifies it correctly handles the
+    /// conversion from Iceberg Time to Arrow Time64(Microsecond).
+    #[test]
+    fn schema_evolution_adds_time_column_with_nulls() {
+        let snapshot_schema = Arc::new(
+            Schema::builder()
+                .with_schema_id(1)
+                .with_fields(vec![
+                    NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
+                    NestedField::optional(2, "name", Type::Primitive(PrimitiveType::String)).into(),
+                    NestedField::optional(3, "time_col", Type::Primitive(PrimitiveType::Time))
+                        .into(),
+                ])
+                .build()
+                .unwrap(),
+        );
+        let projected_iceberg_field_ids = [1, 2, 3];
+
+        let mut transformer =
+            RecordBatchTransformerBuilder::new(snapshot_schema, &projected_iceberg_field_ids)
+                .build();
+
+        let file_schema = Arc::new(ArrowSchema::new(vec![
+            simple_field("id", DataType::Int32, false, "1"),
+            simple_field("name", DataType::Utf8, true, "2"),
+        ]));
+
+        let file_batch = RecordBatch::try_new(file_schema, vec![
+            Arc::new(Int32Array::from(vec![1, 2, 3])),
+            Arc::new(StringArray::from(vec![
+                Some("Alice"),
+                Some("Bob"),
+                Some("Charlie"),
+            ])),
+        ])
+        .unwrap();
+
+        let result = transformer.process_record_batch(file_batch).unwrap();
+
+        assert_eq!(result.num_columns(), 3);
+        assert_eq!(result.num_rows(), 3);
+
+        let time_col = result
+            .column(2)
+            .as_any()
+            .downcast_ref::<Time64MicrosecondArray>()
+            .unwrap();
+        assert!(time_col.is_null(0));
+        assert!(time_col.is_null(1));
+        assert!(time_col.is_null(2));
+    }
+
+    /// Asserts that schema evolution correctly materializes a null-filled column when the
+    /// source Parquet file is missing the Uuid column. Verifies it correctly handles the
+    /// conversion from Iceberg Uuid to Arrow FixedSizeBinary(16).
+    #[test]
+    fn schema_evolution_adds_uuid_column_with_nulls() {
+        let snapshot_schema = Arc::new(
+            Schema::builder()
+                .with_schema_id(1)
+                .with_fields(vec![
+                    NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
+                    NestedField::optional(2, "name", Type::Primitive(PrimitiveType::String)).into(),
+                    NestedField::optional(3, "uuid_col", Type::Primitive(PrimitiveType::Uuid))
+                        .into(),
+                ])
+                .build()
+                .unwrap(),
+        );
+        let projected_iceberg_field_ids = [1, 2, 3];
+
+        let mut transformer =
+            RecordBatchTransformerBuilder::new(snapshot_schema, &projected_iceberg_field_ids)
+                .build();
+
+        let file_schema = Arc::new(ArrowSchema::new(vec![
+            simple_field("id", DataType::Int32, false, "1"),
+            simple_field("name", DataType::Utf8, true, "2"),
+        ]));
+
+        let file_batch = RecordBatch::try_new(file_schema, vec![
+            Arc::new(Int32Array::from(vec![1, 2, 3])),
+            Arc::new(StringArray::from(vec![
+                Some("Alice"),
+                Some("Bob"),
+                Some("Charlie"),
+            ])),
+        ])
+        .unwrap();
+
+        let result = transformer.process_record_batch(file_batch).unwrap();
+
+        assert_eq!(result.num_columns(), 3);
+        assert_eq!(result.num_rows(), 3);
+
+        let uuid_col = result
+            .column(2)
+            .as_any()
+            .downcast_ref::<FixedSizeBinaryArray>()
+            .unwrap();
+        assert_eq!(uuid_col.data_type(), &DataType::FixedSizeBinary(16));
+        assert!(uuid_col.is_null(0));
+        assert!(uuid_col.is_null(1));
+        assert!(uuid_col.is_null(2));
+    }
+
+    /// Asserts that schema evolution correctly materializes a null-filled column when the
+    /// source Parquet file is missing the Fixed column. Verifies it correctly handles the
+    /// conversion from Iceberg Fixed(len) to Arrow FixedSizeBinary(len).
+    #[test]
+    fn schema_evolution_adds_fixed_column_with_nulls() {
+        let snapshot_schema = Arc::new(
+            Schema::builder()
+                .with_schema_id(1)
+                .with_fields(vec![
+                    NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
+                    NestedField::optional(2, "name", Type::Primitive(PrimitiveType::String)).into(),
+                    NestedField::optional(3, "fixed_col", Type::Primitive(PrimitiveType::Fixed(4)))
+                        .into(),
+                ])
+                .build()
+                .unwrap(),
+        );
+        let projected_iceberg_field_ids = [1, 2, 3];
+
+        let mut transformer =
+            RecordBatchTransformerBuilder::new(snapshot_schema, &projected_iceberg_field_ids)
+                .build();
+
+        let file_schema = Arc::new(ArrowSchema::new(vec![
+            simple_field("id", DataType::Int32, false, "1"),
+            simple_field("name", DataType::Utf8, true, "2"),
+        ]));
+
+        let file_batch = RecordBatch::try_new(file_schema, vec![
+            Arc::new(Int32Array::from(vec![1, 2, 3])),
+            Arc::new(StringArray::from(vec![
+                Some("Alice"),
+                Some("Bob"),
+                Some("Charlie"),
+            ])),
+        ])
+        .unwrap();
+
+        let result = transformer.process_record_batch(file_batch).unwrap();
+
+        assert_eq!(result.num_columns(), 3);
+        assert_eq!(result.num_rows(), 3);
+
+        let fixed_col = result
+            .column(2)
+            .as_any()
+            .downcast_ref::<FixedSizeBinaryArray>()
+            .unwrap();
+        assert_eq!(fixed_col.data_type(), &DataType::FixedSizeBinary(4));
+        assert!(fixed_col.is_null(0));
+        assert!(fixed_col.is_null(1));
+        assert!(fixed_col.is_null(2));
     }
 }

--- a/crates/iceberg/src/arrow/value.rs
+++ b/crates/iceberg/src/arrow/value.rs
@@ -695,6 +695,61 @@ pub(crate) fn create_primitive_array_single_element(
         (DataType::Binary, None) => Ok(Arc::new(BinaryArray::from_opt_vec(vec![
             Option::<&[u8]>::None,
         ]))),
+        (DataType::LargeBinary, Some(PrimitiveLiteral::Binary(v))) => Ok(Arc::new(
+            LargeBinaryArray::from_iter_values(std::iter::once(v.as_slice())),
+        )),
+        (DataType::LargeBinary, None) => Ok(Arc::new(LargeBinaryArray::from(vec![None::<&[u8]>]))),
+        (DataType::Time64(TimeUnit::Microsecond), Some(PrimitiveLiteral::Long(v))) => {
+            Ok(Arc::new(Time64MicrosecondArray::from(vec![*v])))
+        }
+        (DataType::Time64(TimeUnit::Microsecond), None) => {
+            Ok(Arc::new(Time64MicrosecondArray::from(vec![
+                Option::<i64>::None,
+            ])))
+        }
+        (DataType::FixedSizeBinary(len), Some(PrimitiveLiteral::Binary(v))) => {
+            if v.len() != *len as usize {
+                return Err(Error::new(
+                    ErrorKind::DataInvalid,
+                    format!(
+                        "Fixed size binary value length {} does not match expected length {}",
+                        v.len(),
+                        len
+                    ),
+                ));
+            }
+            Ok(Arc::new(
+                FixedSizeBinaryArray::try_from_iter(std::iter::once(v.as_slice())).map_err(
+                    |e| {
+                        Error::new(
+                            ErrorKind::Unexpected,
+                            "Failed to create FixedSizeBinaryArray",
+                        )
+                        .with_source(e)
+                    },
+                )?,
+            ))
+        }
+        (DataType::FixedSizeBinary(_len), Some(PrimitiveLiteral::UInt128(v))) => {
+            // Uuid: UInt128 → big-endian [u8; 16]
+            let bytes = v.to_be_bytes();
+            Ok(Arc::new(
+                FixedSizeBinaryArray::try_from_iter(std::iter::once(bytes.as_slice())).map_err(
+                    |e| {
+                        Error::new(
+                            ErrorKind::Unexpected,
+                            "Failed to create FixedSizeBinaryArray",
+                        )
+                        .with_source(e)
+                    },
+                )?,
+            ))
+        }
+        (DataType::FixedSizeBinary(len), None) => Ok(Arc::new(FixedSizeBinaryArray::new(
+            *len,
+            arrow_buffer::Buffer::from(vec![0u8; *len as usize]),
+            Some(arrow_buffer::NullBuffer::new_null(1)),
+        ))),
         (DataType::Decimal128(precision, scale), Some(PrimitiveLiteral::Int128(v))) => {
             let array = Decimal128Array::from(vec![{ *v }])
                 .with_precision_and_scale(*precision, *scale)
@@ -782,6 +837,36 @@ pub(crate) fn create_primitive_array_single_element(
                                 Arc::new(BinaryArray::from_opt_vec(vec![Option::<&[u8]>::None]))
                                     as ArrayRef,
                             )
+                        }
+                        DataType::LargeBinary => {
+                            Ok(
+                                Arc::new(LargeBinaryArray::from(vec![None::<&[u8]>])) as ArrayRef
+                            )
+                        }
+                        DataType::Time64(TimeUnit::Microsecond) => {
+                            Ok(Arc::new(Time64MicrosecondArray::from(vec![
+                                Option::<i64>::None,
+                            ])) as ArrayRef)
+                        }
+                        DataType::FixedSizeBinary(len) => {
+                            Ok(Arc::new(FixedSizeBinaryArray::new(
+                                *len,
+                                arrow_buffer::Buffer::from(vec![0u8; *len as usize]),
+                                Some(arrow_buffer::NullBuffer::new_null(1)),
+                            )) as ArrayRef)
+                        }
+                        DataType::Decimal128(precision, scale) => {
+                            let array = Decimal128Array::from(vec![Option::<i128>::None])
+                                .with_precision_and_scale(*precision, *scale)
+                                .map_err(|e| {
+                                    Error::new(
+                                        ErrorKind::DataInvalid,
+                                        format!(
+                                            "Failed to create Decimal128Array with precision {precision} and scale {scale}: {e}"
+                                        ),
+                                    )
+                                })?;
+                            Ok(Arc::new(array) as ArrayRef)
                         }
                         _ => Err(Error::new(
                             ErrorKind::Unexpected,
@@ -909,6 +994,66 @@ pub(crate) fn create_primitive_array_repeated(
             let vals: Vec<Option<&[u8]>> = vec![None; num_rows];
             Arc::new(BinaryArray::from_opt_vec(vals))
         }
+        (DataType::LargeBinary, Some(PrimitiveLiteral::Binary(value))) => {
+            Arc::new(LargeBinaryArray::from_iter_values(
+                std::iter::repeat_n(value.as_slice(), num_rows),
+            ))
+        }
+        (DataType::LargeBinary, None) => {
+            Arc::new(LargeBinaryArray::from(vec![None::<&[u8]>; num_rows]))
+        }
+        (DataType::Time64(TimeUnit::Microsecond), Some(PrimitiveLiteral::Long(value))) => {
+            Arc::new(Time64MicrosecondArray::from(vec![*value; num_rows]))
+        }
+        (DataType::Time64(TimeUnit::Microsecond), None) => {
+            let vals: Vec<Option<i64>> = vec![None; num_rows];
+            Arc::new(Time64MicrosecondArray::from(vals))
+        }
+        (DataType::FixedSizeBinary(len), Some(PrimitiveLiteral::Binary(value))) => {
+            if value.len() != *len as usize {
+                return Err(Error::new(
+                    ErrorKind::DataInvalid,
+                    format!(
+                        "Fixed size binary value length {} does not match expected length {}",
+                        value.len(),
+                        len
+                    ),
+                ));
+            }
+            Arc::new(
+                FixedSizeBinaryArray::try_from_iter(
+                    std::iter::repeat_n(value.as_slice(), num_rows),
+                )
+                .map_err(|e| {
+                    Error::new(
+                        ErrorKind::Unexpected,
+                        "Failed to create FixedSizeBinaryArray",
+                    )
+                    .with_source(e)
+                })?,
+            )
+        }
+        (DataType::FixedSizeBinary(_len), Some(PrimitiveLiteral::UInt128(value))) => {
+            // Uuid: UInt128 → big-endian [u8; 16]
+            let bytes = value.to_be_bytes();
+            Arc::new(
+                FixedSizeBinaryArray::try_from_iter(
+                    std::iter::repeat_n(bytes.as_slice(), num_rows),
+                )
+                .map_err(|e| {
+                    Error::new(
+                        ErrorKind::Unexpected,
+                        "Failed to create FixedSizeBinaryArray",
+                    )
+                    .with_source(e)
+                })?,
+            )
+        }
+        (DataType::FixedSizeBinary(len), None) => Arc::new(FixedSizeBinaryArray::new(
+            *len,
+            arrow_buffer::Buffer::from(vec![0u8; *len as usize * num_rows]),
+            Some(arrow_buffer::NullBuffer::new_null(num_rows)),
+        )),
         (DataType::Decimal128(precision, scale), Some(PrimitiveLiteral::Int128(value))) => {
             Arc::new(
                 Decimal128Array::from(vec![*value; num_rows])

--- a/crates/iceberg/src/arrow/value.rs
+++ b/crates/iceberg/src/arrow/value.rs
@@ -982,9 +982,9 @@ mod test {
 
     use arrow_array::builder::{Int32Builder, ListBuilder, MapBuilder, StructBuilder};
     use arrow_array::{
-        ArrayRef, BinaryArray, BooleanArray, Date32Array, Decimal128Array, Float32Array,
-        Float64Array, Int32Array, Int64Array, StringArray, StructArray, Time64MicrosecondArray,
-        TimestampMicrosecondArray, TimestampNanosecondArray,
+        ArrayRef, BinaryArray, BooleanArray, Date32Array, Decimal128Array, FixedSizeBinaryArray,
+        Float32Array, Float64Array, Int32Array, Int64Array, LargeBinaryArray, StringArray,
+        StructArray, Time64MicrosecondArray, TimestampMicrosecondArray, TimestampNanosecondArray,
     };
     use arrow_schema::{DataType, Field, Fields, TimeUnit};
     use parquet::arrow::PARQUET_FIELD_ID_META_KEY;
@@ -1894,5 +1894,260 @@ mod test {
 
         assert_eq!(array.data_type(), &target_type);
         assert_eq!(array.len(), num_rows);
+    }
+
+    #[test]
+    fn test_create_primitive_array_repeated_large_binary() {
+        let value = PrimitiveLiteral::Binary(vec![1, 2, 3]);
+        let num_rows = 3;
+        let array = create_primitive_array_repeated(&DataType::LargeBinary, &Some(value), num_rows)
+            .expect("LargeBinary with value should succeed");
+
+        assert_eq!(array.data_type(), &DataType::LargeBinary);
+        assert_eq!(array.len(), num_rows);
+        let typed = array
+            .as_any()
+            .downcast_ref::<LargeBinaryArray>()
+            .expect("should downcast to LargeBinaryArray");
+        for i in 0..num_rows {
+            assert!(!typed.is_null(i));
+            assert_eq!(typed.value(i), &[1, 2, 3]);
+        }
+    }
+
+    #[test]
+    fn test_create_primitive_array_repeated_large_binary_null() {
+        let num_rows = 3;
+        let array = create_primitive_array_repeated(&DataType::LargeBinary, &None, num_rows)
+            .expect("LargeBinary with null should succeed");
+
+        assert_eq!(array.data_type(), &DataType::LargeBinary);
+        assert_eq!(array.len(), num_rows);
+        for i in 0..num_rows {
+            assert!(array.is_null(i));
+        }
+    }
+
+    #[test]
+    fn test_create_primitive_array_repeated_time64() {
+        // 36_000_000_000 microseconds = 10:00:00
+        let value = PrimitiveLiteral::Long(36_000_000_000);
+        let num_rows = 3;
+        let array = create_primitive_array_repeated(
+            &DataType::Time64(TimeUnit::Microsecond),
+            &Some(value),
+            num_rows,
+        )
+        .expect("Time64(Microsecond) with value should succeed");
+
+        assert_eq!(array.data_type(), &DataType::Time64(TimeUnit::Microsecond));
+        assert_eq!(array.len(), num_rows);
+        let typed = array
+            .as_any()
+            .downcast_ref::<Time64MicrosecondArray>()
+            .expect("should downcast to Time64MicrosecondArray");
+        for i in 0..num_rows {
+            assert!(!typed.is_null(i));
+            assert_eq!(typed.value(i), 36_000_000_000);
+        }
+    }
+
+    #[test]
+    fn test_create_primitive_array_repeated_time64_null() {
+        let num_rows = 3;
+        let array = create_primitive_array_repeated(
+            &DataType::Time64(TimeUnit::Microsecond),
+            &None,
+            num_rows,
+        )
+        .expect("Time64(Microsecond) with null should succeed");
+
+        assert_eq!(array.data_type(), &DataType::Time64(TimeUnit::Microsecond));
+        assert_eq!(array.len(), num_rows);
+        for i in 0..num_rows {
+            assert!(array.is_null(i));
+        }
+    }
+
+    #[test]
+    fn test_create_primitive_array_repeated_fixed_size_binary() {
+        let value = PrimitiveLiteral::Binary(vec![0xCA, 0xFE, 0xBA, 0xBE]);
+        let num_rows = 3;
+        let array =
+            create_primitive_array_repeated(&DataType::FixedSizeBinary(4), &Some(value), num_rows)
+                .expect("FixedSizeBinary(4) with value should succeed");
+
+        assert_eq!(array.data_type(), &DataType::FixedSizeBinary(4));
+        assert_eq!(array.len(), num_rows);
+        let typed = array
+            .as_any()
+            .downcast_ref::<FixedSizeBinaryArray>()
+            .expect("should downcast to FixedSizeBinaryArray");
+        for i in 0..num_rows {
+            assert!(!typed.is_null(i));
+            assert_eq!(typed.value(i), &[0xCA, 0xFE, 0xBA, 0xBE]);
+        }
+    }
+
+    #[test]
+    fn test_create_primitive_array_repeated_fixed_size_binary_null() {
+        let num_rows = 3;
+        let array = create_primitive_array_repeated(&DataType::FixedSizeBinary(4), &None, num_rows)
+            .expect("FixedSizeBinary(4) with null should succeed");
+
+        assert_eq!(array.data_type(), &DataType::FixedSizeBinary(4));
+        assert_eq!(array.len(), num_rows);
+        for i in 0..num_rows {
+            assert!(array.is_null(i));
+        }
+    }
+
+    #[test]
+    fn test_create_primitive_array_repeated_uuid() {
+        let uuid_val: u128 = 0x550e8400_e29b_41d4_a716_446655440000;
+        let value = PrimitiveLiteral::UInt128(uuid_val);
+        let num_rows = 3;
+        let array =
+            create_primitive_array_repeated(&DataType::FixedSizeBinary(16), &Some(value), num_rows)
+                .expect("FixedSizeBinary(16) with UUID should succeed");
+
+        assert_eq!(array.data_type(), &DataType::FixedSizeBinary(16));
+        assert_eq!(array.len(), num_rows);
+        let typed = array
+            .as_any()
+            .downcast_ref::<FixedSizeBinaryArray>()
+            .expect("should downcast to FixedSizeBinaryArray");
+        let expected_bytes = uuid_val.to_be_bytes();
+        for i in 0..num_rows {
+            assert!(!typed.is_null(i));
+            assert_eq!(typed.value(i), expected_bytes);
+        }
+    }
+
+    #[test]
+    fn test_create_primitive_array_repeated_uuid_null() {
+        let num_rows = 3;
+        let array =
+            create_primitive_array_repeated(&DataType::FixedSizeBinary(16), &None, num_rows)
+                .expect("FixedSizeBinary(16) with null should succeed");
+
+        assert_eq!(array.data_type(), &DataType::FixedSizeBinary(16));
+        assert_eq!(array.len(), num_rows);
+        for i in 0..num_rows {
+            assert!(array.is_null(i));
+        }
+    }
+
+    // ---- Tier 1: create_primitive_array_single_element — missing Arrow type coverage ----
+
+    #[test]
+    fn test_create_primitive_array_single_element_large_binary() {
+        let value = PrimitiveLiteral::Binary(vec![1, 2, 3]);
+        let array = create_primitive_array_single_element(&DataType::LargeBinary, &Some(value))
+            .expect("LargeBinary single element with value should succeed");
+
+        assert_eq!(array.data_type(), &DataType::LargeBinary);
+        assert_eq!(array.len(), 1);
+        let typed = array
+            .as_any()
+            .downcast_ref::<LargeBinaryArray>()
+            .expect("should downcast to LargeBinaryArray");
+        assert!(!typed.is_null(0));
+        assert_eq!(typed.value(0), &[1, 2, 3]);
+    }
+
+    #[test]
+    fn test_create_primitive_array_single_element_large_binary_null() {
+        let array = create_primitive_array_single_element(&DataType::LargeBinary, &None)
+            .expect("LargeBinary single element with null should succeed");
+
+        assert_eq!(array.data_type(), &DataType::LargeBinary);
+        assert_eq!(array.len(), 1);
+        assert!(array.is_null(0));
+    }
+
+    #[test]
+    fn test_create_primitive_array_single_element_time64() {
+        let value = PrimitiveLiteral::Long(36_000_000_000);
+        let array = create_primitive_array_single_element(
+            &DataType::Time64(TimeUnit::Microsecond),
+            &Some(value),
+        )
+        .expect("Time64 single element with value should succeed");
+
+        assert_eq!(array.data_type(), &DataType::Time64(TimeUnit::Microsecond));
+        assert_eq!(array.len(), 1);
+        let typed = array
+            .as_any()
+            .downcast_ref::<Time64MicrosecondArray>()
+            .expect("should downcast to Time64MicrosecondArray");
+        assert!(!typed.is_null(0));
+        assert_eq!(typed.value(0), 36_000_000_000);
+    }
+
+    #[test]
+    fn test_create_primitive_array_single_element_time64_null() {
+        let array =
+            create_primitive_array_single_element(&DataType::Time64(TimeUnit::Microsecond), &None)
+                .expect("Time64 single element with null should succeed");
+
+        assert_eq!(array.data_type(), &DataType::Time64(TimeUnit::Microsecond));
+        assert_eq!(array.len(), 1);
+        assert!(array.is_null(0));
+    }
+
+    #[test]
+    fn test_create_primitive_array_single_element_fixed_size_binary() {
+        let value = PrimitiveLiteral::Binary(vec![0xCA, 0xFE, 0xBA, 0xBE]);
+        let array =
+            create_primitive_array_single_element(&DataType::FixedSizeBinary(4), &Some(value))
+                .expect("FixedSizeBinary single element with value should succeed");
+
+        assert_eq!(array.data_type(), &DataType::FixedSizeBinary(4));
+        assert_eq!(array.len(), 1);
+        let typed = array
+            .as_any()
+            .downcast_ref::<FixedSizeBinaryArray>()
+            .expect("should downcast to FixedSizeBinaryArray");
+        assert!(!typed.is_null(0));
+        assert_eq!(typed.value(0), &[0xCA, 0xFE, 0xBA, 0xBE]);
+    }
+
+    #[test]
+    fn test_create_primitive_array_single_element_fixed_size_binary_null() {
+        let array = create_primitive_array_single_element(&DataType::FixedSizeBinary(4), &None)
+            .expect("FixedSizeBinary single element with null should succeed");
+
+        assert_eq!(array.data_type(), &DataType::FixedSizeBinary(4));
+        assert_eq!(array.len(), 1);
+        assert!(array.is_null(0));
+    }
+
+    #[test]
+    fn test_create_primitive_array_single_element_uuid() {
+        let uuid_val: u128 = 0x550e8400_e29b_41d4_a716_446655440000;
+        let value = PrimitiveLiteral::UInt128(uuid_val);
+        let array =
+            create_primitive_array_single_element(&DataType::FixedSizeBinary(16), &Some(value))
+                .expect("FixedSizeBinary(16) single element with UUID should succeed");
+
+        assert_eq!(array.data_type(), &DataType::FixedSizeBinary(16));
+        assert_eq!(array.len(), 1);
+        let typed = array
+            .as_any()
+            .downcast_ref::<FixedSizeBinaryArray>()
+            .expect("should downcast to FixedSizeBinaryArray");
+        assert!(!typed.is_null(0));
+        assert_eq!(typed.value(0), uuid_val.to_be_bytes());
+    }
+
+    #[test]
+    fn test_create_primitive_array_single_element_uuid_null() {
+        let array = create_primitive_array_single_element(&DataType::FixedSizeBinary(16), &None)
+            .expect("FixedSizeBinary(16) single element with null should succeed");
+
+        assert_eq!(array.data_type(), &DataType::FixedSizeBinary(16));
+        assert_eq!(array.len(), 1);
+        assert!(array.is_null(0));
     }
 }

--- a/crates/iceberg/src/arrow/value.rs
+++ b/crates/iceberg/src/arrow/value.rs
@@ -620,6 +620,21 @@ pub fn arrow_primitive_to_literal(
     )
 }
 
+/// Validate that a FixedSizeBinary length is non-negative and return it as usize.
+///
+/// Arrow's `DataType::FixedSizeBinary` uses `i32` for the length field. A negative value
+/// would wrap around to a large `usize` when cast, potentially exhausting memory if used
+/// for allocating an empty buffer.
+fn validated_fixed_len(len: i32) -> Result<usize> {
+    if len < 0 {
+        return Err(Error::new(
+            ErrorKind::DataInvalid,
+            format!("FixedSizeBinary length must be non-negative, got {len}"),
+        ));
+    }
+    Ok(len as usize)
+}
+
 /// Create a single-element array from a primitive literal.
 ///
 /// This is used for creating constant arrays (Run-End Encoded arrays) where we need
@@ -745,11 +760,14 @@ pub(crate) fn create_primitive_array_single_element(
                 )?,
             ))
         }
-        (DataType::FixedSizeBinary(len), None) => Ok(Arc::new(FixedSizeBinaryArray::new(
-            *len,
-            arrow_buffer::Buffer::from(vec![0u8; *len as usize]),
-            Some(arrow_buffer::NullBuffer::new_null(1)),
-        ))),
+        (DataType::FixedSizeBinary(len), None) => {
+            let byte_len = validated_fixed_len(*len)?;
+            Ok(Arc::new(FixedSizeBinaryArray::new(
+                *len,
+                arrow_buffer::Buffer::from(vec![0u8; byte_len]),
+                Some(arrow_buffer::NullBuffer::new_null(1)),
+            )))
+        }
         (DataType::Decimal128(precision, scale), Some(PrimitiveLiteral::Int128(v))) => {
             let array = Decimal128Array::from(vec![{ *v }])
                 .with_precision_and_scale(*precision, *scale)
@@ -849,9 +867,10 @@ pub(crate) fn create_primitive_array_single_element(
                             ])) as ArrayRef)
                         }
                         DataType::FixedSizeBinary(len) => {
+                            let byte_len = validated_fixed_len(*len)?;
                             Ok(Arc::new(FixedSizeBinaryArray::new(
                                 *len,
-                                arrow_buffer::Buffer::from(vec![0u8; *len as usize]),
+                                arrow_buffer::Buffer::from(vec![0u8; byte_len]),
                                 Some(arrow_buffer::NullBuffer::new_null(1)),
                             )) as ArrayRef)
                         }
@@ -1049,11 +1068,14 @@ pub(crate) fn create_primitive_array_repeated(
                 })?,
             )
         }
-        (DataType::FixedSizeBinary(len), None) => Arc::new(FixedSizeBinaryArray::new(
-            *len,
-            arrow_buffer::Buffer::from(vec![0u8; *len as usize * num_rows]),
-            Some(arrow_buffer::NullBuffer::new_null(num_rows)),
-        )),
+        (DataType::FixedSizeBinary(len), None) => {
+            let byte_len = validated_fixed_len(*len)?;
+            Arc::new(FixedSizeBinaryArray::new(
+                *len,
+                arrow_buffer::Buffer::from(vec![0u8; byte_len * num_rows]),
+                Some(arrow_buffer::NullBuffer::new_null(num_rows)),
+            ))
+        }
         (DataType::Decimal128(precision, scale), Some(PrimitiveLiteral::Int128(value))) => {
             Arc::new(
                 Decimal128Array::from(vec![*value; num_rows])


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #.

## What changes are included in this PR?

The `RecordBatchTransformer` fails at runtime when reading a Parquet file that is missing a column (e.g. schema evolution where a column was added), and the missing column's Iceberg type maps to an Arrow type that is not handled in `create_primitive_array_repeated` or `create_primitive_array_single_element`. 

We have a concrete case where a `binary` type added to table schema triggered this error. 
```
DataFusion error: External error: Unexpected => unexpected target column type LargeBinary
```

However, there are other types impacted as well. All impacted types include  `Binary`, `Time`, `Uuid`, `Fixed(len)`.

This change adds support for those types.


## Are these changes tested?

- Unit tests in `values.rs`
- Integration testing in `record_batch_transformer.rs`