### PR TITLE
fix(rest): refresh token after unauthorized response

### DIFF
--- a/crates/catalog/rest/src/catalog.rs
+++ b/crates/catalog/rest/src/catalog.rs
@@ -1111,6 +1111,66 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_oauth_refreshes_token_after_unauthorized_response() {
+        let mut server = Server::new_async().await;
+        let oauth_mock =
+            create_oauth_mock_with_path(&mut server, "/v1/oauth/tokens", "expired-token", 200)
+                .await;
+        let config_mock = create_config_mock(&mut server).await;
+        let expired_token_mock = server
+            .mock("GET", "/v1/namespaces")
+            .match_header("authorization", "Bearer expired-token")
+            .with_status(401)
+            .with_header("content-type", "application/json")
+            .with_body(
+                r#"{
+                    "error": {
+                        "message": "The access token expired",
+                        "type": "UnauthorizedException",
+                        "code": 401
+                    }
+                }"#,
+            )
+            .expect(1)
+            .create_async()
+            .await;
+        let refresh_oauth_mock =
+            create_oauth_mock_with_path(&mut server, "/v1/oauth/tokens", "refreshed-token", 200)
+                .await;
+        let refreshed_token_mock = server
+            .mock("GET", "/v1/namespaces")
+            .match_header("authorization", "Bearer refreshed-token")
+            .with_status(200)
+            .with_body(r#"{"namespaces": [["default"]]}"#)
+            .expect(1)
+            .create_async()
+            .await;
+
+        let mut props = HashMap::new();
+        props.insert("credential".to_string(), "client1:secret1".to_string());
+
+        let catalog = RestCatalog::new(
+            RestCatalogConfig::builder()
+                .uri(server.url())
+                .props(props)
+                .build(),
+        );
+
+        let namespaces = catalog.list_namespaces(None).await.unwrap();
+
+        oauth_mock.assert_async().await;
+        config_mock.assert_async().await;
+        expired_token_mock.assert_async().await;
+        refresh_oauth_mock.assert_async().await;
+        refreshed_token_mock.assert_async().await;
+        assert_eq!(namespaces, vec![NamespaceIdent::new("default".to_string())]);
+        assert_eq!(
+            catalog.context().await.unwrap().client.token().await,
+            Some("refreshed-token".to_string())
+        );
+    }
+
+    #[tokio::test]
     async fn test_oauth_with_optional_param() {
         let mut props = HashMap::new();
         props.insert("credential".to_string(), "client1:secret1".to_string());

--- a/crates/catalog/rest/src/client.rs
+++ b/crates/catalog/rest/src/client.rs
@@ -218,9 +218,21 @@ impl HttpClient {
     /// If credential is invalid, or the request fails, this method will return an error and leave
     /// the current token unchanged.
     pub(crate) async fn regenerate_token(&self) -> Result<()> {
-        let new_token = self.exchange_credential_for_token().await?;
+        let new_token = self.exchange_token().await?;
         *self.token.lock().await = Some(new_token.clone());
         Ok(())
+    }
+
+    async fn exchange_token(&self) -> Result<String> {
+        if self.gcp_credential.is_some() {
+            self.exchange_gcp_credential_for_token().await
+        } else {
+            self.exchange_credential_for_token().await
+        }
+    }
+
+    fn can_refresh_token(&self) -> bool {
+        self.credential.is_some() || self.gcp_credential.is_some()
     }
 
     /// Authenticates the request by adding a bearer token to the authorization header.
@@ -234,8 +246,6 @@ impl HttpClient {
     ///
     /// When both `credential` and `token` are present, `token` takes precedence.
     /// When GCP service account is present, it takes precedence over credential-based auth.
-    ///
-    /// # TODO: Support automatic token refreshing.
     async fn authenticate(&self, req: &mut Request) -> Result<()> {
         // Clone the token from lock without holding the lock for entire function.
         let token = self.token.lock().await.clone();
@@ -248,11 +258,7 @@ impl HttpClient {
         let token = match token {
             Some(token) => token,
             None => {
-                let token = if self.gcp_credential.is_some() {
-                    self.exchange_gcp_credential_for_token().await?
-                } else {
-                    self.exchange_credential_for_token().await?
-                };
+                let token = self.exchange_token().await?;
                 // Update token so that we use it for next request instead of
                 // exchanging credential for token from the server again
                 *self.token.lock().await = Some(token.clone());
@@ -291,8 +297,21 @@ impl HttpClient {
     // Queries the Iceberg REST catalog after authentication with the given `Request` and
     // returns a `Response`.
     pub async fn query_catalog(&self, mut request: Request) -> Result<Response> {
+        let retry_request = request.try_clone();
         self.authenticate(&mut request).await?;
-        self.execute(request).await
+        let response = self.execute(request).await?;
+
+        if response.status() != StatusCode::UNAUTHORIZED || !self.can_refresh_token() {
+            return Ok(response);
+        }
+
+        let Some(mut retry_request) = retry_request else {
+            return Ok(response);
+        };
+
+        self.invalidate_token().await?;
+        self.authenticate(&mut retry_request).await?;
+        self.execute(retry_request).await
     }
 }
 


### PR DESCRIPTION
## Summary
- cherry-pick token refresh after unauthorized REST response onto the release-2.8 iceberg-rust baseline
- keep the dependency stack compatible with RisingWave release-2.8

## Testing
- consumed by iceberg-compaction and RisingWave release-2.8 checks