### PR TITLE
fix: skip opendal TimeoutLayer under madsim

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,6 +72,10 @@ dirs = "6"
 enum-ordinalize = "4.3.0"
 env_logger = "0.11.8"
 expect-test = "1"
+fastnum = { version = "0.7", default-features = false, features = [
+  "std",
+  "serde",
+] }
 faststr = "0.2.31"
 flate2 = "1.1.5"
 fnv = "1.0.7"
@@ -109,7 +113,6 @@ rand = "0.8.5"
 regex = "1.11.3"
 reqwest = { version = "0.12.12", default-features = false, features = ["json"] }
 roaring = { version = "0.11" }
-fastnum = { version = "0.7", default-features = false, features = ["std", "serde"] }
 serde = { version = "1.0.219", features = ["rc"] }
 serde_bytes = "0.11.17"
 serde_derive = "1.0.219"
@@ -133,3 +136,6 @@ uuid = { version = "1.18", features = ["v7"] }
 volo = "0.10.6"
 volo-thrift = "0.10.8"
 zstd = "0.13.3"
+
+[workspace.lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(madsim)'] }

--- a/crates/iceberg/Cargo.toml
+++ b/crates/iceberg/Cargo.toml
@@ -108,3 +108,6 @@ minijinja = { workspace = true }
 [package.metadata.cargo-machete]
 # These dependencies are added to ensure minimal dependency version
 ignored = ["tap"]
+
+[lints]
+workspace = true

--- a/crates/iceberg/src/io/storage/opendal/mod.rs
+++ b/crates/iceberg/src/io/storage/opendal/mod.rs
@@ -26,7 +26,9 @@ use async_trait::async_trait;
 #[cfg(feature = "storage-azdls")]
 use azdls::AzureStorageScheme;
 use bytes::Bytes;
-use opendal::layers::{RetryLayer, TimeoutLayer};
+use opendal::layers::RetryLayer;
+#[cfg(not(madsim))]
+use opendal::layers::TimeoutLayer;
 #[cfg(feature = "storage-azblob")]
 use opendal::services::AzblobConfig;
 #[cfg(feature = "storage-azdls")]
@@ -406,6 +408,11 @@ impl OpenDalStorage {
         };
 
         // Configure timeout layer for IO operations.
+        //
+        // Skipped under madsim: opendal's TimeoutLayer relies on real
+        // `tokio::time::timeout`, which is not provided by the madsim runtime
+        // and triggers "no reactor running" panics during simulated tests.
+        #[cfg(not(madsim))]
         let operator = if let Some(timeout_secs) = parse_config::<u64>(config, IO_TIMEOUT_SECONDS)?
         {
             operator.layer(TimeoutLayer::new().with_io_timeout(Duration::from_secs(timeout_secs)))


### PR DESCRIPTION
## Update

Opendal's TimeoutLayer relies on real `tokio::time::timeout`, which is not provided by the madsim runtime and triggers "no reactor running" panics during simulated tests.