### PR TITLE
fix: avoid panic in snapshot summary update_totals on malformed values

### DIFF
--- a/crates/iceberg/src/spec/snapshot_summary.rs
+++ b/crates/iceberg/src/spec/snapshot_summary.rs
@@ -350,11 +350,6 @@ pub(crate) fn update_snapshot_summaries(
     let mut summary = match previous_summary {
         Some(prev_summary) if truncate_full_table && summary.operation == Operation::Overwrite => {
             truncate_table_summary(summary, prev_summary)
-                .map_err(|err| {
-                    Error::new(ErrorKind::Unexpected, "Failed to truncate table summary.")
-                        .with_source(err)
-                })
-                .unwrap()
         }
         _ => summary,
     };
@@ -409,24 +404,24 @@ pub(crate) fn update_snapshot_summaries(
     Ok(summary)
 }
 
+/// Read a `total_*` property from a previous summary as a `u64`.
+///
+/// Snapshot summary values are decimal strings inside a
+/// `HashMap<String, String>` and may be written by any Iceberg engine
+/// (Java, Python, Rust, ...). A malformed entry, an empty string, or a
+/// value exceeding `u64::MAX` must not panic the writer — we treat any
+/// unparseable value as `0`, matching the policy in `update_totals`.
 #[allow(dead_code)]
-fn get_prop(previous_summary: &Summary, prop: &str) -> Result<i32> {
-    let value_str = previous_summary
+fn previous_total_or_zero(previous_summary: &Summary, prop: &str) -> u64 {
+    previous_summary
         .additional_properties
         .get(prop)
-        .map(String::as_str)
-        .unwrap_or("0");
-    value_str.parse::<i32>().map_err(|err| {
-        Error::new(
-            ErrorKind::Unexpected,
-            "Failed to parse value from previous summary property.",
-        )
-        .with_source(err)
-    })
+        .and_then(|v| v.parse::<u64>().ok())
+        .unwrap_or(0)
 }
 
 #[allow(dead_code)]
-fn truncate_table_summary(mut summary: Summary, previous_summary: &Summary) -> Result<Summary> {
+fn truncate_table_summary(mut summary: Summary, previous_summary: &Summary) -> Summary {
     for prop in [
         TOTAL_DATA_FILES,
         TOTAL_DELETE_FILES,
@@ -440,46 +435,23 @@ fn truncate_table_summary(mut summary: Summary, previous_summary: &Summary) -> R
             .insert(prop.to_string(), "0".to_string());
     }
 
-    let value = get_prop(previous_summary, TOTAL_DATA_FILES)?;
-    if value != 0 {
-        summary
-            .additional_properties
-            .insert(DELETED_DATA_FILES.to_string(), value.to_string());
-    }
-    let value = get_prop(previous_summary, TOTAL_DELETE_FILES)?;
-    if value != 0 {
-        summary
-            .additional_properties
-            .insert(REMOVED_DELETE_FILES.to_string(), value.to_string());
-    }
-    let value = get_prop(previous_summary, TOTAL_RECORDS)?;
-    if value != 0 {
-        summary
-            .additional_properties
-            .insert(DELETED_RECORDS.to_string(), value.to_string());
-    }
-    let value = get_prop(previous_summary, TOTAL_FILE_SIZE)?;
-    if value != 0 {
-        summary
-            .additional_properties
-            .insert(REMOVED_FILE_SIZE.to_string(), value.to_string());
+    for (total_prop, removed_prop) in [
+        (TOTAL_DATA_FILES, DELETED_DATA_FILES),
+        (TOTAL_DELETE_FILES, REMOVED_DELETE_FILES),
+        (TOTAL_RECORDS, DELETED_RECORDS),
+        (TOTAL_FILE_SIZE, REMOVED_FILE_SIZE),
+        (TOTAL_POSITION_DELETES, REMOVED_POSITION_DELETES),
+        (TOTAL_EQUALITY_DELETES, REMOVED_EQUALITY_DELETES),
+    ] {
+        let value = previous_total_or_zero(previous_summary, total_prop);
+        if value != 0 {
+            summary
+                .additional_properties
+                .insert(removed_prop.to_string(), value.to_string());
+        }
     }
 
-    let value = get_prop(previous_summary, TOTAL_POSITION_DELETES)?;
-    if value != 0 {
-        summary
-            .additional_properties
-            .insert(REMOVED_POSITION_DELETES.to_string(), value.to_string());
-    }
-
-    let value = get_prop(previous_summary, TOTAL_EQUALITY_DELETES)?;
-    if value != 0 {
-        summary
-            .additional_properties
-            .insert(REMOVED_EQUALITY_DELETES.to_string(), value.to_string());
-    }
-
-    Ok(summary)
+    summary
 }
 
 #[allow(dead_code)]
@@ -640,6 +612,110 @@ mod tests {
         );
     }
 
+    /// The truncate-overwrite path used to parse previous-summary totals via
+    /// `get_prop` as `i32` and `?`-propagate the error, which
+    /// `update_snapshot_summaries` then unwrapped — so a malformed or
+    /// overflowing previous value (perfectly legal in a summary written by
+    /// another engine) would panic the writer. Truncation must now degrade
+    /// gracefully: unparseable totals are treated as `0` and produce no
+    /// `removed_*` entry, while well-formed totals still flow through.
+    #[test]
+    fn test_update_snapshot_summaries_truncate_overwrite_handles_malformed_and_overflow() {
+        // > u64::MAX, so `parse::<u64>()` fails with PosOverflow.
+        let overflow = "99999999999999999999".to_string();
+        // Also exceeds the old i32 ceiling (~2.1 GB) — proves the previous
+        // `get_prop -> i32` implementation was too narrow even for valid
+        // `TOTAL_FILE_SIZE` values produced by other engines.
+        let big_but_valid_u64 = "5000000000".to_string();
+        let prev_props: HashMap<String, String> = [
+            // Malformed: not a number at all.
+            (TOTAL_DATA_FILES.to_string(), "garbage".to_string()),
+            // Malformed: empty string.
+            (TOTAL_DELETE_FILES.to_string(), "".to_string()),
+            // Overflows u64.
+            (TOTAL_RECORDS.to_string(), overflow),
+            // Valid u64 that overflows i32 — must survive truncation intact.
+            (TOTAL_FILE_SIZE.to_string(), big_but_valid_u64.clone()),
+            // Well-formed small value — must still produce REMOVED_*.
+            (TOTAL_POSITION_DELETES.to_string(), "7".to_string()),
+            // Missing TOTAL_EQUALITY_DELETES on purpose.
+        ]
+        .into_iter()
+        .collect();
+        let previous_summary = Summary {
+            operation: Operation::Overwrite,
+            additional_properties: prev_props,
+        };
+
+        let summary = Summary {
+            operation: Operation::Overwrite,
+            additional_properties: HashMap::new(),
+        };
+
+        // Must not panic.
+        let updated = update_snapshot_summaries(summary, Some(&previous_summary), true).unwrap();
+
+        // All totals are reset by truncation, regardless of previous health.
+        for prop in [
+            TOTAL_DATA_FILES,
+            TOTAL_DELETE_FILES,
+            TOTAL_RECORDS,
+            TOTAL_FILE_SIZE,
+            TOTAL_POSITION_DELETES,
+            TOTAL_EQUALITY_DELETES,
+        ] {
+            assert_eq!(
+                updated.additional_properties.get(prop).map(String::as_str),
+                Some("0"),
+                "expected {prop} to be reset to 0 after truncate"
+            );
+        }
+
+        // Malformed / overflowing / missing previous totals must NOT emit a
+        // bogus removed_* counter — treating them as 0 is the only safe choice.
+        assert!(
+            !updated
+                .additional_properties
+                .contains_key(DELETED_DATA_FILES),
+            "malformed TOTAL_DATA_FILES must not produce a removed counter"
+        );
+        assert!(
+            !updated
+                .additional_properties
+                .contains_key(REMOVED_DELETE_FILES),
+            "empty TOTAL_DELETE_FILES must not produce a removed counter"
+        );
+        assert!(
+            !updated.additional_properties.contains_key(DELETED_RECORDS),
+            "overflowing TOTAL_RECORDS must not produce a removed counter"
+        );
+        assert!(
+            !updated
+                .additional_properties
+                .contains_key(REMOVED_EQUALITY_DELETES),
+            "missing TOTAL_EQUALITY_DELETES must not produce a removed counter"
+        );
+
+        // Well-formed previous values still drive removed_* — including ones
+        // that would have overflowed the old i32 path.
+        assert_eq!(
+            updated
+                .additional_properties
+                .get(REMOVED_FILE_SIZE)
+                .map(String::as_str),
+            Some(big_but_valid_u64.as_str()),
+            "valid u64 TOTAL_FILE_SIZE must be carried into REMOVED_FILE_SIZE"
+        );
+        assert_eq!(
+            updated
+                .additional_properties
+                .get(REMOVED_POSITION_DELETES)
+                .map(String::as_str),
+            Some("7"),
+            "valid TOTAL_POSITION_DELETES must be carried into REMOVED_POSITION_DELETES"
+        );
+    }
+
     #[test]
     fn test_update_snapshot_summaries_append() {
         let prev_props: HashMap<String, String> = [
@@ -742,7 +818,7 @@ mod tests {
             additional_properties: new_props,
         };
 
-        let truncated = truncate_table_summary(summary, &previous_summary).unwrap();
+        let truncated = truncate_table_summary(summary, &previous_summary);
 
         assert_eq!(
             truncated

--- a/crates/iceberg/src/spec/snapshot_summary.rs
+++ b/crates/iceberg/src/spec/snapshot_summary.rs
@@ -490,28 +490,26 @@ fn update_totals(
     added_property: &str,
     removed_property: &str,
 ) {
+    // Snapshot summary values are stored as decimal strings inside a
+    // `HashMap<String, String>` and are written by any Iceberg engine (Java,
+    // Python, Rust, ...). We must not panic if a value is missing, malformed,
+    // or exceeds `u64::MAX` — that aborts the writer and produces no progress
+    // signal. Treat any unparseable value as `0` (the same as a missing
+    // entry) and use saturating arithmetic so a `removed > previous + added`
+    // skew from a corrupt history can never underflow.
+    fn parse_or_zero(value: Option<&String>) -> u64 {
+        value.and_then(|v| v.parse::<u64>().ok()).unwrap_or(0)
+    }
+
     let previous_total = previous_summary.map_or(0, |previous_summary| {
-        previous_summary
-            .additional_properties
-            .get(total_property)
-            .map_or(0, |value| value.parse::<u64>().unwrap())
+        parse_or_zero(previous_summary.additional_properties.get(total_property))
     });
 
-    let mut new_total = previous_total;
-    if let Some(value) = summary
-        .additional_properties
-        .get(added_property)
-        .map(|value| value.parse::<u64>().unwrap())
-    {
-        new_total += value;
-    }
-    if let Some(value) = summary
-        .additional_properties
-        .get(removed_property)
-        .map(|value| value.parse::<u64>().unwrap())
-    {
-        new_total -= value;
-    }
+    let added = parse_or_zero(summary.additional_properties.get(added_property));
+    let removed = parse_or_zero(summary.additional_properties.get(removed_property));
+
+    let new_total = previous_total.saturating_add(added).saturating_sub(removed);
+
     summary
         .additional_properties
         .insert(total_property.to_string(), new_total.to_string());
@@ -527,6 +525,120 @@ mod tests {
         DataFileFormat, Datum, Literal, NestedField, PartitionSpec, PrimitiveType, Schema, Struct,
         Transform, Type, UnboundPartitionField,
     };
+
+    /// Previous-summary values that overflow `u64` (e.g. written by a
+    /// non-Rust engine using unbounded integers) used to panic with
+    /// `ParseIntError { kind: PosOverflow }` inside `update_totals`. They
+    /// must now be treated as `0` so compaction can still make progress.
+    #[test]
+    fn test_update_totals_handles_overflowing_previous_total() {
+        // > u64::MAX (= 18_446_744_073_709_551_615)
+        let huge = "99999999999999999999".to_string();
+        let prev_props: HashMap<String, String> = [
+            (TOTAL_FILE_SIZE.to_string(), huge),
+            (TOTAL_RECORDS.to_string(), "100".to_string()),
+        ]
+        .into_iter()
+        .collect();
+        let previous_summary = Summary {
+            operation: Operation::Append,
+            additional_properties: prev_props,
+        };
+
+        let new_props: HashMap<String, String> = [
+            (ADDED_FILE_SIZE.to_string(), "400".to_string()),
+            (ADDED_RECORDS.to_string(), "10".to_string()),
+        ]
+        .into_iter()
+        .collect();
+        let summary = Summary {
+            operation: Operation::Append,
+            additional_properties: new_props,
+        };
+
+        let updated = update_snapshot_summaries(summary, Some(&previous_summary), false).unwrap();
+
+        // Overflowing previous total is reset to 0, then `added` is applied.
+        assert_eq!(
+            updated.additional_properties.get(TOTAL_FILE_SIZE).unwrap(),
+            "400"
+        );
+        // Non-overflowing values still aggregate correctly.
+        assert_eq!(
+            updated.additional_properties.get(TOTAL_RECORDS).unwrap(),
+            "110"
+        );
+    }
+
+    /// A corrupt history could leave `removed > previous + added`, which
+    /// used to panic on `new_total -= value` in debug builds and silently
+    /// wrap in release. `saturating_sub` clamps the result to `0`.
+    #[test]
+    fn test_update_totals_saturates_on_underflow() {
+        let prev_props: HashMap<String, String> = [(TOTAL_RECORDS.to_string(), "5".to_string())]
+            .into_iter()
+            .collect();
+        let previous_summary = Summary {
+            operation: Operation::Append,
+            additional_properties: prev_props,
+        };
+
+        let new_props: HashMap<String, String> = [
+            (ADDED_RECORDS.to_string(), "1".to_string()),
+            (DELETED_RECORDS.to_string(), "100".to_string()),
+        ]
+        .into_iter()
+        .collect();
+        let summary = Summary {
+            operation: Operation::Append,
+            additional_properties: new_props,
+        };
+
+        let updated = update_snapshot_summaries(summary, Some(&previous_summary), false).unwrap();
+
+        assert_eq!(
+            updated.additional_properties.get(TOTAL_RECORDS).unwrap(),
+            "0"
+        );
+    }
+
+    /// Non-numeric or empty values must not panic — they are treated the
+    /// same as a missing entry (value `0`).
+    #[test]
+    fn test_update_totals_treats_malformed_value_as_zero() {
+        let prev_props: HashMap<String, String> = [
+            (TOTAL_RECORDS.to_string(), "garbage".to_string()),
+            (TOTAL_FILE_SIZE.to_string(), "".to_string()),
+        ]
+        .into_iter()
+        .collect();
+        let previous_summary = Summary {
+            operation: Operation::Append,
+            additional_properties: prev_props,
+        };
+
+        let new_props: HashMap<String, String> = [
+            (ADDED_RECORDS.to_string(), "7".to_string()),
+            (ADDED_FILE_SIZE.to_string(), "70".to_string()),
+        ]
+        .into_iter()
+        .collect();
+        let summary = Summary {
+            operation: Operation::Append,
+            additional_properties: new_props,
+        };
+
+        let updated = update_snapshot_summaries(summary, Some(&previous_summary), false).unwrap();
+
+        assert_eq!(
+            updated.additional_properties.get(TOTAL_RECORDS).unwrap(),
+            "7"
+        );
+        assert_eq!(
+            updated.additional_properties.get(TOTAL_FILE_SIZE).unwrap(),
+            "70"
+        );
+    }
 
     #[test]
     fn test_update_snapshot_summaries_append() {


### PR DESCRIPTION
## What changes are included in this PR?

Fixes a panic in iceberg::spec::snapshot_summary::update_totals that aborts any writer attempting to commit against a table whose snapshot summary contains a value that does not parse cleanly into a u64.
The function previously did:
.map_or(0, |value| value.parse::<u64>().unwrap())   // previous total
.map(|value| value.parse::<u64>().unwrap())         // added / removed
new_total -= value;                                 // unchecked subtraction
Three latent panics in one function:
1. PosOverflow — a previous summary value greater than u64::MAX (e.g. written by a non-Rust engine using unbounded integers, or otherwise corrupt history) yields ParseIntError { kind: PosOverflow } and aborts the writer.
2. InvalidDigit — a non-numeric or empty string aborts the same way.
3. Underflow — new_total -= value panics in debug builds and silently wraps in release when removed > previous + added, which is reachable on corrupt history.
This PR replaces all three with parse-or-zero (unwrap_or(0)) plus saturating_add / saturating_sub, factored through a small local parse_or_zero helper. Semantics now match Java Iceberg's SnapshotSummary, which treats missing or unparseable values as 0. A single corrupt prior summary can no longer indefinitely break commits for a table.
No public API change; update_totals is a private free function and its caller (update_snapshot_summaries) is unchanged.

## Are these changes tested?


Yes — three new unit tests in crates/iceberg/src/spec/snapshot_summary.rs::tests, plus the five existing tests in the same module continue to pass:

test_update_totals_handles_overflowing_previous_total — seeds total-files-size with "99999999999999999999" (> u64::MAX). Previously panicked; now resets the overflowing total to 0 and applies added cleanly.

test_update_totals_saturates_on_underflow — removed=100, previous=5, added=1 previously panicked on new_total -= value; now saturates to 0.

test_update_totals_treats_malformed_value_as_zero — "garbage" and "" are accepted as 0 instead of panicking.
cargo test -p iceberg --lib spec::snapshot_summary::

test result: ok. 8 passed; 0 failed; 0 ignored
cargo fmt and cargo clippy -p iceberg --lib --tests --no-deps are clean on the touched file.