### PR TITLE
fix(transaction): account for added delete files in snapshot summary

### DIFF
--- a/crates/iceberg/src/transaction/snapshot.rs
+++ b/crates/iceberg/src/transaction/snapshot.rs
@@ -658,6 +658,19 @@ partition_struct: {:?}, partition_type: {:?}",
             );
         }
 
+        // Also account for added delete files (position / equality deletes),
+        // so the `added-*` / `total-*` delete counters in the snapshot summary
+        // stay consistent with the delete manifests written below. The
+        // collector branches on `data_file.content` to update the matching
+        // counters.
+        for delete_file in &self.added_delete_files {
+            summary_collector.add_file(
+                delete_file,
+                table_metadata.current_schema().clone(),
+                table_metadata.default_partition_spec().clone(),
+            );
+        }
+
         // Also account for files removed by this action (e.g. Replace / Delete).
         // Without this, `deleted-records` / `removed-files-size` /
         // `deleted-data-files` stay at zero on the new summary, so
@@ -1363,6 +1376,156 @@ mod tests {
         assert_eq!(
             total_data_files, PARENT_TOTAL_DATA_FILES,
             "total-data-files must stay at {PARENT_TOTAL_DATA_FILES} (added=1 − removed=1)",
+        );
+    }
+
+    /// Regression test: delete files added by a commit must be reflected in
+    /// the snapshot summary. `summary()` previously only fed
+    /// `added_data_files` into the collector, so `added-delete-files` /
+    /// `added-position-deletes` / `added-equality-deletes` were never emitted
+    /// and the `total-*` delete counters rolled forward as zero on every
+    /// commit, no matter how many delete files the manifests carried.
+    #[tokio::test]
+    async fn test_summary_accounts_for_added_delete_files() {
+        const PARENT_SNAPSHOT_ID: i64 = 42;
+        const PARENT_TOTAL_DELETE_FILES: u64 = 2;
+        const PARENT_TOTAL_POSITION_DELETES: u64 = 7;
+        const PARENT_TOTAL_EQUALITY_DELETES: u64 = 3;
+        const POS_DELETE_RECORDS: u64 = 4;
+        const EQ_DELETE_RECORDS: u64 = 2;
+
+        // Parent snapshot on `main` that already reports cumulative delete
+        // totals, so the test also covers the roll-forward arithmetic.
+        let base = make_v2_minimal_table();
+        let parent_summary = Summary {
+            operation: Operation::Append,
+            additional_properties: HashMap::from([
+                (
+                    "total-delete-files".to_string(),
+                    PARENT_TOTAL_DELETE_FILES.to_string(),
+                ),
+                (
+                    "total-position-deletes".to_string(),
+                    PARENT_TOTAL_POSITION_DELETES.to_string(),
+                ),
+                (
+                    "total-equality-deletes".to_string(),
+                    PARENT_TOTAL_EQUALITY_DELETES.to_string(),
+                ),
+            ]),
+        };
+        let parent_snapshot = Snapshot::builder()
+            .with_snapshot_id(PARENT_SNAPSHOT_ID)
+            .with_timestamp_ms(base.metadata().last_updated_ms() + 1)
+            .with_sequence_number(1)
+            .with_schema_id(0)
+            .with_manifest_list("memory:///unused-by-summary.avro")
+            .with_summary(parent_summary)
+            .build();
+
+        let metadata_with_parent = base
+            .metadata()
+            .clone()
+            .into_builder(Some("s3://bucket/test/location/metadata/v1.json".into()))
+            .add_snapshot(parent_snapshot)
+            .unwrap()
+            .set_ref(MAIN_BRANCH, SnapshotReference {
+                snapshot_id: PARENT_SNAPSHOT_ID,
+                retention: SnapshotRetention::Branch {
+                    min_snapshots_to_keep: None,
+                    max_snapshot_age_ms: None,
+                    max_ref_age_ms: None,
+                },
+            })
+            .unwrap()
+            .build()
+            .unwrap()
+            .metadata;
+        let table = base.with_metadata(Arc::new(metadata_with_parent));
+
+        let make_file = |path: &str, content: DataContentType, records: u64| {
+            DataFileBuilder::default()
+                .partition_spec_id(table.metadata().default_partition_spec_id())
+                .content(content)
+                .file_path(path.to_string())
+                .file_format(DataFileFormat::Parquet)
+                .file_size_in_bytes(100)
+                .record_count(records)
+                .partition(Struct::from_iter([Some(Literal::long(300))]))
+                .build()
+                .unwrap()
+        };
+        let added_data = make_file("test/data.parquet", DataContentType::Data, 10);
+        let added_pos_delete = make_file(
+            "test/pos-del.parquet",
+            DataContentType::PositionDeletes,
+            POS_DELETE_RECORDS,
+        );
+        let added_eq_delete = make_file(
+            "test/eq-del.parquet",
+            DataContentType::EqualityDeletes,
+            EQ_DELETE_RECORDS,
+        );
+
+        let producer = SnapshotProducer::new(
+            &table,
+            Uuid::now_v7(),
+            None,
+            None,
+            HashMap::new(),
+            vec![added_data],
+            vec![added_pos_delete, added_eq_delete],
+            vec![],
+            vec![],
+        );
+
+        let summary = producer.summary(&RewriteFilesOperation).unwrap();
+        let props = &summary.additional_properties;
+
+        // Added delete-file accounting — absent before the fix.
+        assert_eq!(
+            props.get("added-delete-files").map(String::as_str),
+            Some("2"),
+            "added-delete-files must count both delete files",
+        );
+        assert_eq!(
+            props.get("added-position-delete-files").map(String::as_str),
+            Some("1"),
+        );
+        assert_eq!(
+            props.get("added-equality-delete-files").map(String::as_str),
+            Some("1"),
+        );
+        assert_eq!(
+            props.get("added-position-deletes").map(String::as_str),
+            Some(POS_DELETE_RECORDS.to_string().as_str()),
+        );
+        assert_eq!(
+            props.get("added-equality-deletes").map(String::as_str),
+            Some(EQ_DELETE_RECORDS.to_string().as_str()),
+        );
+
+        // Totals roll forward from the parent instead of staying at zero.
+        assert_eq!(
+            props.get("total-delete-files").map(String::as_str),
+            Some((PARENT_TOTAL_DELETE_FILES + 2).to_string().as_str()),
+            "total-delete-files must roll forward from the parent",
+        );
+        assert_eq!(
+            props.get("total-position-deletes").map(String::as_str),
+            Some(
+                (PARENT_TOTAL_POSITION_DELETES + POS_DELETE_RECORDS)
+                    .to_string()
+                    .as_str()
+            ),
+        );
+        assert_eq!(
+            props.get("total-equality-deletes").map(String::as_str),
+            Some(
+                (PARENT_TOTAL_EQUALITY_DELETES + EQ_DELETE_RECORDS)
+                    .to_string()
+                    .as_str()
+            ),
         );
     }
 


### PR DESCRIPTION
## Problem

Snapshot summaries incorrectly report delete-file statistics.

Even when a table contains live position-delete and equality-delete files, snapshot summaries always show:

* `total-delete-files = 0`
* `total-position-deletes = 0`
* `total-equality-deletes = 0`

and never emit:

* `added-delete-files`
* `added-position-delete-files`
* `added-equality-delete-files`

As a result, consumers relying on snapshot summaries may make incorrect decisions. For example:

* Query engines may choose an unsupported or suboptimal read path.
* Validation logic may fail to detect delete-file usage.
* Upsert tables may appear as append-only tables in observability tooling.

In production, we observed a table with 1,707 live delete files across 394 delete manifests whose snapshot summary still reported `total-delete-files: 0`.

## Root Cause

`SnapshotProducer::summary()` only forwards `added_data_files` to `SnapshotSummaryCollector`.

Although `added_delete_files` are correctly written to delete manifests by `manifest_file()`, they are never passed to the collector. Consequently:

* `added-*` delete metrics are never populated.
* `update_totals()` continuously computes delete totals as `previous + 0`, causing all `total-*` delete counters to remain incorrect.

The removed-file path was fixed in #152, but the added-file path was overlooked.

## Fix

Forward `added_delete_files` to `SnapshotSummaryCollector` in `SnapshotProducer::summary()`, mirroring the existing handling of `added_data_files`.

No collector changes are required. `SnapshotSummaryCollector::add_file()` already updates the appropriate delete counters based on `data_file.content`.

## Testing

Added regression test: `test_summary_accounts_for_added_delete_files`.

The test creates a producer containing:

* One data file
* One position-delete file
* One equality-delete file

against a parent snapshot with existing delete totals, and verifies that:

* `added-delete-files`, `added-position-delete-files`, and `added-equality-delete-files` are emitted.
* `added-position-deletes` and `added-equality-deletes` reflect the correct record counts.
* `total-delete-files`, `total-position-deletes`, and `total-equality-deletes` are correctly rolled forward from the parent snapshot.

## Compatibility Note

This change prevents future snapshots from producing incorrect delete-file summary statistics.

Existing incorrect totals are not automatically repaired because snapshot totals are derived from the previous snapshot summary. A table requires a truncating overwrite or full rewrite to regenerate accurate historical totals.
