### PR TITLE
feat(iceberg): add RemoveDanglingDeleteFilesAction

### DIFF
--- a/crates/catalog/glue/src/schema.rs
+++ b/crates/catalog/glue/src/schema.rs
@@ -25,8 +25,8 @@ pub(crate) const ICEBERG_FIELD_CURRENT: &str = "iceberg.field.current";
 use std::collections::HashMap;
 
 use aws_sdk_glue::types::Column;
-use iceberg::spec::{PrimitiveType, SchemaVisitor, TableMetadata, VariantType, visit_schema};
 use iceberg::Result;
+use iceberg::spec::{PrimitiveType, SchemaVisitor, TableMetadata, VariantType, visit_schema};
 
 use crate::error::from_aws_build_error;
 

--- a/crates/iceberg/src/actions/mod.rs
+++ b/crates/iceberg/src/actions/mod.rs
@@ -17,9 +17,11 @@
 
 //! Table maintenance actions.
 //!
-//! This module provides actions for table maintenance operations that do not
-//! modify table metadata, such as cleaning up orphan files.
+//! This module provides actions for table maintenance operations, such as
+//! cleaning up orphan files and removing dangling delete file references.
 
+mod remove_dangling_delete_files;
 mod remove_orphan_files;
 
+pub use remove_dangling_delete_files::*;
 pub use remove_orphan_files::*;

--- a/crates/iceberg/src/actions/remove_dangling_delete_files.rs
+++ b/crates/iceberg/src/actions/remove_dangling_delete_files.rs
@@ -1,0 +1,810 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Remove dangling delete files action.
+//!
+//! Removes position delete files, deletion vectors, and equality delete files
+//! from manifests when they no longer apply to any live data file in the
+//! current snapshot. This reduces metadata overhead and storage consumption
+//! for tables with high CDC throughput.
+
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+
+use crate::spec::{DataContentType, DataFile, MAIN_BRANCH, Struct};
+use crate::transaction::{ApplyTransactionAction, Transaction};
+use crate::utils::{DEFAULT_LOAD_CONCURRENCY_LIMIT, load_manifests};
+use crate::{Catalog, Error, ErrorKind, Result, TableIdent};
+
+/// Action to remove dangling delete files from a table.
+///
+/// Three categories of dangling deletes are handled:
+///
+/// - **Position deletes / deletion vectors**: removed when their
+///   `referenced_data_file` no longer exists in the current snapshot.
+/// - **Equality deletes**: removed when their sequence number is ≤ the
+///   minimum data file sequence number in their partition (Iceberg V2 spec:
+///   an equality delete at seq S only applies to data files with seq < S).
+///
+/// # Example
+///
+/// ```ignore
+/// let removed = RemoveDanglingDeleteFilesAction::new(catalog, table_ident)
+///     .to_branch("main")
+///     .execute()
+///     .await?;
+/// println!("Removed {} dangling delete files", removed);
+/// ```
+pub struct RemoveDanglingDeleteFilesAction {
+    catalog: Arc<dyn Catalog>,
+    table_ident: TableIdent,
+    to_branch: String,
+}
+
+impl RemoveDanglingDeleteFilesAction {
+    /// Creates a new action for the given catalog and table.
+    pub fn new(catalog: Arc<dyn Catalog>, table_ident: TableIdent) -> Self {
+        Self {
+            catalog,
+            table_ident,
+            to_branch: MAIN_BRANCH.to_string(),
+        }
+    }
+
+    /// Sets the branch to operate on.
+    pub fn to_branch(mut self, branch: impl Into<String>) -> Self {
+        self.to_branch = branch.into();
+        self
+    }
+
+    /// Executes the action, returning the number of dangling delete files removed.
+    pub async fn execute(self) -> Result<usize> {
+        let table = self.catalog.load_table(&self.table_ident).await?;
+        let Some(snapshot) = table.metadata().snapshot_for_ref(&self.to_branch) else {
+            return Ok(0);
+        };
+
+        let manifest_list = snapshot
+            .load_manifest_list(table.file_io(), table.metadata())
+            .await?;
+
+        let mut data_file_paths: HashSet<String> = HashSet::new();
+        let mut pos_deletes: Vec<(DataFile, Option<i64>)> = Vec::new();
+        let mut eq_deletes: Vec<(DataFile, i64)> = Vec::new();
+        let mut partition_min_seq: HashMap<(i32, Struct), i64> = HashMap::new();
+        let mut global_min_data_seq: Option<i64> = None;
+
+        let manifest_files: Vec<_> = manifest_list.entries().to_vec();
+        let loaded = load_manifests(
+            table.file_io(),
+            manifest_files,
+            DEFAULT_LOAD_CONCURRENCY_LIMIT,
+        )
+        .await?;
+
+        for (_, manifest) in loaded {
+            let (entries, _) = manifest.into_parts();
+
+            for entry in entries {
+                if !entry.is_alive() {
+                    continue;
+                }
+
+                let df = entry.data_file();
+                let seq = entry.sequence_number();
+
+                match entry.content_type() {
+                    DataContentType::Data => {
+                        data_file_paths.insert(df.file_path().to_string());
+                        if let Some(s) = seq {
+                            let key = (df.partition_spec_id(), df.partition().clone());
+                            partition_min_seq
+                                .entry(key)
+                                .and_modify(|min| *min = (*min).min(s))
+                                .or_insert(s);
+                            global_min_data_seq = Some(global_min_data_seq.map_or(s, |g| g.min(s)));
+                        }
+                    }
+                    DataContentType::PositionDeletes => {
+                        pos_deletes.push((df.clone(), seq));
+                    }
+                    DataContentType::EqualityDeletes => {
+                        if let Some(s) = seq {
+                            eq_deletes.push((df.clone(), s));
+                        }
+                    }
+                }
+            }
+        }
+
+        let mut dangling: Vec<DataFile> = Vec::new();
+
+        dangling.extend(
+            pos_deletes
+                .into_iter()
+                .filter(|(df, df_seq)| {
+                    if let Some(ref_path) = df.referenced_data_file() {
+                        // Path-based: dangling if the referenced data file no longer exists
+                        !data_file_paths.contains(&ref_path)
+                    } else if let Some(s) = df_seq {
+                        // Sequence-based: dangling if seq < min_data_seq in this partition
+                        let key = (df.partition_spec_id(), df.partition().clone());
+                        partition_min_seq
+                            .get(&key)
+                            .map_or(true, |&min_seq| *s < min_seq)
+                    } else {
+                        // No referenced_data_file and no sequence number — cannot determine
+                        false
+                    }
+                })
+                .map(|(df, _)| df),
+        );
+
+        dangling.extend(
+            eq_deletes
+                .into_iter()
+                .filter(|(df, seq)| {
+                    if df.partition().fields().is_empty() {
+                        // Unpartitioned equality deletes are global — they apply to all
+                        // data files regardless of partition. Only remove if seq is <=
+                        // the global minimum data sequence number.
+                        global_min_data_seq.map_or(true, |g| *seq <= g)
+                    } else {
+                        let key = (df.partition_spec_id(), df.partition().clone());
+                        partition_min_seq
+                            .get(&key)
+                            .map_or(true, |&min_seq| *seq <= min_seq)
+                    }
+                })
+                .map(|(df, _)| df),
+        );
+
+        let mut seen: HashSet<String> = HashSet::new();
+        dangling.retain(|df| seen.insert(df.file_path().to_string()));
+
+        if dangling.is_empty() {
+            return Ok(0);
+        }
+
+        let dangling_count = dangling.len();
+        let txn = Transaction::new(&table);
+        let branch = self.to_branch.clone();
+        let action = txn
+            .rewrite_files()
+            .delete_files(dangling)
+            .set_target_branch(branch);
+
+        let txn = action.apply(txn).map_err(|e| {
+            Error::new(
+                ErrorKind::Unexpected,
+                format!("Failed to build rewrite action: {e}"),
+            )
+        })?;
+
+        txn.commit(self.catalog.as_ref()).await?;
+
+        Ok(dangling_count)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
+    use super::RemoveDanglingDeleteFilesAction;
+    use crate::catalog::memory::{MEMORY_CATALOG_WAREHOUSE, MemoryCatalogBuilder};
+    use crate::catalog::{Catalog, CatalogBuilder};
+    use crate::spec::{
+        DataContentType, DataFileBuilder, DataFileFormat, Literal, MAIN_BRANCH, NestedField,
+        PrimitiveType, Schema, Struct, Transform, Type, UnboundPartitionSpec,
+    };
+    use crate::table::Table;
+    use crate::transaction::{ApplyTransactionAction, Transaction};
+    use crate::{NamespaceIdent, TableCreation, TableIdent};
+
+    fn simple_schema() -> Schema {
+        Schema::builder()
+            .with_schema_id(0)
+            .with_identifier_field_ids(vec![1])
+            .with_fields(vec![
+                NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
+                NestedField::optional(2, "name", Type::Primitive(PrimitiveType::String)).into(),
+            ])
+            .build()
+            .unwrap()
+    }
+
+    async fn create_test_table(
+        catalog: &Arc<dyn Catalog>,
+        table_name: &str,
+    ) -> (TableIdent, Table) {
+        let ns = NamespaceIdent::new("test_ns".into());
+        catalog.create_namespace(&ns, HashMap::new()).await.ok();
+
+        let table_ident = TableIdent::new(ns, table_name.to_string());
+        let table_creation = TableCreation::builder()
+            .name(table_ident.name().into())
+            .schema(simple_schema())
+            .build();
+
+        catalog
+            .create_table(&table_ident.namespace, table_creation)
+            .await
+            .unwrap();
+
+        let table = catalog.load_table(&table_ident).await.unwrap();
+        (table_ident, table)
+    }
+
+    async fn commit_data_file(catalog: &Arc<dyn Catalog>, table: &Table, file_path: &str) -> Table {
+        let data_file = DataFileBuilder::default()
+            .content(DataContentType::Data)
+            .file_path(file_path.to_string())
+            .file_format(DataFileFormat::Parquet)
+            .record_count(1)
+            .file_size_in_bytes(100)
+            .build()
+            .unwrap();
+
+        let txn = Transaction::new(table);
+        let action = txn
+            .rewrite_files()
+            .add_data_files(vec![data_file])
+            .set_target_branch(MAIN_BRANCH.to_string());
+        let txn = action.apply(txn).unwrap();
+        txn.commit(catalog.as_ref()).await.unwrap()
+    }
+
+    /// Creates a table partitioned by `id` (identity transform), so that data
+    /// and delete files can be placed into distinct partitions.
+    async fn create_partitioned_table(
+        catalog: &Arc<dyn Catalog>,
+        table_name: &str,
+    ) -> (TableIdent, Table) {
+        let ns = NamespaceIdent::new("test_ns".into());
+        catalog.create_namespace(&ns, HashMap::new()).await.ok();
+
+        let partition_spec = UnboundPartitionSpec::builder()
+            .with_spec_id(0)
+            .add_partition_field(1, "id".to_string(), Transform::Identity)
+            .unwrap()
+            .build();
+
+        let table_ident = TableIdent::new(ns, table_name.to_string());
+        let table_creation = TableCreation::builder()
+            .name(table_ident.name().into())
+            .schema(simple_schema())
+            .partition_spec(partition_spec)
+            .build();
+
+        catalog
+            .create_table(&table_ident.namespace, table_creation)
+            .await
+            .unwrap();
+
+        let table = catalog.load_table(&table_ident).await.unwrap();
+        (table_ident, table)
+    }
+
+    /// Commits a single file (data or delete) into the given identity partition.
+    async fn commit_partitioned_file(
+        catalog: &Arc<dyn Catalog>,
+        table: &Table,
+        file_path: &str,
+        content: DataContentType,
+        partition_val: i32,
+    ) -> Table {
+        let spec_id = table.metadata().default_partition_spec_id();
+        let mut builder = DataFileBuilder::default();
+        builder
+            .content(content)
+            .file_path(file_path.to_string())
+            .file_format(DataFileFormat::Parquet)
+            .record_count(1)
+            .file_size_in_bytes(100)
+            .partition_spec_id(spec_id)
+            .partition(Struct::from_iter([Some(Literal::int(partition_val))]));
+        if content == DataContentType::EqualityDeletes {
+            builder.equality_ids(Some(vec![1]));
+        }
+        let data_file = builder.build().unwrap();
+
+        let txn = Transaction::new(table);
+        let action = txn
+            .rewrite_files()
+            .add_data_files(vec![data_file])
+            .set_target_branch(MAIN_BRANCH.to_string());
+        let txn = action.apply(txn).unwrap();
+        txn.commit(catalog.as_ref()).await.unwrap()
+    }
+
+    /// Returns whether a live delete-file entry with the given path exists in
+    /// the table's current snapshot.
+    async fn delete_file_is_live(table: &Table, file_path: &str) -> bool {
+        let snapshot = table.metadata().current_snapshot().unwrap();
+        let manifest_list = snapshot
+            .load_manifest_list(table.file_io(), table.metadata())
+            .await
+            .unwrap();
+        for mf in manifest_list.entries() {
+            let manifest = mf.load_manifest(table.file_io()).await.unwrap();
+            for entry in manifest.entries() {
+                if entry.is_alive() && entry.data_file().file_path() == file_path {
+                    return true;
+                }
+            }
+        }
+        false
+    }
+
+    async fn build_catalog() -> Arc<dyn Catalog> {
+        let warehouse = "memory://test/";
+        let catalog = MemoryCatalogBuilder::default()
+            .load(
+                "memory",
+                HashMap::from([(MEMORY_CATALOG_WAREHOUSE.to_string(), warehouse.to_string())]),
+            )
+            .await
+            .unwrap();
+        Arc::new(catalog)
+    }
+
+    #[tokio::test]
+    async fn test_remove_dangling_delete_files() {
+        let catalog = build_catalog().await;
+        let (table_ident, table) = create_test_table(&catalog, "test_dangling").await;
+        let table = commit_data_file(&catalog, &table, "memory://test/data-1.parquet").await;
+
+        let pos_delete = DataFileBuilder::default()
+            .content(DataContentType::PositionDeletes)
+            .file_path("memory://test/pos-del-1.parquet".to_string())
+            .file_format(DataFileFormat::Parquet)
+            .record_count(1)
+            .file_size_in_bytes(100)
+            .referenced_data_file(Some("memory://test/nonexistent.parquet".to_string()))
+            .build()
+            .unwrap();
+
+        let txn = Transaction::new(&table);
+        let action = txn
+            .rewrite_files()
+            .add_data_files(vec![pos_delete])
+            .set_target_branch(MAIN_BRANCH.to_string());
+        let txn = action.apply(txn).unwrap();
+        txn.commit(catalog.as_ref()).await.unwrap();
+
+        let removed = RemoveDanglingDeleteFilesAction::new(catalog.clone(), table_ident)
+            .execute()
+            .await
+            .unwrap();
+        assert_eq!(removed, 1);
+    }
+
+    #[tokio::test]
+    async fn test_remove_dangling_delete_files_none_when_referenced() {
+        let catalog = build_catalog().await;
+        let (table_ident, table) = create_test_table(&catalog, "test_referenced").await;
+
+        let data_file_path = "memory://test/data-1.parquet";
+        let table = commit_data_file(&catalog, &table, data_file_path).await;
+
+        let pos_delete = DataFileBuilder::default()
+            .content(DataContentType::PositionDeletes)
+            .file_path("memory://test/pos-del-1.parquet".to_string())
+            .file_format(DataFileFormat::Parquet)
+            .record_count(1)
+            .file_size_in_bytes(100)
+            .referenced_data_file(Some(data_file_path.to_string()))
+            .build()
+            .unwrap();
+
+        let txn = Transaction::new(&table);
+        let action = txn
+            .rewrite_files()
+            .add_data_files(vec![pos_delete])
+            .set_target_branch(MAIN_BRANCH.to_string());
+        let txn = action.apply(txn).unwrap();
+        txn.commit(catalog.as_ref()).await.unwrap();
+
+        let removed = RemoveDanglingDeleteFilesAction::new(catalog.clone(), table_ident)
+            .execute()
+            .await
+            .unwrap();
+        assert_eq!(removed, 0);
+    }
+
+    #[tokio::test]
+    async fn test_remove_dangling_equality_delete() {
+        let catalog = build_catalog().await;
+        let (table_ident, table) = create_test_table(&catalog, "test_eq_dangling").await;
+
+        // Commit equality delete first → gets lower sequence number
+        let eq_delete = DataFileBuilder::default()
+            .content(DataContentType::EqualityDeletes)
+            .file_path("memory://test/eq-del-1.parquet".to_string())
+            .file_format(DataFileFormat::Parquet)
+            .record_count(1)
+            .file_size_in_bytes(100)
+            .equality_ids(Some(vec![1]))
+            .build()
+            .unwrap();
+
+        let txn = Transaction::new(&table);
+        let action = txn
+            .rewrite_files()
+            .add_data_files(vec![eq_delete])
+            .set_target_branch(MAIN_BRANCH.to_string());
+        let txn = action.apply(txn).unwrap();
+        let table = txn.commit(catalog.as_ref()).await.unwrap();
+
+        // Commit data file second → gets higher sequence number.
+        // The equality delete at lower seq applies to files with seq < its seq.
+        // All data files have higher seq, so the equality delete is dangling.
+        let _table = commit_data_file(&catalog, &table, "memory://test/data-1.parquet").await;
+
+        let removed = RemoveDanglingDeleteFilesAction::new(catalog.clone(), table_ident)
+            .execute()
+            .await
+            .unwrap();
+        assert_eq!(removed, 1);
+    }
+
+    #[tokio::test]
+    async fn test_keep_equality_delete_when_data_has_lower_seq() {
+        let catalog = build_catalog().await;
+        let (table_ident, table) = create_test_table(&catalog, "test_eq_kept").await;
+
+        // Commit data file first → gets lower sequence number
+        let table = commit_data_file(&catalog, &table, "memory://test/data-1.parquet").await;
+
+        // Commit equality delete second → gets higher sequence number.
+        // The equality delete at higher seq applies to the data file at lower seq.
+        let eq_delete = DataFileBuilder::default()
+            .content(DataContentType::EqualityDeletes)
+            .file_path("memory://test/eq-del-1.parquet".to_string())
+            .file_format(DataFileFormat::Parquet)
+            .record_count(1)
+            .file_size_in_bytes(100)
+            .equality_ids(Some(vec![1]))
+            .build()
+            .unwrap();
+
+        let txn = Transaction::new(&table);
+        let action = txn
+            .rewrite_files()
+            .add_data_files(vec![eq_delete])
+            .set_target_branch(MAIN_BRANCH.to_string());
+        let txn = action.apply(txn).unwrap();
+        txn.commit(catalog.as_ref()).await.unwrap();
+
+        let removed = RemoveDanglingDeleteFilesAction::new(catalog.clone(), table_ident)
+            .execute()
+            .await
+            .unwrap();
+        assert_eq!(removed, 0);
+    }
+
+    #[tokio::test]
+    async fn test_position_delete_without_ref_removed_by_seq() {
+        let catalog = build_catalog().await;
+        let (table_ident, table) = create_test_table(&catalog, "test_pos_seq").await;
+
+        let pos_delete = DataFileBuilder::default()
+            .content(DataContentType::PositionDeletes)
+            .file_path("memory://test/pos-del-1.parquet".to_string())
+            .file_format(DataFileFormat::Parquet)
+            .record_count(1)
+            .file_size_in_bytes(100)
+            .build()
+            .unwrap();
+
+        let txn = Transaction::new(&table);
+        let action = txn
+            .rewrite_files()
+            .add_data_files(vec![pos_delete])
+            .set_target_branch(MAIN_BRANCH.to_string());
+        let txn = action.apply(txn).unwrap();
+        let table = txn.commit(catalog.as_ref()).await.unwrap();
+
+        let _ = commit_data_file(&catalog, &table, "memory://test/data-1.parquet").await;
+
+        let removed = RemoveDanglingDeleteFilesAction::new(catalog.clone(), table_ident)
+            .execute()
+            .await
+            .unwrap();
+        assert_eq!(removed, 1);
+    }
+
+    #[tokio::test]
+    async fn test_position_delete_without_ref_kept_by_seq() {
+        let catalog = build_catalog().await;
+        let (table_ident, table) = create_test_table(&catalog, "test_pos_seq_kept").await;
+
+        let table = commit_data_file(&catalog, &table, "memory://test/data-1.parquet").await;
+
+        let pos_delete = DataFileBuilder::default()
+            .content(DataContentType::PositionDeletes)
+            .file_path("memory://test/pos-del-1.parquet".to_string())
+            .file_format(DataFileFormat::Parquet)
+            .record_count(1)
+            .file_size_in_bytes(100)
+            .build()
+            .unwrap();
+
+        let txn = Transaction::new(&table);
+        let action = txn
+            .rewrite_files()
+            .add_data_files(vec![pos_delete])
+            .set_target_branch(MAIN_BRANCH.to_string());
+        let txn = action.apply(txn).unwrap();
+        txn.commit(catalog.as_ref()).await.unwrap();
+
+        let removed = RemoveDanglingDeleteFilesAction::new(catalog.clone(), table_ident)
+            .execute()
+            .await
+            .unwrap();
+        assert_eq!(removed, 0);
+    }
+
+    #[tokio::test]
+    async fn test_remove_global_equality_delete() {
+        let catalog = build_catalog().await;
+        let (table_ident, table) = create_test_table(&catalog, "test_global_eq").await;
+
+        let eq_delete = DataFileBuilder::default()
+            .content(DataContentType::EqualityDeletes)
+            .file_path("memory://test/eq-del-1.parquet".to_string())
+            .file_format(DataFileFormat::Parquet)
+            .record_count(1)
+            .file_size_in_bytes(100)
+            .equality_ids(Some(vec![1]))
+            .build()
+            .unwrap();
+
+        let txn = Transaction::new(&table);
+        let action = txn
+            .rewrite_files()
+            .add_data_files(vec![eq_delete])
+            .set_target_branch(MAIN_BRANCH.to_string());
+        let txn = action.apply(txn).unwrap();
+        let table = txn.commit(catalog.as_ref()).await.unwrap();
+
+        let _ = commit_data_file(&catalog, &table, "memory://test/data-1.parquet").await;
+
+        let removed = RemoveDanglingDeleteFilesAction::new(catalog.clone(), table_ident)
+            .execute()
+            .await
+            .unwrap();
+        assert_eq!(removed, 1);
+    }
+
+    #[tokio::test]
+    async fn test_partial_delete_manifest_removes_dangling_only() {
+        let catalog = build_catalog().await;
+        let (table_ident, table) = create_test_table(&catalog, "test_partial").await;
+
+        let data_file_path = "memory://test/data-1.parquet";
+        let table = commit_data_file(&catalog, &table, data_file_path).await;
+
+        let dangling = DataFileBuilder::default()
+            .content(DataContentType::PositionDeletes)
+            .file_path("memory://test/dangling.parquet".to_string())
+            .file_format(DataFileFormat::Parquet)
+            .record_count(1)
+            .file_size_in_bytes(100)
+            .referenced_data_file(Some("memory://test/nonexistent.parquet".to_string()))
+            .build()
+            .unwrap();
+
+        let kept = DataFileBuilder::default()
+            .content(DataContentType::PositionDeletes)
+            .file_path("memory://test/kept.parquet".to_string())
+            .file_format(DataFileFormat::Parquet)
+            .record_count(1)
+            .file_size_in_bytes(100)
+            .referenced_data_file(Some(data_file_path.to_string()))
+            .build()
+            .unwrap();
+
+        let txn = Transaction::new(&table);
+        let action = txn
+            .rewrite_files()
+            .add_data_files(vec![dangling, kept])
+            .set_target_branch(MAIN_BRANCH.to_string());
+        let txn = action.apply(txn).unwrap();
+        txn.commit(catalog.as_ref()).await.unwrap();
+
+        let removed = RemoveDanglingDeleteFilesAction::new(catalog.clone(), table_ident.clone())
+            .execute()
+            .await
+            .unwrap();
+        assert_eq!(removed, 1);
+
+        let table = catalog.load_table(&table_ident).await.unwrap();
+        let snapshot = table.metadata().current_snapshot().unwrap();
+        let manifest_list = snapshot
+            .load_manifest_list(table.file_io(), table.metadata())
+            .await
+            .unwrap();
+
+        let mut found_kept = false;
+        let mut found_dangling = false;
+        for mf in manifest_list.entries() {
+            let manifest = mf.load_manifest(table.file_io()).await.unwrap();
+            for entry in manifest.entries() {
+                if !entry.is_alive() {
+                    continue;
+                }
+                let path = entry.data_file().file_path();
+                if path == "memory://test/kept.parquet" {
+                    found_kept = true;
+                }
+                if path == "memory://test/dangling.parquet" {
+                    found_dangling = true;
+                }
+            }
+        }
+        assert!(found_kept, "kept delete should still be live");
+        assert!(!found_dangling, "dangling delete should be removed");
+    }
+
+    /// Equality deletes are isolated per partition: a delete is dangling only
+    /// when its sequence number is <= the minimum data sequence number *within
+    /// its own partition*.
+    ///
+    /// The commit ordering is chosen so the result diverges from a naive
+    /// global-minimum implementation: the dangling delete (`eq-p2`, seq 3)
+    /// sits in partition 2 whose min data seq is 4, but the global min data
+    /// seq is 1 (from partition 1). Correct per-partition logic removes it
+    /// (3 <= 4); a global-min implementation would wrongly keep it (3 > 1).
+    /// `eq-p1` is kept under both, proving cross-partition isolation.
+    ///
+    /// This exercises the partitioned branch of the equality-delete filter,
+    /// which the unpartitioned tests never reach.
+    #[tokio::test]
+    async fn test_partitioned_equality_delete_isolated_per_partition() {
+        let catalog = build_catalog().await;
+        let (table_ident, table) = create_partitioned_table(&catalog, "test_part_eq").await;
+
+        // seq 1: data in p1 (sets global min data seq to 1, p1 min to 1).
+        let table = commit_partitioned_file(
+            &catalog,
+            &table,
+            "memory://test/data-p1.parquet",
+            DataContentType::Data,
+            1,
+        )
+        .await;
+        // seq 2: eq delete in p1. min_data_seq(p1) = 1, 2 <= 1 is false -> kept.
+        let table = commit_partitioned_file(
+            &catalog,
+            &table,
+            "memory://test/eq-p1.parquet",
+            DataContentType::EqualityDeletes,
+            1,
+        )
+        .await;
+        // seq 3: eq delete in p2 (the discriminating file).
+        let table = commit_partitioned_file(
+            &catalog,
+            &table,
+            "memory://test/eq-p2.parquet",
+            DataContentType::EqualityDeletes,
+            2,
+        )
+        .await;
+        // seq 4: data in p2. min_data_seq(p2) = 4, eq-p2 seq 3 <= 4 -> dangling.
+        let _table = commit_partitioned_file(
+            &catalog,
+            &table,
+            "memory://test/data-p2.parquet",
+            DataContentType::Data,
+            2,
+        )
+        .await;
+
+        let removed = RemoveDanglingDeleteFilesAction::new(catalog.clone(), table_ident.clone())
+            .execute()
+            .await
+            .unwrap();
+        assert_eq!(
+            removed, 1,
+            "only the partition-2 equality delete is dangling"
+        );
+
+        let table = catalog.load_table(&table_ident).await.unwrap();
+        assert!(
+            delete_file_is_live(&table, "memory://test/eq-p1.parquet").await,
+            "partition-1 equality delete should be kept"
+        );
+        assert!(
+            !delete_file_is_live(&table, "memory://test/eq-p2.parquet").await,
+            "partition-2 equality delete should be removed"
+        );
+    }
+
+    /// Position deletes without a `referenced_data_file` fall back to the
+    /// sequence-based, per-partition check (dangling when seq < min data seq in
+    /// the same partition).
+    ///
+    /// As with the equality test, ordering is chosen to diverge from a naive
+    /// global minimum: the dangling delete (`pos-p2`, seq 3) is in partition 2
+    /// (min data seq 4) while the global min is 1. Correct per-partition logic
+    /// removes it (3 < 4); a global-min implementation keeps it (3 > 1).
+    #[tokio::test]
+    async fn test_partitioned_position_delete_isolated_per_partition() {
+        let catalog = build_catalog().await;
+        let (table_ident, table) = create_partitioned_table(&catalog, "test_part_pos").await;
+
+        // seq 1: data in p1 (global min = 1, p1 min = 1).
+        let table = commit_partitioned_file(
+            &catalog,
+            &table,
+            "memory://test/data-p1.parquet",
+            DataContentType::Data,
+            1,
+        )
+        .await;
+        // seq 2: pos delete in p1. min_data_seq(p1) = 1, 2 < 1 is false -> kept.
+        let table = commit_partitioned_file(
+            &catalog,
+            &table,
+            "memory://test/pos-p1.parquet",
+            DataContentType::PositionDeletes,
+            1,
+        )
+        .await;
+        // seq 3: pos delete in p2 (the discriminating file).
+        let table = commit_partitioned_file(
+            &catalog,
+            &table,
+            "memory://test/pos-p2.parquet",
+            DataContentType::PositionDeletes,
+            2,
+        )
+        .await;
+        // seq 4: data in p2. min_data_seq(p2) = 4, pos-p2 seq 3 < 4 -> dangling.
+        let _table = commit_partitioned_file(
+            &catalog,
+            &table,
+            "memory://test/data-p2.parquet",
+            DataContentType::Data,
+            2,
+        )
+        .await;
+
+        let removed = RemoveDanglingDeleteFilesAction::new(catalog.clone(), table_ident.clone())
+            .execute()
+            .await
+            .unwrap();
+        assert_eq!(
+            removed, 1,
+            "only the partition-2 position delete is dangling"
+        );
+
+        let table = catalog.load_table(&table_ident).await.unwrap();
+        assert!(
+            delete_file_is_live(&table, "memory://test/pos-p1.parquet").await,
+            "partition-1 position delete should be kept"
+        );
+        assert!(
+            !delete_file_is_live(&table, "memory://test/pos-p2.parquet").await,
+            "partition-2 position delete should be removed"
+        );
+    }
+}

--- a/crates/iceberg/src/actions/remove_dangling_delete_files.rs
+++ b/crates/iceberg/src/actions/remove_dangling_delete_files.rs
@@ -145,7 +145,7 @@ impl RemoveDanglingDeleteFilesAction {
                         let key = (df.partition_spec_id(), df.partition().clone());
                         partition_min_seq
                             .get(&key)
-                            .map_or(true, |&min_seq| *s < min_seq)
+                            .is_none_or(|&min_seq| *s < min_seq)
                     } else {
                         // No referenced_data_file and no sequence number — cannot determine
                         false
@@ -162,12 +162,12 @@ impl RemoveDanglingDeleteFilesAction {
                         // Unpartitioned equality deletes are global — they apply to all
                         // data files regardless of partition. Only remove if seq is <=
                         // the global minimum data sequence number.
-                        global_min_data_seq.map_or(true, |g| *seq <= g)
+                        global_min_data_seq.is_none_or(|g| *seq <= g)
                     } else {
                         let key = (df.partition_spec_id(), df.partition().clone());
                         partition_min_seq
                             .get(&key)
-                            .map_or(true, |&min_seq| *seq <= min_seq)
+                            .is_none_or(|&min_seq| *seq <= min_seq)
                     }
                 })
                 .map(|(df, _)| df),

--- a/crates/iceberg/src/actions/remove_dangling_delete_files.rs
+++ b/crates/iceberg/src/actions/remove_dangling_delete_files.rs
@@ -25,9 +25,10 @@
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
+use crate::delete_file_index::try_infer_single_referenced_data_file_from_bounds;
 use crate::spec::{DataContentType, DataFile, MAIN_BRANCH, Struct};
 use crate::transaction::{ApplyTransactionAction, Transaction};
-use crate::utils::{DEFAULT_LOAD_CONCURRENCY_LIMIT, for_each_manifest};
+use crate::utils::{DEFAULT_LOAD_CONCURRENCY_LIMIT, delete_file_key, for_each_manifest};
 use crate::{Catalog, Error, ErrorKind, Result, TableIdent};
 
 /// Action to remove dangling delete files from a table.
@@ -138,6 +139,13 @@ impl RemoveDanglingDeleteFilesAction {
                     if let Some(ref_path) = df.referenced_data_file() {
                         // Path-based: dangling if the referenced data file no longer exists
                         !data_file_paths.contains(&ref_path)
+                    } else if let Some(inferred_path) =
+                        try_infer_single_referenced_data_file_from_bounds(df)
+                    {
+                        // V2 position deletes may omit `referenced_data_file` while their
+                        // `file_path` column's lower/upper bounds still prove a single
+                        // target (the same heuristic the reader uses to scope deletes).
+                        !data_file_paths.contains(&inferred_path)
                     } else if let Some(s) = df_seq {
                         // Sequence-based: dangling if seq < min_data_seq in this partition
                         let key = (df.partition_spec_id(), df.partition().clone());
@@ -171,8 +179,12 @@ impl RemoveDanglingDeleteFilesAction {
                 .map(|(df, _)| df),
         );
 
-        let mut seen: HashSet<String> = HashSet::new();
-        dangling.retain(|df| seen.insert(df.file_path().to_string()));
+        // Dedup by `(file_path, content_offset, content_size_in_bytes)`, not
+        // `file_path` alone: several deletion vectors can share one Puffin
+        // file, so a path-only key would collapse a dangling DV and a
+        // still-live DV in the same file into one entry.
+        let mut seen = HashSet::new();
+        dangling.retain(|df| seen.insert(delete_file_key(df)));
 
         if dangling.is_empty() {
             return Ok(0);
@@ -343,6 +355,28 @@ mod tests {
             let manifest = mf.load_manifest(table.file_io()).await.unwrap();
             for entry in manifest.entries() {
                 if entry.is_alive() && entry.data_file().file_path() == file_path {
+                    return true;
+                }
+            }
+        }
+        false
+    }
+
+    /// Like [`delete_file_is_live`], but also matches on `content_offset` — the
+    /// identity of a specific deletion-vector blob within a shared Puffin file.
+    async fn dv_entry_is_live(table: &Table, file_path: &str, content_offset: i64) -> bool {
+        let snapshot = table.metadata().current_snapshot().unwrap();
+        let manifest_list = snapshot
+            .load_manifest_list(table.file_io(), table.metadata())
+            .await
+            .unwrap();
+        for mf in manifest_list.entries() {
+            let manifest = mf.load_manifest(table.file_io()).await.unwrap();
+            for entry in manifest.entries() {
+                if entry.is_alive()
+                    && entry.data_file().file_path() == file_path
+                    && entry.data_file().content_offset() == Some(content_offset)
+                {
                     return true;
                 }
             }
@@ -803,6 +837,211 @@ mod tests {
         assert!(
             !delete_file_is_live(&table, "memory://test/pos-p2.parquet").await,
             "partition-2 position delete should be removed"
+        );
+    }
+
+    /// Iceberg identifies a deletion-vector blob by
+    /// `(file_path, content_offset, content_size_in_bytes)`, because several DVs
+    /// can share one physical Puffin file. A dangling DV for one data file must
+    /// not drop a still-live DV for another data file that happens to share the
+    /// same Puffin `file_path`.
+    #[tokio::test]
+    async fn test_shared_puffin_file_keeps_live_dv_removes_dangling_dv() {
+        let catalog = build_catalog().await;
+        let (table_ident, table) = create_test_table(&catalog, "test_shared_puffin").await;
+
+        let live_data_path = "memory://test/data-a.parquet";
+        let table = commit_data_file(&catalog, &table, live_data_path).await;
+
+        let shared_puffin_path = "memory://test/shared.puffin";
+
+        let live_dv = DataFileBuilder::default()
+            .content(DataContentType::PositionDeletes)
+            .file_path(shared_puffin_path.to_string())
+            .file_format(DataFileFormat::Puffin)
+            .record_count(1)
+            .file_size_in_bytes(200)
+            .referenced_data_file(Some(live_data_path.to_string()))
+            .content_offset(Some(4))
+            .content_size_in_bytes(Some(64))
+            .build()
+            .unwrap();
+
+        let dangling_dv = DataFileBuilder::default()
+            .content(DataContentType::PositionDeletes)
+            .file_path(shared_puffin_path.to_string())
+            .file_format(DataFileFormat::Puffin)
+            .record_count(1)
+            .file_size_in_bytes(200)
+            .referenced_data_file(Some("memory://test/nonexistent.parquet".to_string()))
+            .content_offset(Some(200))
+            .content_size_in_bytes(Some(64))
+            .build()
+            .unwrap();
+
+        let txn = Transaction::new(&table);
+        let action = txn
+            .rewrite_files()
+            .add_data_files(vec![live_dv, dangling_dv])
+            .set_target_branch(MAIN_BRANCH.to_string());
+        let txn = action.apply(txn).unwrap();
+        txn.commit(catalog.as_ref()).await.unwrap();
+
+        let removed = RemoveDanglingDeleteFilesAction::new(catalog.clone(), table_ident.clone())
+            .execute()
+            .await
+            .unwrap();
+        assert_eq!(removed, 1, "only the dangling DV blob should be removed");
+
+        let table = catalog.load_table(&table_ident).await.unwrap();
+        assert!(
+            dv_entry_is_live(&table, shared_puffin_path, 4).await,
+            "the live DV blob sharing the Puffin file must survive"
+        );
+        assert!(
+            !dv_entry_is_live(&table, shared_puffin_path, 200).await,
+            "the dangling DV blob should be removed"
+        );
+    }
+
+    /// Two *dangling* DVs sharing one Puffin file must both be identified and
+    /// removed as distinct entries. Before deduping by identity instead of
+    /// path, the scan would collapse them into a single `DataFile`, so only
+    /// one of the two manifest entries would end up in the removal set —
+    /// leaving the other to survive even though it is dangling too.
+    #[tokio::test]
+    async fn test_shared_puffin_file_removes_both_dangling_dvs() {
+        let catalog = build_catalog().await;
+        let (table_ident, table) = create_test_table(&catalog, "test_shared_puffin_both").await;
+
+        let shared_puffin_path = "memory://test/shared.puffin";
+
+        let dangling_dv_a = DataFileBuilder::default()
+            .content(DataContentType::PositionDeletes)
+            .file_path(shared_puffin_path.to_string())
+            .file_format(DataFileFormat::Puffin)
+            .record_count(1)
+            .file_size_in_bytes(200)
+            .referenced_data_file(Some("memory://test/nonexistent-a.parquet".to_string()))
+            .content_offset(Some(4))
+            .content_size_in_bytes(Some(64))
+            .build()
+            .unwrap();
+
+        let dangling_dv_b = DataFileBuilder::default()
+            .content(DataContentType::PositionDeletes)
+            .file_path(shared_puffin_path.to_string())
+            .file_format(DataFileFormat::Puffin)
+            .record_count(1)
+            .file_size_in_bytes(200)
+            .referenced_data_file(Some("memory://test/nonexistent-b.parquet".to_string()))
+            .content_offset(Some(200))
+            .content_size_in_bytes(Some(64))
+            .build()
+            .unwrap();
+
+        let txn = Transaction::new(&table);
+        let action = txn
+            .rewrite_files()
+            .add_data_files(vec![dangling_dv_a, dangling_dv_b])
+            .set_target_branch(MAIN_BRANCH.to_string());
+        let txn = action.apply(txn).unwrap();
+        txn.commit(catalog.as_ref()).await.unwrap();
+
+        let removed = RemoveDanglingDeleteFilesAction::new(catalog.clone(), table_ident.clone())
+            .execute()
+            .await
+            .unwrap();
+        assert_eq!(
+            removed, 2,
+            "both dangling DV blobs must be counted and removed, not collapsed into one"
+        );
+
+        let table = catalog.load_table(&table_ident).await.unwrap();
+        assert!(
+            !dv_entry_is_live(&table, shared_puffin_path, 4).await,
+            "dangling DV blob A should be removed"
+        );
+        assert!(
+            !dv_entry_is_live(&table, shared_puffin_path, 200).await,
+            "dangling DV blob B should be removed"
+        );
+    }
+
+    /// V2 position deletes may omit `referenced_data_file` while their
+    /// `file_path` column's lower/upper bounds still prove a single target (the
+    /// same heuristic the reader uses, see `delete_file_index`). A delete
+    /// scoped this way to an already-removed data file is provably dangling
+    /// even when a partition-wide sequence check alone would keep it, because
+    /// another still-live data file with a lower sequence number sits in the
+    /// same partition.
+    #[tokio::test]
+    async fn test_position_delete_without_ref_removed_by_bounds_inference() {
+        use crate::delete_file_index::FIELD_ID_POSITIONAL_DELETE_FILE_PATH;
+        use crate::spec::Datum;
+
+        let catalog = build_catalog().await;
+        let (table_ident, table) = create_partitioned_table(&catalog, "test_pos_bounds").await;
+
+        // seq 1: data-a in partition 1, stays alive with the lowest sequence
+        // number in the partition.
+        let table = commit_partitioned_file(
+            &catalog,
+            &table,
+            "memory://test/data-a.parquet",
+            DataContentType::Data,
+            1,
+        )
+        .await;
+
+        // seq 2: position delete in partition 1 whose bounds prove it targets
+        // only "nonexistent-data-b.parquet" (a data file that was already
+        // compacted away and never re-appears). Its sequence (2) is not below
+        // the partition's min data sequence (1), so a sequence-only check
+        // would wrongly keep it.
+        let target_path = "memory://test/nonexistent-data-b.parquet";
+        let spec_id = table.metadata().default_partition_spec_id();
+        let pos_delete = DataFileBuilder::default()
+            .content(DataContentType::PositionDeletes)
+            .file_path("memory://test/pos-bounds.parquet".to_string())
+            .file_format(DataFileFormat::Parquet)
+            .record_count(1)
+            .file_size_in_bytes(100)
+            .partition_spec_id(spec_id)
+            .partition(Struct::from_iter([Some(Literal::int(1))]))
+            .lower_bounds(HashMap::from([(
+                FIELD_ID_POSITIONAL_DELETE_FILE_PATH,
+                Datum::string(target_path),
+            )]))
+            .upper_bounds(HashMap::from([(
+                FIELD_ID_POSITIONAL_DELETE_FILE_PATH,
+                Datum::string(target_path),
+            )]))
+            .build()
+            .unwrap();
+
+        let txn = Transaction::new(&table);
+        let action = txn
+            .rewrite_files()
+            .add_data_files(vec![pos_delete])
+            .set_target_branch(MAIN_BRANCH.to_string());
+        let txn = action.apply(txn).unwrap();
+        txn.commit(catalog.as_ref()).await.unwrap();
+
+        let removed = RemoveDanglingDeleteFilesAction::new(catalog.clone(), table_ident.clone())
+            .execute()
+            .await
+            .unwrap();
+        assert_eq!(
+            removed, 1,
+            "bounds prove the delete targets an already-removed data file, so it is dangling \
+             even though the partition-wide sequence check alone would keep it"
+        );
+
+        let table = catalog.load_table(&table_ident).await.unwrap();
+        assert!(
+            !delete_file_is_live(&table, "memory://test/pos-bounds.parquet").await,
+            "the bounds-scoped dangling position delete should be removed"
         );
     }
 }

--- a/crates/iceberg/src/actions/remove_dangling_delete_files.rs
+++ b/crates/iceberg/src/actions/remove_dangling_delete_files.rs
@@ -25,11 +25,14 @@
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
+use async_trait::async_trait;
+
 use crate::delete_file_index::try_infer_single_referenced_data_file_from_bounds;
 use crate::spec::{DataContentType, DataFile, MAIN_BRANCH, Struct};
-use crate::transaction::{ApplyTransactionAction, Transaction};
+use crate::table::Table;
+use crate::transaction::{ActionCommit, ApplyTransactionAction, Transaction, TransactionAction};
 use crate::utils::{DEFAULT_LOAD_CONCURRENCY_LIMIT, delete_file_key, for_each_manifest};
-use crate::{Catalog, Error, ErrorKind, Result, TableIdent};
+use crate::{Catalog, Error, ErrorKind, Result, TableIdent, TableRequirement};
 
 /// Action to remove dangling delete files from a table.
 ///
@@ -193,6 +196,23 @@ impl RemoveDanglingDeleteFilesAction {
         let dangling_count = dangling.len();
         let txn = Transaction::new(&table);
         let branch = self.to_branch.clone();
+
+        // Fail the whole commit if `branch` has moved since the snapshot we just
+        // scanned, instead of silently re-applying our dangling-file decision
+        // against a structurally different (refreshed) snapshot. See
+        // `RequireScannedSnapshotAction` for why this must be the first action applied.
+        let txn = RequireScannedSnapshotAction {
+            branch: branch.clone(),
+            snapshot_id: snapshot.snapshot_id(),
+        }
+        .apply(txn)
+        .map_err(|e| {
+            Error::new(
+                ErrorKind::Unexpected,
+                format!("Failed to build snapshot-guard action: {e}"),
+            )
+        })?;
+
         let action = txn
             .rewrite_files()
             .delete_files(dangling)
@@ -211,12 +231,45 @@ impl RemoveDanglingDeleteFilesAction {
     }
 }
 
+/// A no-op [`TransactionAction`] that only carries a [`TableRequirement`]: `branch` must
+/// still point at `snapshot_id` at commit time.
+///
+/// [`Transaction::commit`] unconditionally refreshes to the table's latest state on
+/// every attempt (not just retries) before re-applying its actions. Without this guard,
+/// a dangling-file decision computed against the snapshot scanned by
+/// [`RemoveDanglingDeleteFilesAction::execute`] could silently be replayed against a
+/// newer, structurally different snapshot — e.g. one where a concurrent commit made a
+/// previously-dangling delete applicable again. Chaining this action turns that into a
+/// hard, retryable-but-never-silent commit failure instead: the caller must re-invoke
+/// `execute()` to rescan.
+///
+/// This must be applied to the transaction *before* the real rewrite action: requirement
+/// checks run against the table state accumulated from all earlier actions in the same
+/// commit, so if this ran after the rewrite, it would be checking against the branch
+/// pointer the rewrite itself just moved (which never equals the scanned snapshot id).
+struct RequireScannedSnapshotAction {
+    branch: String,
+    snapshot_id: i64,
+}
+
+#[async_trait]
+impl TransactionAction for RequireScannedSnapshotAction {
+    async fn commit(self: Arc<Self>, _table: &Table) -> Result<ActionCommit> {
+        Ok(ActionCommit::new(vec![], vec![
+            TableRequirement::RefSnapshotIdMatch {
+                r#ref: self.branch.clone(),
+                snapshot_id: Some(self.snapshot_id),
+            },
+        ]))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
     use std::sync::Arc;
 
-    use super::RemoveDanglingDeleteFilesAction;
+    use super::{RemoveDanglingDeleteFilesAction, RequireScannedSnapshotAction};
     use crate::catalog::memory::{MEMORY_CATALOG_WAREHOUSE, MemoryCatalogBuilder};
     use crate::catalog::{Catalog, CatalogBuilder};
     use crate::spec::{
@@ -1042,6 +1095,58 @@ mod tests {
         assert!(
             !delete_file_is_live(&table, "memory://test/pos-bounds.parquet").await,
             "the bounds-scoped dangling position delete should be removed"
+        );
+    }
+
+    /// Regression test for review of #168 point 1: a stale scan must not be silently
+    /// replayed against a table that moved concurrently.
+    ///
+    /// `Transaction::commit` unconditionally refreshes to the table's latest state
+    /// before re-applying its actions -- on every attempt, not just retries. Without a
+    /// guard, a dangling-file decision computed against an older snapshot could be
+    /// committed against a newer one where that decision may no longer hold.
+    /// `RequireScannedSnapshotAction` turns this into a hard, immediate commit failure
+    /// instead of a silent misapplication.
+    #[tokio::test]
+    async fn test_stale_scan_fails_instead_of_reapplying() {
+        let catalog = build_catalog().await;
+        let (table_ident, table) = create_test_table(&catalog, "test_stale_scan").await;
+        let table = commit_data_file(&catalog, &table, "memory://test/data-1.parquet").await;
+
+        // Simulate what `execute()` does: load and scan the table at snapshot A.
+        let table_at_scan = catalog.load_table(&table_ident).await.unwrap();
+        let scanned_snapshot_id = table_at_scan
+            .metadata()
+            .current_snapshot()
+            .unwrap()
+            .snapshot_id();
+
+        // A concurrent writer commits on top of the same snapshot A, advancing the
+        // branch to a new snapshot B before our (simulated) commit lands.
+        let _ = commit_data_file(&catalog, &table, "memory://test/data-2.parquet").await;
+
+        // Build a transaction from the now-stale `table_at_scan`, guarded to require
+        // the branch is still at the snapshot we scanned -- exactly what
+        // `RemoveDanglingDeleteFilesAction::execute` does before its rewrite action.
+        let txn = Transaction::new(&table_at_scan);
+        let txn = RequireScannedSnapshotAction {
+            branch: MAIN_BRANCH.to_string(),
+            snapshot_id: scanned_snapshot_id,
+        }
+        .apply(txn)
+        .unwrap();
+
+        let result = txn.commit(catalog.as_ref()).await;
+
+        assert!(
+            result.is_err(),
+            "commit must fail when the branch moved since the scan, not silently succeed \
+             against the newer snapshot"
+        );
+        assert!(
+            result.unwrap_err().retryable(),
+            "the failure should be flagged retryable so callers know a fresh execute() call \
+             (rescan) may succeed"
         );
     }
 }

--- a/crates/iceberg/src/actions/remove_dangling_delete_files.rs
+++ b/crates/iceberg/src/actions/remove_dangling_delete_files.rs
@@ -27,7 +27,7 @@ use std::sync::Arc;
 
 use crate::spec::{DataContentType, DataFile, MAIN_BRANCH, Struct};
 use crate::transaction::{ApplyTransactionAction, Transaction};
-use crate::utils::{DEFAULT_LOAD_CONCURRENCY_LIMIT, load_manifests};
+use crate::utils::{DEFAULT_LOAD_CONCURRENCY_LIMIT, for_each_manifest};
 use crate::{Catalog, Error, ErrorKind, Result, TableIdent};
 
 /// Action to remove dangling delete files from a table.
@@ -89,47 +89,45 @@ impl RemoveDanglingDeleteFilesAction {
         let mut global_min_data_seq: Option<i64> = None;
 
         let manifest_files: Vec<_> = manifest_list.entries().to_vec();
-        let loaded = load_manifests(
+        for_each_manifest(
             table.file_io(),
             manifest_files,
             DEFAULT_LOAD_CONCURRENCY_LIMIT,
+            |_, manifest| {
+                for entry in manifest.entries() {
+                    if !entry.is_alive() {
+                        continue;
+                    }
+
+                    let df = entry.data_file();
+                    let seq = entry.sequence_number();
+
+                    match entry.content_type() {
+                        DataContentType::Data => {
+                            data_file_paths.insert(df.file_path().to_string());
+                            if let Some(s) = seq {
+                                let key = (df.partition_spec_id(), df.partition().clone());
+                                partition_min_seq
+                                    .entry(key)
+                                    .and_modify(|min| *min = (*min).min(s))
+                                    .or_insert(s);
+                                global_min_data_seq =
+                                    Some(global_min_data_seq.map_or(s, |g| g.min(s)));
+                            }
+                        }
+                        DataContentType::PositionDeletes => {
+                            pos_deletes.push((df.clone(), seq));
+                        }
+                        DataContentType::EqualityDeletes => {
+                            if let Some(s) = seq {
+                                eq_deletes.push((df.clone(), s));
+                            }
+                        }
+                    }
+                }
+            },
         )
         .await?;
-
-        for (_, manifest) in loaded {
-            let (entries, _) = manifest.into_parts();
-
-            for entry in entries {
-                if !entry.is_alive() {
-                    continue;
-                }
-
-                let df = entry.data_file();
-                let seq = entry.sequence_number();
-
-                match entry.content_type() {
-                    DataContentType::Data => {
-                        data_file_paths.insert(df.file_path().to_string());
-                        if let Some(s) = seq {
-                            let key = (df.partition_spec_id(), df.partition().clone());
-                            partition_min_seq
-                                .entry(key)
-                                .and_modify(|min| *min = (*min).min(s))
-                                .or_insert(s);
-                            global_min_data_seq = Some(global_min_data_seq.map_or(s, |g| g.min(s)));
-                        }
-                    }
-                    DataContentType::PositionDeletes => {
-                        pos_deletes.push((df.clone(), seq));
-                    }
-                    DataContentType::EqualityDeletes => {
-                        if let Some(s) = seq {
-                            eq_deletes.push((df.clone(), s));
-                        }
-                    }
-                }
-            }
-        }
 
         let mut dangling: Vec<DataFile> = Vec::new();
 

--- a/crates/iceberg/src/delete_file_index.rs
+++ b/crates/iceberg/src/delete_file_index.rs
@@ -31,9 +31,11 @@ use crate::spec::{DataContentType, DataFile, Struct};
 //
 // See Iceberg spec (position deletes) and our `POSITION_DELETE_SCHEMA` in
 // `writer/base_writer/position_delete_file_writer.rs`.
-const FIELD_ID_POSITIONAL_DELETE_FILE_PATH: i32 = 2147483546;
+pub(crate) const FIELD_ID_POSITIONAL_DELETE_FILE_PATH: i32 = 2147483546;
 
-fn try_infer_single_referenced_data_file_from_bounds(delete_file: &DataFile) -> Option<String> {
+pub(crate) fn try_infer_single_referenced_data_file_from_bounds(
+    delete_file: &DataFile,
+) -> Option<String> {
     // Match Iceberg Java's `DeleteFileUtil.referencedDataFile(DeleteFile)` heuristic:
     // if lower and upper bounds for PATH_ID are present and equal, the delete file
     // targets a single data file.

--- a/crates/iceberg/src/spec/manifest/writer.rs
+++ b/crates/iceberg/src/spec/manifest/writer.rs
@@ -420,10 +420,6 @@ impl ManifestWriter {
     /// Add a delete manifest entry. This method will update following status of the entry:
     /// - Update the entry status to `Deleted`
     /// - Set the snapshot id to the current snapshot id
-    ///
-    /// # TODO
-    /// Remove this allow later
-    #[allow(dead_code)]
     pub(crate) fn add_delete_entry(&mut self, mut entry: ManifestEntry) -> Result<()> {
         self.check_data_file(&entry.data_file)?;
         entry.status = ManifestStatus::Deleted;

--- a/crates/iceberg/src/transaction/manifest_filter.rs
+++ b/crates/iceberg/src/transaction/manifest_filter.rs
@@ -28,6 +28,7 @@ use crate::spec::{
     ManifestWriter, ManifestWriterBuilder, PartitionSpec, Schema,
 };
 use crate::transaction::snapshot::new_manifest_path;
+use crate::utils::{DeleteFileKey, delete_file_key};
 use crate::{Error, ErrorKind};
 
 /// Context for creating manifest writers during filtering operations
@@ -107,8 +108,10 @@ impl ManifestWriterContext {
 
 /// Manager for filtering manifest files and handling delete operations
 pub struct ManifestFilterManager {
-    /// Files to be deleted by path
-    files_to_delete: HashMap<String, DataFile>,
+    /// Files to be deleted, keyed by `(file_path, content_offset, content_size_in_bytes)`
+    /// rather than path alone: several deletion vectors may share one Puffin file, so a
+    /// path-only key would collapse them.
+    files_to_delete: HashMap<DeleteFileKey, DataFile>,
 
     /// Minimum sequence number for removing old delete files
     min_sequence_number: i64,
@@ -119,7 +122,7 @@ pub struct ManifestFilterManager {
     /// Cache of filtered manifests to avoid reprocessing
     filtered_manifests: HashMap<String, ManifestFile>, // manifest_path -> filtered_manifest
     /// Tracking where files were deleted to validate retries quickly
-    filtered_manifest_to_deleted_files: HashMap<String, Vec<String>>, // manifest_path -> deleted_files
+    filtered_manifest_to_deleted_files: HashMap<String, Vec<DeleteFileKey>>, // manifest_path -> deleted_file_keys
     ///    this is only being used for the DeleteManifestFilterManager to detect orphaned deletes for removed data file paths
     removed_data_file_path: HashSet<String>,
 
@@ -172,9 +175,9 @@ impl ManifestFilterManager {
     /// Mark a data file for deletion
     pub fn delete_file(&mut self, file: DataFile) -> Result<()> {
         // Todo: check all deletes references in manifests?
-        let file_path = file.file_path.clone();
+        let key = delete_file_key(&file);
 
-        self.files_to_delete.insert(file_path, file);
+        self.files_to_delete.insert(key, file);
 
         Ok(())
     }
@@ -286,12 +289,12 @@ impl ManifestFilterManager {
             // Why an entry is removed matters, so keep the reasons separate.
             //
             // An explicit delete, or the sequence-number rule, condemns the *whole file*
-            // and may therefore be promoted to the path-level `files_to_delete` set.
+            // and may therefore be promoted to the identity-keyed `files_to_delete` set.
             // Danglingness is different: it is a property of a single deletion-vector
             // *blob*. Several DVs can share one Puffin file, distinguished by
             // (`file_path`, `content_offset`, `content_size_in_bytes`), so a dangling blob
             // says nothing about its neighbours in the same file.
-            let explicitly_deleted = self.files_to_delete.contains_key(file.file_path());
+            let explicitly_deleted = self.files_to_delete.contains_key(&delete_file_key(file));
             // For delete manifests, check sequence number for old delete files
             let superseded_by_sequence_number = is_delete
                 && matches!(entry.sequence_number(), Some(seq_num) if seq_num != crate::spec::UNASSIGNED_SEQUENCE_NUMBER
@@ -324,30 +327,30 @@ impl ManifestFilterManager {
                     // Mark this entry as deleted
                     writer.add_delete_entry(entry.clone())?;
 
-                    // A blob-level decision must NOT be promoted to the path-level sets:
-                    // `files_to_delete` is keyed by path and is consulted for every entry
-                    // in this and every later manifest, so recording a shared Puffin here
-                    // would drop the *live* deletion vectors of data files that were never
-                    // rewritten -- silently resurrecting their deleted rows. Dropping this
-                    // one entry is the whole effect we want.
+                    // A blob-level decision must NOT be promoted to the identity-keyed
+                    // sets: `files_to_delete` is consulted for every entry in this and
+                    // every later manifest, so recording a shared Puffin blob's identity
+                    // here would still be harmless on its own, but recording it under a
+                    // path-only key would drop the *live* deletion vectors of data files
+                    // that were never rewritten -- silently resurrecting their deleted
+                    // rows. Dropping this one entry is the whole effect we want.
                     if explicitly_deleted || superseded_by_sequence_number {
                         // Create a copy of the file without stats
                         let file_copy = file.clone();
+                        let key = delete_file_key(&file_copy);
 
                         // For file that it was deleted using an expression
-                        self.files_to_delete
-                            .insert(file.file_path().to_string(), file_copy.clone());
+                        self.files_to_delete.insert(key.clone(), file_copy.clone());
 
                         // TODO: add file to removed_data_file_path once we implement drop_partition
 
-                        // Track deleted files for duplicate detection and validation
-                        if deleted_files.contains_key(file_copy.file_path()) {
-                            // TODO: Log warning about duplicate
-                        } else {
-                            // Only add the file to deletes if it is a new delete
-                            // This keeps the snapshot summary accurate for non-duplicate data
-                            deleted_files.insert(file_copy.file_path.to_owned(), file_copy.clone());
-                        }
+                        // Track deleted files for duplicate detection and validation.
+                        // Only add the file to deletes if it is a new delete -- this keeps
+                        // the snapshot summary accurate for non-duplicate data. A duplicate
+                        // is silently a no-op here (TODO: log a warning about it).
+                        deleted_files
+                            .entry(key)
+                            .or_insert_with(|| file_copy.clone());
                     }
                 } else {
                     // Keep the entry as existing
@@ -366,11 +369,11 @@ impl ManifestFilterManager {
         self.filtered_manifests
             .insert(manifest.manifest_path.clone(), filtered_manifest.clone());
 
-        // Track deleted files for validation - convert HashSet to Vec of file paths
-        let deleted_file_paths: Vec<String> = deleted_files.keys().cloned().collect();
+        // Track deleted files for validation - convert to a Vec of identity keys
+        let deleted_file_keys: Vec<DeleteFileKey> = deleted_files.into_keys().collect();
 
         self.filtered_manifest_to_deleted_files
-            .insert(filtered_manifest.manifest_path.clone(), deleted_file_paths);
+            .insert(filtered_manifest.manifest_path.clone(), deleted_file_keys);
 
         Ok(filtered_manifest)
     }
@@ -381,11 +384,15 @@ impl ManifestFilterManager {
             let deleted_files = self.deleted_files(manifests);
             // check deleted_files contains all files in self.delete_files
 
-            for file_path in self.files_to_delete.keys() {
-                if !deleted_files.contains(file_path) {
+            for key in self.files_to_delete.keys() {
+                if !deleted_files.contains(key) {
+                    let (path, content_offset, content_size_in_bytes) = key;
                     return Err(Error::new(
                         ErrorKind::DataInvalid,
-                        format!("Required delete path missing: {file_path}"),
+                        format!(
+                            "Required delete file missing: {path} \
+                             (content_offset={content_offset:?}, content_size_in_bytes={content_size_in_bytes:?})"
+                        ),
                     ));
                 }
             }
@@ -393,7 +400,7 @@ impl ManifestFilterManager {
         Ok(())
     }
 
-    fn deleted_files(&self, manifests: &[ManifestFile]) -> HashSet<String> {
+    fn deleted_files(&self, manifests: &[ManifestFile]) -> HashSet<DeleteFileKey> {
         let mut deleted_files = HashSet::new();
         for manifest in manifests {
             if let Some(deleted) = self
@@ -429,8 +436,8 @@ impl ManifestFilterManager {
             // Mirrors the decision in `filter_manifest_with_deleted_files`; see the comment
             // there for why the dangling-delete case is deliberately per-blob.
             let marked_for_delete =
-                // Check if file path is in files to delete
-                self.files_to_delete.contains_key(file.file_path()) ||
+                // Check if this exact delete-file identity is in files to delete
+                self.files_to_delete.contains_key(&delete_file_key(file)) ||
                 // For delete manifests, check sequence number for old delete files
                 (is_delete &&
                  entry.status() != ManifestStatus::Deleted &&
@@ -819,6 +826,7 @@ mod tests {
         // Test 1: Delete file by path
         let file_path = "/test/path/file.parquet";
         let test_file1 = create_test_data_file(file_path, 0);
+        let key1 = delete_file_key(&test_file1);
 
         // Initially no deletes
         assert!(!manager.contains_deletes());
@@ -828,17 +836,17 @@ mod tests {
 
         // Should now contain deletes
         assert!(manager.contains_deletes());
-        assert!(manager.files_to_delete.contains_key(file_path));
+        assert!(manager.files_to_delete.contains_key(&key1));
 
         // Test 2: Delete another file and verify tracking
         let test_file2 = create_test_data_file("/test/data/file2.parquet", 0);
-        let file_path2 = test_file2.file_path.clone();
+        let key2 = delete_file_key(&test_file2);
         manager.delete_file(test_file2).unwrap();
 
         // Should track both files for deletion
         let deleted_files = manager.files_to_be_deleted();
         assert_eq!(deleted_files.len(), 2);
-        assert!(manager.files_to_delete.contains_key(&file_path2));
+        assert!(manager.files_to_delete.contains_key(&key2));
     }
 
     #[test]
@@ -922,7 +930,7 @@ mod tests {
             result
                 .unwrap_err()
                 .to_string()
-                .contains("Required delete path missing")
+                .contains("Required delete file missing")
         );
     }
 
@@ -956,8 +964,16 @@ mod tests {
         // Verify manifest filtering capabilities
         assert!(manager.can_contain_deleted_files(&manifest));
         assert!(manager.manifest_has_deleted_files(&manifest).await.unwrap());
-        assert!(manager.files_to_delete.contains_key(&delete_file.file_path));
-        assert!(!manager.files_to_delete.contains_key(&keep_file.file_path));
+        assert!(
+            manager
+                .files_to_delete
+                .contains_key(&delete_file_key(&delete_file))
+        );
+        assert!(
+            !manager
+                .files_to_delete
+                .contains_key(&delete_file_key(&keep_file))
+        );
 
         // Verify manager state
         assert!(manager.contains_deletes());
@@ -1036,7 +1052,11 @@ mod tests {
 
         // Verify manifest can contain deleted files
         assert!(manager.can_contain_deleted_files(&manifest));
-        assert!(manager.files_to_delete.contains_key(&delete_file.file_path));
+        assert!(
+            manager
+                .files_to_delete
+                .contains_key(&delete_file_key(&delete_file))
+        );
 
         // Validation should pass when no required deletes are set
         assert!(manager.validate_required_deletes(&[manifest]).is_ok());
@@ -1541,6 +1561,87 @@ mod tests {
                 .iter()
                 .any(|f| f.file_path() == PUFFIN),
             "a partially-dangling Puffin must not be promoted to a path-level delete"
+        );
+    }
+
+    /// Regression test for the `explicitly_deleted` path raised in review of #168.
+    ///
+    /// `delete_file()` (used e.g. for expression-based overwrites) marks a specific
+    /// [`DataFile`] for removal via `files_to_delete`. When two deletion vectors share
+    /// one Puffin file, marking only one of them for deletion must not drop the other:
+    /// `files_to_delete` must be keyed by the full `(file_path, content_offset,
+    /// content_size_in_bytes)` identity, not by `file_path` alone.
+    #[tokio::test]
+    async fn test_shared_puffin_explicit_delete_keeps_live_deletion_vector() {
+        let (mut manager, temp_dir) = setup_test_manager();
+        let schema = create_test_schema();
+
+        const PUFFIN: &str = "/test/explicit-shared.puffin";
+        let deleted_blob = create_test_deletion_vector_at(PUFFIN, "/test/data-a.parquet", 4);
+        let live_blob = create_test_deletion_vector_at(PUFFIN, "/test/data-b.parquet", 128);
+
+        // Only the first blob is explicitly marked for deletion.
+        manager.delete_file(deleted_blob.clone()).unwrap();
+
+        let manifest_path = temp_dir
+            .path()
+            .join("explicit-delete-manifest.avro")
+            .to_string_lossy()
+            .to_string();
+
+        write_delete_manifest_with_entries(
+            &manager,
+            &manifest_path,
+            &schema,
+            create_entries_from_files(vec![deleted_blob, live_blob]),
+            12345,
+        )
+        .await
+        .unwrap();
+
+        let input_manifest = create_manifest_metadata(
+            &manifest_path,
+            ManifestContentType::Deletes,
+            10,
+            12345,
+            (2, 0, 0),
+        );
+
+        let filtered = manager
+            .filter_manifests(&schema, vec![input_manifest.clone()])
+            .await
+            .unwrap();
+
+        assert_eq!(filtered.len(), 1);
+        assert_ne!(
+            filtered[0].manifest_path, input_manifest.manifest_path,
+            "manifest must be rewritten when it contains an explicitly deleted blob"
+        );
+
+        let filtered_manifest = filtered[0].load_manifest(&manager.file_io).await.unwrap();
+        let statuses: HashMap<Option<i64>, ManifestStatus> = filtered_manifest
+            .entries()
+            .iter()
+            .map(|entry| (entry.data_file().content_offset(), entry.status()))
+            .collect();
+
+        assert_eq!(
+            statuses.get(&Some(4)),
+            Some(&ManifestStatus::Deleted),
+            "the explicitly-deleted blob must be dropped"
+        );
+        assert_eq!(
+            statuses.get(&Some(128)),
+            Some(&ManifestStatus::Existing),
+            "a live blob sharing the same Puffin path must survive an explicit delete of \
+             its neighbour"
+        );
+
+        // The Puffin path itself must not be promoted whole into `files_to_delete`.
+        assert_eq!(
+            manager.files_to_be_deleted().len(),
+            1,
+            "only the exact deleted blob identity should be tracked, not the shared path"
         );
     }
 }

--- a/crates/iceberg/src/transaction/replace_files.rs
+++ b/crates/iceberg/src/transaction/replace_files.rs
@@ -34,6 +34,7 @@ use crate::spec::{
 use crate::table::Table;
 use crate::transaction::snapshot::SnapshotProduceOperation;
 use crate::transaction::{ActionCommit, TransactionAction};
+use crate::utils::{delete_file_key, delete_file_paths};
 
 /// Which snapshot [`Operation`] a file replacement records.
 ///
@@ -105,6 +106,11 @@ impl<M: ReplaceFilesMode> SnapshotProduceOperation for ReplaceFilesOperation<M> 
 
             let mut deleted_entries = Vec::new();
 
+            // Cheap, allocation-free path pre-filter: only entries whose path
+            // is even a candidate pay for the allocating `delete_file_key`.
+            let removed_delete_paths =
+                delete_file_paths(&snapshot_produce.removed_delete_file_keys);
+
             for manifest_file in manifest_list.entries() {
                 if !snapshot_produce.has_removed_files_for_manifest_type(manifest_file.content) {
                     continue;
@@ -129,9 +135,10 @@ impl<M: ReplaceFilesMode> SnapshotProduceOperation for ReplaceFilesOperation<M> 
 
                     if (entry.content_type() == DataContentType::PositionDeletes
                         || entry.content_type() == DataContentType::EqualityDeletes)
+                        && removed_delete_paths.contains(entry.data_file().file_path())
                         && snapshot_produce
-                            .removed_delete_file_paths
-                            .contains(entry.data_file().file_path())
+                            .removed_delete_file_keys
+                            .contains(&delete_file_key(entry.data_file()))
                     {
                         deleted_entries.push(gen_manifest_entry(entry));
                     }
@@ -165,6 +172,8 @@ impl<M: ReplaceFilesMode> SnapshotProduceOperation for ReplaceFilesOperation<M> 
 
         let mut existing_files = Vec::new();
 
+        let removed_delete_paths = delete_file_paths(&snapshot_produce.removed_delete_file_keys);
+
         for manifest_file in manifest_list.entries() {
             if !snapshot_produce.has_removed_files_for_manifest_type(manifest_file.content) {
                 existing_files.push(manifest_file.clone());
@@ -173,6 +182,10 @@ impl<M: ReplaceFilesMode> SnapshotProduceOperation for ReplaceFilesOperation<M> 
 
             let manifest = manifest_file.load_manifest(file_io_ref).await?;
 
+            // Keyed by `(file_path, content_offset, content_size_in_bytes)`, not
+            // `file_path` alone: several deletion vectors can share one Puffin
+            // file, and a path-only key would drop every DV in that file once
+            // any one of them is found deleted.
             let found_deleted_files: HashSet<_> = manifest
                 .entries()
                 .iter()
@@ -180,26 +193,33 @@ impl<M: ReplaceFilesMode> SnapshotProduceOperation for ReplaceFilesOperation<M> 
                     if !entry.is_alive() {
                         return None;
                     }
-                    if snapshot_produce
-                        .removed_data_file_paths
-                        .contains(entry.data_file().file_path())
-                        || snapshot_produce
-                            .removed_delete_file_paths
-                            .contains(entry.data_file().file_path())
-                    {
-                        Some(entry.data_file().file_path().to_string())
-                    } else {
-                        None
+                    let path = entry.data_file().file_path();
+                    if snapshot_produce.removed_data_file_paths.contains(path) {
+                        return Some(delete_file_key(entry.data_file()));
                     }
+                    if removed_delete_paths.contains(path) {
+                        let key = delete_file_key(entry.data_file());
+                        if snapshot_produce.removed_delete_file_keys.contains(&key) {
+                            return Some(key);
+                        }
+                    }
+                    None
                 })
                 .collect();
 
             if found_deleted_files.is_empty() {
                 existing_files.push(manifest_file.clone());
             } else {
-                // Rewrite the manifest file without the deleted data files
+                // Rewrite the manifest file without the deleted data files.
+                // `found_deleted_files` only ever holds a handful of entries
+                // (the ones actually removed from this manifest), so the same
+                // path pre-filter trick keeps this allocation-free for most
+                // surviving entries too.
+                let found_deleted_paths = delete_file_paths(&found_deleted_files);
                 let survives = |entry: &ManifestEntry| {
-                    entry.is_alive() && !found_deleted_files.contains(entry.data_file().file_path())
+                    entry.is_alive()
+                        && !(found_deleted_paths.contains(entry.data_file().file_path())
+                            && found_deleted_files.contains(&delete_file_key(entry.data_file())))
                 };
 
                 if manifest.entries().iter().any(|entry| survives(entry)) {
@@ -462,7 +482,7 @@ mod tests {
     /// `delete_entries` once guarded the delete-file branch with
     ///   `content == PositionDeletes || content == EqualityDeletes && removed.contains(path)`
     /// and because `&&` binds tighter than `||`, every `PositionDeletes` entry in
-    /// the parent snapshot matched regardless of `removed_delete_file_paths`.
+    /// the parent snapshot matched regardless of `removed_delete_file_keys`.
     async fn assert_only_removed_delete_files_marked<M: ReplaceFilesMode>() {
         let table = make_v2_table_with_delete_manifest().await;
         let removed = position_delete_file(&table, REMOVED_DELETE_FILE);

--- a/crates/iceberg/src/transaction/replace_files.rs
+++ b/crates/iceberg/src/transaction/replace_files.rs
@@ -106,11 +106,19 @@ impl<M: ReplaceFilesMode> SnapshotProduceOperation for ReplaceFilesOperation<M> 
             let mut deleted_entries = Vec::new();
 
             for manifest_file in manifest_list.entries() {
+                if !snapshot_produce.can_contain_removed_files(manifest_file.content) {
+                    continue;
+                }
+
                 let manifest = manifest_file
                     .load_manifest(snapshot_produce.table.file_io())
                     .await?;
 
                 for entry in manifest.entries() {
+                    if !entry.is_alive() {
+                        continue;
+                    }
+
                     if entry.content_type() == DataContentType::Data
                         && snapshot_produce
                             .removed_data_file_paths
@@ -158,12 +166,20 @@ impl<M: ReplaceFilesMode> SnapshotProduceOperation for ReplaceFilesOperation<M> 
         let mut existing_files = Vec::new();
 
         for manifest_file in manifest_list.entries() {
+            if !snapshot_produce.can_contain_removed_files(manifest_file.content) {
+                existing_files.push(manifest_file.clone());
+                continue;
+            }
+
             let manifest = manifest_file.load_manifest(file_io_ref).await?;
 
             let found_deleted_files: HashSet<_> = manifest
                 .entries()
                 .iter()
                 .filter_map(|entry| {
+                    if !entry.is_alive() {
+                        return None;
+                    }
                     if snapshot_produce
                         .removed_data_file_paths
                         .contains(entry.data_file().file_path())

--- a/crates/iceberg/src/transaction/replace_files.rs
+++ b/crates/iceberg/src/transaction/replace_files.rs
@@ -106,7 +106,7 @@ impl<M: ReplaceFilesMode> SnapshotProduceOperation for ReplaceFilesOperation<M> 
             let mut deleted_entries = Vec::new();
 
             for manifest_file in manifest_list.entries() {
-                if !snapshot_produce.can_contain_removed_files(manifest_file.content) {
+                if !snapshot_produce.has_removed_files_for_manifest_type(manifest_file.content) {
                     continue;
                 }
 
@@ -166,7 +166,7 @@ impl<M: ReplaceFilesMode> SnapshotProduceOperation for ReplaceFilesOperation<M> 
         let mut existing_files = Vec::new();
 
         for manifest_file in manifest_list.entries() {
-            if !snapshot_produce.can_contain_removed_files(manifest_file.content) {
+            if !snapshot_produce.has_removed_files_for_manifest_type(manifest_file.content) {
                 existing_files.push(manifest_file.clone());
                 continue;
             }

--- a/crates/iceberg/src/transaction/snapshot.rs
+++ b/crates/iceberg/src/transaction/snapshot.rs
@@ -37,7 +37,7 @@ use crate::spec::{
 use crate::table::Table;
 use crate::transaction::{ActionCommit, ManifestFilterManager, ManifestWriterContext};
 use crate::utils::bin::ListPacker;
-use crate::utils::load_manifests;
+use crate::utils::{DeleteFileKey, delete_file_key, load_manifests};
 use crate::{Error, ErrorKind, TableRequirement, TableUpdate};
 
 const META_ROOT_PATH: &str = "metadata";
@@ -127,12 +127,16 @@ pub(crate) struct SnapshotProducer<'a> {
 
     // for filtering out files that are removed by action
     pub removed_data_file_paths: HashSet<String>,
-    pub removed_delete_file_paths: HashSet<String>,
+    // Keyed by `(file_path, content_offset, content_size_in_bytes)` rather than
+    // `file_path` alone: several deletion vectors may share one Puffin file, so
+    // a path-only key would drop a still-live DV whenever another DV in the
+    // same physical file is removed.
+    pub removed_delete_file_keys: HashSet<DeleteFileKey>,
     // Full DataFile objects for removed files. Retained so the snapshot summary
     // can roll up `deleted-records`, `removed-files-size`, etc. from the file
-    // metadata. Only paths are needed for manifest filtering, but the summary
-    // collector needs the full records to produce accurate `total-*` fields
-    // on the new snapshot.
+    // metadata. Only identity keys are needed for manifest filtering, but the
+    // summary collector needs the full records to produce accurate `total-*`
+    // fields on the new snapshot.
     pub removed_data_files: Vec<DataFile>,
     pub removed_delete_files: Vec<DataFile>,
 
@@ -165,10 +169,7 @@ impl<'a> SnapshotProducer<'a> {
             .iter()
             .map(|df| df.file_path.clone())
             .collect();
-        let removed_delete_file_paths = removed_delete_files
-            .iter()
-            .map(|df| df.file_path.clone())
-            .collect();
+        let removed_delete_file_keys = removed_delete_files.iter().map(delete_file_key).collect();
 
         let manifest_counter = Arc::new(AtomicU64::new(0));
 
@@ -185,7 +186,7 @@ impl<'a> SnapshotProducer<'a> {
             added_data_files,
             added_delete_files,
             removed_data_file_paths,
-            removed_delete_file_paths,
+            removed_delete_file_keys,
             removed_data_files,
             removed_delete_files,
             new_data_file_sequence_number: None,
@@ -197,7 +198,7 @@ impl<'a> SnapshotProducer<'a> {
     pub(crate) fn has_removed_files_for_manifest_type(&self, content: ManifestContentType) -> bool {
         match content {
             ManifestContentType::Data => !self.removed_data_file_paths.is_empty(),
-            ManifestContentType::Deletes => !self.removed_delete_file_paths.is_empty(),
+            ManifestContentType::Deletes => !self.removed_delete_file_keys.is_empty(),
         }
     }
 
@@ -529,7 +530,7 @@ partition_struct: {:?}, partition_type: {:?}",
             && self.snapshot_properties.is_empty()
             && self.added_delete_files.is_empty()
             && self.removed_data_file_paths.is_empty()
-            && self.removed_delete_file_paths.is_empty()
+            && self.removed_delete_file_keys.is_empty()
         {
             return Err(Error::new(
                 ErrorKind::PreconditionFailed,

--- a/crates/iceberg/src/transaction/snapshot.rs
+++ b/crates/iceberg/src/transaction/snapshot.rs
@@ -194,7 +194,7 @@ impl<'a> SnapshotProducer<'a> {
         }
     }
 
-    pub(crate) fn can_contain_removed_files(&self, content: ManifestContentType) -> bool {
+    pub(crate) fn has_removed_files_for_manifest_type(&self, content: ManifestContentType) -> bool {
         match content {
             ManifestContentType::Data => !self.removed_data_file_paths.is_empty(),
             ManifestContentType::Deletes => !self.removed_delete_file_paths.is_empty(),

--- a/crates/iceberg/src/transaction/snapshot.rs
+++ b/crates/iceberg/src/transaction/snapshot.rs
@@ -194,6 +194,13 @@ impl<'a> SnapshotProducer<'a> {
         }
     }
 
+    pub(crate) fn can_contain_removed_files(&self, content: ManifestContentType) -> bool {
+        match content {
+            ManifestContentType::Data => !self.removed_data_file_paths.is_empty(),
+            ManifestContentType::Deletes => !self.removed_delete_file_paths.is_empty(),
+        }
+    }
+
     pub(crate) fn validate_added_data_files(&self, added_data_files: &[DataFile]) -> Result<()> {
         for data_file in added_data_files {
             // Check if the data file partition spec id matches the table default partition spec id.

--- a/crates/iceberg/src/utils.rs
+++ b/crates/iceberg/src/utils.rs
@@ -250,10 +250,39 @@ use futures::stream::{self, StreamExt};
 
 use crate::error::Result;
 use crate::io::FileIO;
-use crate::spec::{Manifest, ManifestFile, ManifestList, ManifestStatus, Snapshot};
+use crate::spec::{DataFile, Manifest, ManifestFile, ManifestList, ManifestStatus, Snapshot};
 
 pub(crate) const DEFAULT_DELETE_CONCURRENCY_LIMIT: usize = 10;
 pub(crate) const DEFAULT_LOAD_CONCURRENCY_LIMIT: usize = 16;
+
+/// Identity of a delete file, matching Java's `DeleteFileSet`: deletion vectors
+/// are addressed by `(file_path, content_offset, content_size_in_bytes)` since
+/// multiple DVs may share one physical Puffin file, while other delete files
+/// (whose offset/size are always `None`) are identified by `file_path` alone.
+pub(crate) type DeleteFileKey = (String, Option<i64>, Option<i64>);
+
+/// Builds a [`DeleteFileKey`] for `df`. Safe to use for any [`DataFile`],
+/// including data files: their offset/size are always `None`, so the key
+/// degenerates to `file_path` alone.
+pub(crate) fn delete_file_key(df: &DataFile) -> DeleteFileKey {
+    (
+        df.file_path().to_string(),
+        df.content_offset(),
+        df.content_size_in_bytes(),
+    )
+}
+
+/// Extracts just the `file_path` component of each key in `keys`.
+///
+/// Intended as a cheap pre-filter before the full [`DeleteFileKey`] check: a
+/// manifest scan can test a candidate entry's path against this set with no
+/// allocation (`HashSet<String>::contains` accepts `&str` via `Borrow`),
+/// reserving the allocating [`delete_file_key`] call for entries whose path
+/// actually matches — which, in the common case of removing a handful of
+/// dangling deletes from a much larger manifest, is the rare case.
+pub(crate) fn delete_file_paths(keys: &HashSet<DeleteFileKey>) -> HashSet<String> {
+    keys.iter().map(|(path, _, _)| path.clone()).collect()
+}
 
 /// Streams the manifest lists for `snapshots`, invoking `f` on each loaded
 /// [`ManifestList`] and dropping it immediately afterwards.


### PR DESCRIPTION
## PR Description

### Overview

Adds a table maintenance action that removes **dangling delete files** — position and equality deletes that no longer apply to any live data file. After compaction or partition expiration removes the data a delete file targeted, the delete entry lingers in the manifests, inflating manifest size and query-planning cost without affecting results. On high-throughput CDC tables these accumulate indefinitely, since nothing in the normal write path cleans them up on partitioned tables.

The action loads the target branch's manifests, correlates delete files against the live data files, and removes those that can no longer match anything:

- **Position deletes** — dangling when their referenced data file is gone, or (without a reference) when their sequence number falls below the minimum live data sequence number in their partition.
- **Equality deletes** — dangling when their sequence number is at or below that partition's minimum. Unpartitioned (global-scope) equality deletes are compared against the table-wide minimum.

Removal goes through the existing `rewrite_files` transaction. This also includes a supporting fix so `rewrite_files` correctly rewrites **delete** manifests (preserving content type, sequence-number lineage, and existing-entry status), which the action depends on.

### Usage

```rust
use std::sync::Arc;
use iceberg::actions::RemoveDanglingDeleteFilesAction;

let removed = RemoveDanglingDeleteFilesAction::new(catalog, table_ident)
    .to_branch("main") // optional; defaults to the main branch
    .execute()
    .await?;

println!("Removed {removed} dangling delete files");
```

`execute()` returns the number of delete files removed (`0` if none, in which case no commit is made). It's a no-op-safe maintenance operation — run it periodically alongside compaction.

### Example

The below example is using Google Lakehouse Catalog runtime (previously BigLake Metastore REST Catalog).

```rust
use std::collections::HashMap;
use std::process::Command;
use std::sync::Arc;

use iceberg::actions::RemoveDanglingDeleteFilesAction;
use iceberg::{Catalog, CatalogBuilder, TableIdent};
use iceberg_catalog_rest::{
    REST_CATALOG_PROP_URI, REST_CATALOG_PROP_WAREHOUSE, RestCatalogBuilder,
};

const CATALOG_URI: &str = "https://biglake.googleapis.com/iceberg/v1/restcatalog";
const PROJECT_ID: &str = "<PROJECT-ID>";
const WAREHOUSE: &str = "bq://projects/<PROJECT-ID>";
const NAMESPACE: &str = "<NAMESPACE-NAME>";
const TABLE_NAME: &str = "<TABLE-NAME>";

/// Fetches a GCP OAuth2 access token from local Application Default Credentials
/// by shelling out to the `gcloud` CLI. Swap this out for the `gcp_auth` crate
/// (or a service-account flow) in a non-interactive/production deployment.
fn adc_access_token() -> String {
    let output = Command::new("gcloud")
        .args(["auth", "application-default", "print-access-token"])
        .output()
        .expect("failed to run `gcloud`; is the gcloud CLI installed and on PATH?");

    if !output.status.success() {
        panic!(
            "`gcloud auth application-default print-access-token` failed: {}",
            String::from_utf8_lossy(&output.stderr)
        );
    }

    String::from_utf8(output.stdout)
        .expect("token is not valid UTF-8")
        .trim()
        .to_string()
}

#[tokio::main]
async fn main() {
    // 1. Obtain one access token from local ADC and reuse it for both services.
    let token = adc_access_token();

    // 2. Build the props consumed by the REST catalog and the GCS FileIO.
    //    - `token` / `header.*`        -> authenticate to the BigLake REST catalog
    //    - `gcs.oauth2.token` / `gcs.*` -> authenticate the GCS object store reads/writes
    let props = HashMap::from([
        (REST_CATALOG_PROP_URI.to_string(), CATALOG_URI.to_string()),
        (
            REST_CATALOG_PROP_WAREHOUSE.to_string(),
            WAREHOUSE.to_string(),
        ),
        // REST catalog: Bearer auth + the project header BigLake requires.
        ("token".to_string(), token.clone()),
        (
            "header.x-goog-user-project".to_string(),
            PROJECT_ID.to_string(),
        ),
        // GCS FileIO: use the same token directly, and pin the project so we
        // never fall back to GoogleAuthManager / VM metadata / config discovery.
        ("gcs.oauth2.token".to_string(), token),
        ("gcs.project-id".to_string(), PROJECT_ID.to_string()),
        ("gcs.user-project".to_string(), PROJECT_ID.to_string()),
        ("gcs.disable-vm-metadata".to_string(), "true".to_string()),
        ("gcs.disable-config-load".to_string(), "true".to_string()),
    ]);

    let catalog: Arc<dyn Catalog> = Arc::new(
        RestCatalogBuilder::default()
            .load("biglake", props)
            .await
            .expect("failed to initialize BigLake REST catalog"),
    );

    // 3. Run the maintenance action against the target table.
    let table_ident = TableIdent::from_strs([NAMESPACE, TABLE_NAME]).unwrap();

    println!("Scanning {NAMESPACE}.{TABLE_NAME} for dangling delete files...");
    let removed = RemoveDanglingDeleteFilesAction::new(catalog, table_ident)
        .to_branch("main") // optional; "main" is the default
        .execute()
        .await
        .expect("RemoveDanglingDeleteFilesAction failed");

    println!("Removed {removed} dangling delete file(s).");
}
```

### Testing

Covered by unit tests for both unpartitioned and partitioned tables, including per-partition isolation (a dangling delete in one partition must not affect a still-applicable delete in another). The partitioned cases are deliberately ordered to fail under a naive global-minimum implementation.