### PR TITLE
feat(writer): auto-set referenced_data_file on PositionDeleteFileWriter

### DIFF
--- a/crates/iceberg/src/writer/base_writer/position_delete_file_writer.rs
+++ b/crates/iceberg/src/writer/base_writer/position_delete_file_writer.rs
@@ -479,8 +479,7 @@ mod tests {
     #[tokio::test]
     async fn test_referenced_data_file_set_on_all_rolled_files() -> Result<()> {
         // When rolling produces multiple output files but all entries target a single
-        // data file, every output file must carry referenced_data_file. A builders.len() == 1
-        // guard would silently drop the field for rolled files, defeating the optimization.
+        // data file, every output file must carry referenced_data_file.
         let temp_dir = TempDir::new()?;
         let file_io = FileIOBuilder::new_fs_io().build()?;
         let location_gen = DefaultLocationGenerator::with_data_location(

--- a/crates/iceberg/src/writer/base_writer/position_delete_file_writer.rs
+++ b/crates/iceberg/src/writer/base_writer/position_delete_file_writer.rs
@@ -167,7 +167,7 @@ where
     async fn close(&mut self) -> Result<Vec<DataFile>> {
         if let Some(writer) = self.inner.take() {
             let builders = writer.close().await?;
-            let single_ref = if builders.len() == 1 && self.distinct_paths.len() == 1 {
+            let single_ref = if self.distinct_paths.len() == 1 {
                 self.distinct_paths
                     .iter()
                     .next()
@@ -472,6 +472,63 @@ mod tests {
         let data_files = writer.close().await?;
         assert_eq!(data_files.len(), 1);
         assert_eq!(data_files[0].referenced_data_file(), None);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_referenced_data_file_set_on_all_rolled_files() -> Result<()> {
+        // When rolling produces multiple output files but all entries target a single
+        // data file, every output file must carry referenced_data_file. A builders.len() == 1
+        // guard would silently drop the field for rolled files, defeating the optimization.
+        let temp_dir = TempDir::new()?;
+        let file_io = FileIOBuilder::new_fs_io().build()?;
+        let location_gen = DefaultLocationGenerator::with_data_location(
+            temp_dir.path().to_str().unwrap().to_string(),
+        );
+        let file_name_gen =
+            DefaultFileNameGenerator::new("pos_del".to_string(), None, DataFileFormat::Parquet);
+        let schema = Arc::new(POSITION_DELETE_SCHEMA.clone());
+        let parquet_builder =
+            ParquetWriterBuilder::new(WriterProperties::builder().build(), schema.clone());
+        // Use a tiny target size to force rolling after the first write.
+        let rolling_builder = RollingFileWriterBuilder::new(
+            parquet_builder,
+            1,
+            file_io.clone(),
+            location_gen,
+            file_name_gen,
+        );
+        let mut writer = PositionDeleteFileWriterBuilder::new(rolling_builder)
+            .build(None)
+            .await?;
+
+        writer
+            .write(vec![PositionDeleteInput::new(
+                Arc::from("s3://bucket/data/file-1.parquet"),
+                1,
+            )])
+            .await?;
+        writer
+            .write(vec![PositionDeleteInput::new(
+                Arc::from("s3://bucket/data/file-1.parquet"),
+                2,
+            )])
+            .await?;
+
+        let data_files = writer.close().await?;
+        assert!(
+            data_files.len() > 1,
+            "expected rolling to produce multiple files, got {}",
+            data_files.len()
+        );
+        for file in &data_files {
+            assert_eq!(
+                file.referenced_data_file().as_deref(),
+                Some("s3://bucket/data/file-1.parquet"),
+                "all rolled files must carry referenced_data_file"
+            );
+        }
 
         Ok(())
     }

--- a/crates/iceberg/src/writer/base_writer/position_delete_file_writer.rs
+++ b/crates/iceberg/src/writer/base_writer/position_delete_file_writer.rs
@@ -21,6 +21,7 @@
 //! as required by the Iceberg specification. Ordering and deduplication must be handled by the
 //! caller (e.g. by using a sorting writer) before passing records to this writer.
 
+use std::collections::HashSet;
 use std::sync::Arc;
 
 use arrow_array::RecordBatch;
@@ -119,6 +120,7 @@ where
         Ok(PositionDeleteFileWriter {
             inner: Some(self.inner.build()),
             partition_key,
+            distinct_paths: HashSet::new(),
         })
     }
 }
@@ -131,6 +133,7 @@ pub struct PositionDeleteFileWriter<
 > {
     inner: Option<RollingFileWriter<B, L, F>>,
     partition_key: Option<PartitionKey>,
+    distinct_paths: HashSet<Arc<str>>,
 }
 
 #[async_trait::async_trait]
@@ -143,6 +146,10 @@ where
     async fn write(&mut self, input: Vec<PositionDeleteInput>) -> Result<()> {
         if input.is_empty() {
             return Ok(());
+        }
+
+        for pd in &input {
+            self.distinct_paths.insert(Arc::clone(&pd.path));
         }
 
         let batch = build_position_delete_batch(input)?;
@@ -159,9 +166,17 @@ where
 
     async fn close(&mut self) -> Result<Vec<DataFile>> {
         if let Some(writer) = self.inner.take() {
-            writer
-                .close()
-                .await?
+            let builders = writer.close().await?;
+            let single_ref = if builders.len() == 1 && self.distinct_paths.len() == 1 {
+                self.distinct_paths
+                    .iter()
+                    .next()
+                    .map(|p: &Arc<str>| p.as_ref().to_string())
+            } else {
+                None
+            };
+
+            builders
                 .into_iter()
                 .map(|mut builder| {
                     builder.content(DataContentType::PositionDeletes);
@@ -171,6 +186,9 @@ where
                     } else {
                         builder.partition(Struct::empty());
                         builder.partition_spec_id(0);
+                    }
+                    if let Some(ref_path) = single_ref.as_ref() {
+                        builder.referenced_data_file(Some(ref_path.clone()));
                     }
                     builder.build().map_err(|e| {
                         Error::new(
@@ -379,6 +397,81 @@ mod tests {
             DataContentType::PositionDeletes
         );
         assert_eq!(data_files[0].partition(), &partition_value);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_referenced_data_file_single_path() -> Result<()> {
+        let temp_dir = TempDir::new()?;
+        let file_io = FileIOBuilder::new_fs_io().build()?;
+        let location_gen = DefaultLocationGenerator::with_data_location(
+            temp_dir.path().to_str().unwrap().to_string(),
+        );
+        let file_name_gen =
+            DefaultFileNameGenerator::new("pos_del".to_string(), None, DataFileFormat::Parquet);
+        let schema = Arc::new(POSITION_DELETE_SCHEMA.clone());
+        let parquet_builder =
+            ParquetWriterBuilder::new(WriterProperties::builder().build(), schema.clone());
+        let rolling_builder = RollingFileWriterBuilder::new_with_default_file_size(
+            parquet_builder,
+            file_io.clone(),
+            location_gen,
+            file_name_gen,
+        );
+        let mut writer = PositionDeleteFileWriterBuilder::new(rolling_builder)
+            .build(None)
+            .await?;
+
+        writer
+            .write(vec![
+                PositionDeleteInput::new(Arc::from("s3://bucket/data/file-1.parquet"), 1),
+                PositionDeleteInput::new(Arc::from("s3://bucket/data/file-1.parquet"), 2),
+            ])
+            .await?;
+
+        let data_files = writer.close().await?;
+        assert_eq!(data_files.len(), 1);
+        assert_eq!(
+            data_files[0].referenced_data_file().as_deref(),
+            Some("s3://bucket/data/file-1.parquet")
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_referenced_data_file_multi_path_is_null() -> Result<()> {
+        let temp_dir = TempDir::new()?;
+        let file_io = FileIOBuilder::new_fs_io().build()?;
+        let location_gen = DefaultLocationGenerator::with_data_location(
+            temp_dir.path().to_str().unwrap().to_string(),
+        );
+        let file_name_gen =
+            DefaultFileNameGenerator::new("pos_del".to_string(), None, DataFileFormat::Parquet);
+        let schema = Arc::new(POSITION_DELETE_SCHEMA.clone());
+        let parquet_builder =
+            ParquetWriterBuilder::new(WriterProperties::builder().build(), schema.clone());
+        let rolling_builder = RollingFileWriterBuilder::new_with_default_file_size(
+            parquet_builder,
+            file_io.clone(),
+            location_gen,
+            file_name_gen,
+        );
+        let mut writer = PositionDeleteFileWriterBuilder::new(rolling_builder)
+            .build(None)
+            .await?;
+
+        writer
+            .write(vec![
+                PositionDeleteInput::new(Arc::from("s3://bucket/data/file-1.parquet"), 1),
+                PositionDeleteInput::new(Arc::from("s3://bucket/data/file-2.parquet"), 5),
+            ])
+            .await?;
+
+        let data_files = writer.close().await?;
+        assert_eq!(data_files.len(), 1);
+        assert_eq!(data_files[0].referenced_data_file(), None);
 
         Ok(())
     }


### PR DESCRIPTION
## What is `referenced_data_file`?

`referenced_data_file` is an optional field on a position delete `DataFile` that declares: *"this delete file contains deletions exclusively for this one data file."*

When set, readers can skip loading a delete file entirely if it doesn't match the data file currently being scanned. Without this field, a delete file with `referenced_data_file = null` is conservatively attached to **all** data file scan tasks, forcing every reader to open it and filter by the `file_path` column at read time — even when the result is zero matching rows.

## What this PR does

`PositionDeleteFileWriter` now automatically sets `referenced_data_file` on close when all entries written target a single distinct data file path. No caller changes are required.

A secondary fix ensures the field is set on **all** rolled output files when the writer rolls mid-write due to size limits — previously only the first file would have received the field.

## Impact: before vs after

**Setup:** 3 data files, each with its own position delete file.

**Before** (`referenced_data_file = null` on all delete files):

```
── Full scan plan (3 tasks) ──
  data-a-00000.parquet — 3 delete(s)
    ↳ pos-delete-a  referenced_data_file = None
    ↳ pos-delete-b  referenced_data_file = None
    ↳ pos-delete-c  referenced_data_file = None
  data-b-00000.parquet — 3 delete(s)
    ↳ pos-delete-a  referenced_data_file = None
    ↳ pos-delete-b  referenced_data_file = None
    ↳ pos-delete-c  referenced_data_file = None
  data-c-00000.parquet — 3 delete(s)
    ↳ pos-delete-a  referenced_data_file = None
    ↳ pos-delete-b  referenced_data_file = None
    ↳ pos-delete-c  referenced_data_file = None

── Scan task for data-b only ──
  data file : data-b-00000.parquet
  delete(s) : 3   ← must open all 3 delete files and filter by file_path at read time
    ↳ pos-delete-a  referenced_data_file = None
    ↳ pos-delete-b  referenced_data_file = None
    ↳ pos-delete-c  referenced_data_file = None
```

**After** (auto-set `referenced_data_file`):

```
── Full scan plan (3 tasks) ──
  data-a-00000.parquet — 1 delete(s)
    ↳ pos-delete-a  referenced_data_file = Some("data-a-00000.parquet")
  data-b-00000.parquet — 1 delete(s)
    ↳ pos-delete-b  referenced_data_file = Some("data-b-00000.parquet")
  data-c-00000.parquet — 1 delete(s)
    ↳ pos-delete-c  referenced_data_file = Some("data-c-00000.parquet")

── Scan task for data-b only ──
  data file : data-b-00000.parquet
  delete(s) : 1   ← pos-delete-a and pos-delete-c pruned at plan time, zero I/O
    ↳ pos-delete-b  referenced_data_file = Some("data-b-00000.parquet")
```

With N data files and N delete files, the before behaviour is O(N²) delete file I/O per full scan. After this change it is O(1) per data file.

## Tests

- `test_referenced_data_file_single_path` — single-path writer sets the field
- `test_referenced_data_file_multi_path_is_null` — multi-path writer leaves field as `None`
- `test_referenced_data_file_set_on_all_rolled_files` — rolling writer with forced file splits sets the field on every output file