### PR TITLE
fix: stream manifest loading in snapshot-expiration file cleanup

### DIFF
--- a/crates/iceberg/src/transaction/remove_snapshots.rs
+++ b/crates/iceberg/src/transaction/remove_snapshots.rs
@@ -27,7 +27,7 @@ use crate::error::Result;
 use crate::spec::{MAIN_BRANCH, SnapshotReference, SnapshotRetention, TableMetadataRef};
 use crate::table::Table;
 use crate::transaction::{ActionCommit, TransactionAction};
-use crate::utils::{DEFAULT_LOAD_CONCURRENCY_LIMIT, ancestors_of, load_manifest_lists};
+use crate::utils::{DEFAULT_LOAD_CONCURRENCY_LIMIT, ancestors_of, for_each_manifest_list};
 use crate::{Error, ErrorKind, TableRequirement, TableUpdate};
 
 /// Default value for max snapshot age in milliseconds.
@@ -331,19 +331,25 @@ impl TransactionAction for RemoveSnapshotAction {
                 }
             }
 
-            let loaded_lists = load_manifest_lists(
+            // Stream the retained snapshots' manifest lists instead of loading
+            // them all up front. We only need the set of reachable partition
+            // spec ids, so fold each list into `reachable_specs` and drop it
+            // immediately. Collecting every retained manifest list at once is
+            // O(N) in memory and can OOM on tables whose retained manifest lists
+            // are large (e.g. high-churn tables without manifest compaction).
+            // See https://github.com/risingwavelabs/iceberg-rust/issues/173.
+            for_each_manifest_list(
                 table.file_io(),
                 &table_meta,
                 retained_snapshots,
                 DEFAULT_LOAD_CONCURRENCY_LIMIT,
+                |manifest_list| {
+                    for manifest in manifest_list.entries() {
+                        reachable_specs.insert(manifest.partition_spec_id);
+                    }
+                },
             )
             .await?;
-
-            for (_, manifest_list) in loaded_lists {
-                for manifest in manifest_list.entries() {
-                    reachable_specs.insert(manifest.partition_spec_id);
-                }
-            }
 
             let spec_to_remove: Vec<i32> = table_meta
                 .partition_specs_iter()

--- a/crates/iceberg/src/utils.rs
+++ b/crates/iceberg/src/utils.rs
@@ -280,6 +280,45 @@ pub(crate) async fn load_manifest_lists(
         .await
 }
 
+/// Streams the manifest lists for `snapshots`, invoking `f` on each loaded
+/// [`ManifestList`] and dropping it immediately afterwards.
+///
+/// Unlike [`load_manifest_lists`], this never holds more than `concurrency`
+/// manifest lists in memory at once. Use it when you only need to fold a small
+/// summary out of (potentially very large) manifest lists — e.g. collecting the
+/// set of reachable partition-spec ids during snapshot expiration — so that a
+/// table with many (or very large) retained manifest lists does not blow up the
+/// process working set.
+pub(crate) async fn for_each_manifest_list<F>(
+    file_io: &FileIO,
+    table_metadata: &TableMetadataRef,
+    snapshots: Vec<SnapshotRef>,
+    concurrency: usize,
+    mut f: F,
+) -> Result<()>
+where
+    F: FnMut(&ManifestList),
+{
+    let concurrency = concurrency.max(1);
+
+    let mut stream = stream::iter(snapshots)
+        .map(|snapshot| {
+            let file_io = file_io.clone();
+            let table_metadata = table_metadata.clone();
+            async move { snapshot.load_manifest_list(&file_io, &table_metadata).await }
+        })
+        .buffer_unordered(concurrency);
+
+    while let Some(manifest_list) = stream.next().await {
+        let manifest_list = manifest_list?;
+        f(&manifest_list);
+        // `manifest_list` is dropped here, bounding peak memory to at most
+        // `concurrency` manifest lists in flight (rather than all of them).
+    }
+
+    Ok(())
+}
+
 /// Concurrently loads manifests for the given manifest files.
 pub(crate) async fn load_manifests(
     file_io: &FileIO,

--- a/crates/iceberg/src/utils.rs
+++ b/crates/iceberg/src/utils.rs
@@ -340,6 +340,46 @@ pub(crate) async fn load_manifests(
         .await
 }
 
+/// Streams the manifests for `manifest_files`, invoking `f` on each loaded
+/// [`Manifest`] (with its [`ManifestFile`]) and dropping it immediately
+/// afterwards.
+///
+/// Unlike [`load_manifests`], this never holds more than `concurrency` manifests
+/// in memory at once. Use it when you only need to fold a summary out of
+/// (potentially very many / very large) manifests — e.g. collecting data-file
+/// paths during snapshot-expiration cleanup — instead of retaining every loaded
+/// manifest at once.
+pub(crate) async fn for_each_manifest<F>(
+    file_io: &FileIO,
+    manifest_files: Vec<ManifestFile>,
+    concurrency: usize,
+    mut f: F,
+) -> Result<()>
+where
+    F: FnMut(&ManifestFile, &Manifest),
+{
+    let concurrency = concurrency.max(1);
+
+    let mut stream = stream::iter(manifest_files)
+        .map(|manifest_file| {
+            let file_io = file_io.clone();
+            async move {
+                let manifest = manifest_file.load_manifest(&file_io).await?;
+                Ok::<_, crate::Error>((manifest_file, manifest))
+            }
+        })
+        .buffer_unordered(concurrency);
+
+    while let Some(loaded) = stream.next().await {
+        let (manifest_file, manifest) = loaded?;
+        f(&manifest_file, &manifest);
+        // `manifest_file`/`manifest` are dropped here, bounding peak memory to at
+        // most `concurrency` manifests in flight (rather than all of them).
+    }
+
+    Ok(())
+}
+
 /// Strategy for cleaning up unreachable files after snapshot expiration.
 pub struct ReachableFileCleanupStrategy {
     file_io: FileIO,
@@ -418,20 +458,22 @@ impl ReachableFileCleanupStrategy {
             self.collect_expired_snapshots(before_expiration, after_expiration);
 
         let deletion_candidates = {
+            // Stream the expired snapshots' manifest lists, folding their entries
+            // into the candidate set and dropping each list immediately, rather
+            // than holding every loaded list in memory alongside the set.
             let mut deletion_candidates = HashSet::default();
-            let loaded = load_manifest_lists(
+            for_each_manifest_list(
                 &self.file_io,
                 before_expiration,
                 expired_snapshots,
                 self.load_concurrency,
+                |manifest_list| {
+                    for manifest_file in manifest_list.entries() {
+                        deletion_candidates.insert(manifest_file.clone());
+                    }
+                },
             )
             .await?;
-
-            for (_, manifest_list) in loaded {
-                for manifest_file in manifest_list.entries() {
-                    deletion_candidates.insert(manifest_file.clone());
-                }
-            }
             deletion_candidates
         };
 
@@ -472,21 +514,24 @@ impl ReachableFileCleanupStrategy {
         mut deletion_candidates: HashSet<ManifestFile>,
     ) -> Result<(HashSet<ManifestFile>, HashSet<ManifestFile>)> {
         let snapshots: Vec<_> = snapshots.cloned().collect();
-        let loaded = load_manifest_lists(
+
+        // Stream the surviving snapshots' manifest lists, pruning each entry from
+        // the candidate set and recording it as referenced, dropping each list
+        // immediately rather than holding all of them at once.
+        let mut referenced_manifests = HashSet::default();
+        for_each_manifest_list(
             &self.file_io,
             table_meta_data_ref,
             snapshots,
             self.load_concurrency,
+            |manifest_list| {
+                for manifest_file in manifest_list.entries() {
+                    deletion_candidates.remove(manifest_file);
+                    referenced_manifests.insert(manifest_file.clone());
+                }
+            },
         )
         .await?;
-
-        let mut referenced_manifests = HashSet::default();
-        for (_, manifest_list) in loaded {
-            for manifest_file in manifest_list.entries() {
-                deletion_candidates.remove(manifest_file);
-                referenced_manifests.insert(manifest_file.clone());
-            }
-        }
 
         Ok((deletion_candidates, referenced_manifests))
     }
@@ -502,41 +547,45 @@ impl ReachableFileCleanupStrategy {
         manifest_files: &HashSet<ManifestFile>,
         referenced_manifests: &HashSet<ManifestFile>,
     ) -> Result<HashSet<String>> {
-        // Load manifests to delete concurrently
+        // Stream the manifests being deleted, folding their data-file paths into
+        // the candidate set and dropping each manifest immediately.
         let manifests_to_delete_vec: Vec<_> = manifest_files.iter().cloned().collect();
-        let loaded_to_delete = load_manifests(
+        let mut files_to_delete = HashSet::default();
+        for_each_manifest(
             &self.file_io,
             manifests_to_delete_vec,
             self.load_concurrency,
+            |_, manifest| {
+                for entry in manifest.entries() {
+                    files_to_delete.insert(entry.data_file().file_path().to_owned());
+                }
+            },
         )
         .await?;
-
-        let mut files_to_delete = HashSet::default();
-        for (_, manifest) in loaded_to_delete {
-            for entry in manifest.entries() {
-                files_to_delete.insert(entry.data_file().file_path().to_owned());
-            }
-        }
 
         if files_to_delete.is_empty() {
             return Ok(files_to_delete);
         }
 
-        // Load referenced manifests concurrently
+        // Stream the surviving (referenced) manifests, removing files they still
+        // actively reference from the deletion set. Only protect files that are
+        // actively referenced (Added or Existing); entries with Deleted status
+        // are tombstones — they indicate the file was removed from the table and
+        // should not prevent its deletion from storage.
         let referenced_vec: Vec<_> = referenced_manifests.iter().cloned().collect();
-        let loaded_referenced =
-            load_manifests(&self.file_io, referenced_vec, self.load_concurrency).await?;
-
-        // Only protect files that are actively referenced (Added or Existing).
-        // Entries with Deleted status are tombstones — they indicate the file was
-        // removed from the table and should not prevent its deletion from storage.
-        for (_, manifest) in loaded_referenced {
-            for entry in manifest.entries() {
-                if entry.status() != ManifestStatus::Deleted {
-                    files_to_delete.remove(entry.data_file().file_path());
+        for_each_manifest(
+            &self.file_io,
+            referenced_vec,
+            self.load_concurrency,
+            |_, manifest| {
+                for entry in manifest.entries() {
+                    if entry.status() != ManifestStatus::Deleted {
+                        files_to_delete.remove(entry.data_file().file_path());
+                    }
                 }
-            }
-        }
+            },
+        )
+        .await?;
 
         Ok(files_to_delete)
     }


### PR DESCRIPTION
## Summary

Follow-up to #170 (stacked on its branch). Applies the same streaming approach to the snapshot-expiration **file cleanup** path (`ReachableFileCleanupStrategy`, run after a `remove_snapshots` commit when `clear_expired_files` is enabled).

Previously each cleanup step loaded an entire collection up front and held it in memory alongside the set it derived:
- `clean_files` / `prune_referenced_manifests` → `load_manifest_lists` into `Vec<(SnapshotRef, ManifestList)>`, then folded entries into `HashSet<ManifestFile>`.
- `find_files_to_delete` → `load_manifests` into `Vec<(ManifestFile, Manifest)>`, then folded data-file paths into `HashSet<String>`.

Holding the fully-loaded `Vec` *and* the derived set simultaneously roughly doubles peak memory on tables with many/large manifests.

## Change

- Add a `for_each_manifest` streaming helper (analogous to `for_each_manifest_list` from #170): loads with bounded concurrency via `buffer_unordered` and invokes a closure per manifest, dropping each immediately.
- Convert the three cleanup sites to fold entries into their sets while dropping each loaded list/manifest right away.

Peak memory for the load drops from **O(all loaded lists/manifests + derived set)** → **O(concurrency in flight + derived set)**. Behavior is unchanged.

## Scope / caveat

This bounds the **loading**. The derived sets (manifest files, data-file paths) are still O(N) by nature of the diff-based cleanup algorithm — fully bounding cleanup needs a batched/partitioned deletion strategy, which is a separate follow-up.

## Testing

- `cargo check -p iceberg`, `cargo test -p iceberg cleanup` (5 passed), `cargo clippy -p iceberg` clean, `cargo fmt --check` clean.

> Based on #170; review/merge that first. Once #170 merges this can be retargeted to the integration branch.