### PR TITLE
fix(rewrite_manifests): honor target size from snapshot properties

### DIFF
--- a/crates/iceberg/src/transaction/rewrite_manifests.rs
+++ b/crates/iceberg/src/transaction/rewrite_manifests.rs
@@ -388,10 +388,22 @@ impl TransactionAction for RewriteManifestsAction {
             // for the same cluster key. Mirrors Spark/Iceberg
             // `commit.manifest.target-size-bytes` (default 8 MiB) so a hot
             // partition no longer produces one unbounded manifest.
-            let target_manifest_size_bytes: u64 = table
-                .metadata()
-                .properties()
+            //
+            // Resolution order: the per-commit snapshot property set on this
+            // action via `set_snapshot_properties` wins, so a caller can size
+            // the manifests for a single rewrite without persisting a table
+            // property (the snapshot property is also recorded in the snapshot
+            // summary); otherwise fall back to the table property, then the
+            // Iceberg default.
+            let target_manifest_size_bytes: u64 = self
+                .snapshot_properties
                 .get(MANIFEST_TARGET_SIZE_BYTES)
+                .or_else(|| {
+                    table
+                        .metadata()
+                        .properties()
+                        .get(MANIFEST_TARGET_SIZE_BYTES)
+                })
                 .and_then(|s| s.parse::<u64>().ok())
                 .unwrap_or(MANIFEST_TARGET_SIZE_BYTES_DEFAULT as u64);
 

--- a/crates/integration_tests/tests/rewrite_manifests_test.rs
+++ b/crates/integration_tests/tests/rewrite_manifests_test.rs
@@ -301,6 +301,87 @@ async fn test_rewrite_manifests_target_size_rollover() {
     assert_eq!(total_rows, NUM_FILES * 4);
 }
 
+/// Test: a per-commit snapshot property sets the manifest target size and takes
+/// precedence over the table property.
+///
+/// The target size resolves in order: `set_snapshot_properties` on the action,
+/// then the table property, then the default. Here the table property would
+/// consolidate everything into one manifest (large target), but a 1-byte
+/// snapshot property forces each entry into its own manifest — proving the
+/// snapshot property wins without persisting anything on the table.
+#[tokio::test]
+async fn test_rewrite_manifests_target_size_from_snapshot_property() {
+    const NUM_FILES: usize = 4;
+    // Table property is deliberately huge so, on its own, it would consolidate
+    // all entries into a single manifest.
+    let (rest_catalog, table) =
+        create_table_with_manifests_and_properties(NUM_FILES, "t_rwm_snap_target", [(
+            "commit.manifest.target-size-bytes".to_string(),
+            "1073741824".to_string(), // 1 GiB
+        )])
+        .await;
+
+    let snapshot = table.metadata().current_snapshot().unwrap();
+    let manifest_list = snapshot
+        .load_manifest_list(table.file_io(), table.metadata())
+        .await
+        .unwrap();
+    assert_eq!(manifest_list.entries().len(), NUM_FILES);
+
+    // A 1-byte target supplied as a snapshot property overrides the 1 GiB table
+    // property, rolling each entry into its own manifest.
+    let mut props = std::collections::HashMap::new();
+    props.insert(
+        "commit.manifest.target-size-bytes".to_string(),
+        "1".to_string(),
+    );
+    let tx = Transaction::new(&table);
+    let action = tx
+        .rewrite_manifests()
+        .cluster_by(Box::new(|_data_file| "all".to_string()))
+        .set_snapshot_properties(props);
+    let tx = action.apply(tx).unwrap();
+    let table = tx.commit(&rest_catalog).await.unwrap();
+
+    let snapshot = table.metadata().current_snapshot().unwrap();
+    let manifest_list = snapshot
+        .load_manifest_list(table.file_io(), table.metadata())
+        .await
+        .unwrap();
+    assert_eq!(
+        manifest_list.entries().len(),
+        NUM_FILES,
+        "snapshot-property 1-byte target should override the 1 GiB table \
+         property and roll each entry into its own manifest"
+    );
+
+    // The table property is unchanged (the override is per-commit only).
+    assert_eq!(
+        table
+            .metadata()
+            .properties()
+            .get("commit.manifest.target-size-bytes")
+            .map(String::as_str),
+        Some("1073741824"),
+        "snapshot-property override must not mutate the table property"
+    );
+
+    // Data is preserved.
+    let batches: Vec<RecordBatch> = table
+        .scan()
+        .select_all()
+        .build()
+        .unwrap()
+        .to_arrow()
+        .await
+        .unwrap()
+        .try_collect()
+        .await
+        .unwrap();
+    let total_rows: usize = batches.iter().map(|b| b.num_rows()).sum();
+    assert_eq!(total_rows, NUM_FILES * 4);
+}
+
 /// Test: rewrite manifests with rewrite_if predicate only rewrites matching manifests.
 ///
 /// 1. Create 3 manifests via fast_append.


### PR DESCRIPTION
## What

Make the rewrite-manifests target size (`commit.manifest.target-size-bytes`) resolvable from the **staged snapshot property** set on the action, taking precedence over the persistent table property.

Resolution order is now:
1. This action's snapshot property (`set_snapshot_properties`) — per-commit, transient
2. The table property (`table.metadata().properties()`) — persistent
3. The Iceberg default (8 MiB)

## Why

`RewriteManifestsAction` splits a hot cluster's entries across multiple output manifests once a writer reaches the target size (added in #174). That target was read **only** from the persistent *table* properties:

```rust
let target_manifest_size_bytes: u64 = table
    .metadata()
    .properties()
    .get(MANIFEST_TARGET_SIZE_BYTES)
    .and_then(|s| s.parse::<u64>().ok())
    .unwrap_or(MANIFEST_TARGET_SIZE_BYTES_DEFAULT as u64);
```

A caller that sets the size per-commit via `set_snapshot_properties(commit.manifest.target-size-bytes)` — the natural way to control a single rewrite **without** mutating the table's persisted configuration — had no effect on the actual manifest sizing. The value was written into the snapshot summary but silently ignored by the writer loop. This is a footgun: downstream services (e.g. a maintenance job that wants to size manifests for one rewrite) reasonably expect the snapshot property to take effect.

## How

Read the property from `self.snapshot_properties` first, falling back to the table property, then the default:

```rust
let target_manifest_size_bytes: u64 = self
    .snapshot_properties
    .get(MANIFEST_TARGET_SIZE_BYTES)
    .or_else(|| table.metadata().properties().get(MANIFEST_TARGET_SIZE_BYTES))
    .and_then(|s| s.parse::<u64>().ok())
    .unwrap_or(MANIFEST_TARGET_SIZE_BYTES_DEFAULT as u64);
```

## Testing

- Existing `test_rewrite_manifests_target_size_rollover` (table-property path) still passes — the table property remains the fallback.
- New `test_rewrite_manifests_target_size_from_snapshot_property`: sets a **1 GiB table property** (which alone would consolidate everything into one manifest) and a **1-byte snapshot property**, and asserts each entry rolls into its own manifest — proving the snapshot property wins. Also asserts the table property is left unchanged (the override is per-commit only) and data is preserved.
- `cargo check -p iceberg`, `cargo clippy -p iceberg --all-targets`, and `cargo fmt` are clean; the integration test compiles (it requires the REST-catalog docker fixture to run).

## Compatibility

Backwards compatible. Behavior only changes when a caller sets `commit.manifest.target-size-bytes` via `set_snapshot_properties` — previously a no-op, now honored. Tables relying on the table property or the default are unaffected.