### PR TITLE
chore: update code owners (add @netgusto & @agaddis02, remove @jonathanc-n)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -16,4 +16,4 @@
 # under the License.
 
 # Automatically request reviews from these users on all PRs
-* @mwylde @nagraham @Li0k @chenzl25 @jonathanc-n @vovacf201
+* @mwylde @nagraham @Li0k @chenzl25 @jonathanc-n @vovacf201 @netgusto

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -16,4 +16,4 @@
 # under the License.
 
 # Automatically request reviews from these users on all PRs
-* @mwylde @nagraham @Li0k @chenzl25 @vovacf201 @netgusto
+* @mwylde @nagraham @Li0k @chenzl25 @vovacf201 @netgusto @agaddis02

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -16,4 +16,4 @@
 # under the License.
 
 # Automatically request reviews from these users on all PRs
-* @mwylde @nagraham @Li0k @chenzl25 @jonathanc-n @vovacf201 @netgusto
+* @mwylde @nagraham @Li0k @chenzl25 @vovacf201 @netgusto


### PR DESCRIPTION
## Summary
Updates `.github/CODEOWNERS`:
- **Add** `@netgusto` and `@agaddis02`
- **Remove** `@jonathanc-n`

Resulting owner list (auto-requested on all PRs):
```
* @mwylde @nagraham @Li0k @chenzl25 @vovacf201 @netgusto @agaddis02
```

Kept in sync with `nimtable/iceberg-compaction` (nimtable/iceberg-compaction#152) — both repos share the same owner list.