### PR TITLE
perf(iceberg): stream manifest loading in orphan file removal

### DIFF
--- a/crates/iceberg/src/actions/remove_orphan_files.rs
+++ b/crates/iceberg/src/actions/remove_orphan_files.rs
@@ -29,7 +29,7 @@ use futures::stream::{self, StreamExt};
 
 use crate::Result;
 use crate::table::Table;
-use crate::utils::{load_manifest_lists, load_manifests};
+use crate::utils::{for_each_manifest, for_each_manifest_list};
 
 /// Default time offset for orphan file deletion threshold (1 day in milliseconds).
 const DEFAULT_OLDER_THAN_MS: i64 = 7 * 24 * 60 * 60 * 1000; // 7 days
@@ -210,36 +210,42 @@ impl RemoveOrphanFilesAction {
 
         let snapshots: Vec<_> = table_metadata.snapshots().cloned().collect();
 
-        // Load manifest lists concurrently using shared loader
-        let loaded_lists =
-            load_manifest_lists(file_io, &table_metadata, snapshots, self.load_concurrency).await?;
-
-        // Collect manifest list paths, manifest files, and deduplicate for loading
-        let mut unique_manifest_files = Vec::new();
-        for (snapshot, manifest_list) in loaded_lists {
-            // Record manifest list path as reachable
+        // Record manifest list paths as reachable (cheap — just strings).
+        for snapshot in &snapshots {
             let manifest_list_path = snapshot.manifest_list();
             if !manifest_list_path.is_empty() {
                 reachable.insert(manifest_list_path.to_string());
             }
+        }
 
-            for manifest_file in manifest_list.entries() {
-                // Only load each manifest once (reachable set handles deduplication)
-                if reachable.insert(manifest_file.manifest_path.clone()) {
-                    unique_manifest_files.push(manifest_file.clone());
+        let mut unique_manifest_files = Vec::new();
+        for_each_manifest_list(
+            file_io,
+            &table_metadata,
+            snapshots,
+            self.load_concurrency,
+            |manifest_list| {
+                for manifest_file in manifest_list.entries() {
+                    // Only load each manifest once (reachable set handles deduplication).
+                    if reachable.insert(manifest_file.manifest_path.clone()) {
+                        unique_manifest_files.push(manifest_file.clone());
+                    }
                 }
-            }
-        }
+            },
+        )
+        .await?;
 
-        // Load manifests concurrently using shared loader and collect content files
-        let loaded_manifests =
-            load_manifests(file_io, unique_manifest_files, self.load_concurrency).await?;
-
-        for (_, manifest) in loaded_manifests {
-            for entry in manifest.entries() {
-                reachable.insert(entry.data_file().file_path().to_string());
-            }
-        }
+        for_each_manifest(
+            file_io,
+            unique_manifest_files,
+            self.load_concurrency,
+            |_, manifest| {
+                for entry in manifest.entries() {
+                    reachable.insert(entry.data_file().file_path().to_string());
+                }
+            },
+        )
+        .await?;
 
         Ok(())
     }

--- a/crates/iceberg/src/utils.rs
+++ b/crates/iceberg/src/utils.rs
@@ -255,31 +255,6 @@ use crate::spec::{Manifest, ManifestFile, ManifestList, ManifestStatus, Snapshot
 pub(crate) const DEFAULT_DELETE_CONCURRENCY_LIMIT: usize = 10;
 pub(crate) const DEFAULT_LOAD_CONCURRENCY_LIMIT: usize = 16;
 
-/// Concurrently loads manifest lists for the given snapshots.
-pub(crate) async fn load_manifest_lists(
-    file_io: &FileIO,
-    table_metadata: &TableMetadataRef,
-    snapshots: Vec<SnapshotRef>,
-    concurrency: usize,
-) -> Result<Vec<(SnapshotRef, ManifestList)>> {
-    let concurrency = concurrency.max(1);
-
-    stream::iter(snapshots)
-        .map(|snapshot| {
-            let file_io = file_io.clone();
-            let table_metadata = table_metadata.clone();
-            async move {
-                let manifest_list = snapshot
-                    .load_manifest_list(&file_io, &table_metadata)
-                    .await?;
-                Ok((snapshot, manifest_list))
-            }
-        })
-        .buffer_unordered(concurrency)
-        .try_collect()
-        .await
-}
-
 /// Streams the manifest lists for `snapshots`, invoking `f` on each loaded
 /// [`ManifestList`] and dropping it immediately afterwards.
 ///


### PR DESCRIPTION
Replaces the batch-loading approach in RemoveOrphanFilesAction::collect_snapshot_files with the streaming helpers for_each_manifest_list and for_each_manifest (introduced in #170–#172).

**Before**: load_manifest_lists and load_manifests loaded all manifest lists and manifests into memory at once — peak memory scaled with O(all snapshots × manifests).

**After**: Manifest list paths are extracted from snapshots upfront, then manifests are streamed with bounded concurrency and dropped immediately after folding entries into the reachable set. Peak memory is now O(concurrency) instead of O(all manifests).

Also removes load_manifest_lists from utils.rs — zero callers after this change.