### PR TITLE
perf(writer): parallelize FanoutWriter::close() to eliminate sequential upload bottleneck

### DIFF
--- a/crates/iceberg/src/writer/partitioning/fanout_writer.rs
+++ b/crates/iceberg/src/writer/partitioning/fanout_writer.rs
@@ -21,7 +21,7 @@ use std::collections::HashMap;
 use std::marker::PhantomData;
 
 use async_trait::async_trait;
-use futures::future::try_join_all;
+use futures::stream::{self, StreamExt};
 
 use crate::spec::{PartitionKey, Struct};
 use crate::writer::partitioning::PartitioningWriter;
@@ -29,6 +29,12 @@ use crate::writer::{
     DefaultInput, DefaultOutput, IcebergWriter, IcebergWriterBuilder, PositionDeleteInput,
 };
 use crate::{Error, ErrorKind, Result};
+
+/// Maximum number of partition writers that `FanoutWriter::close` finalizes
+/// (flush + upload) concurrently. Closes for distinct partitions are
+/// independent, but bounding the concurrency caps the number of simultaneous
+/// object-store uploads for tables with many active partitions.
+const DEFAULT_CLOSE_CONCURRENCY_LIMIT: usize = 16;
 
 /// A writer that can write data to multiple partitions simultaneously.
 ///
@@ -117,10 +123,32 @@ where
     }
 
     async fn close(mut self) -> Result<O> {
-        let mut writers: Vec<B::R> = self.partition_writers.into_values().collect();
-        let results: Vec<O> = try_join_all(writers.iter_mut().map(|w| w.close())).await?;
-        for result in results {
-            self.output.extend(result);
+        // Finalize partition writers with bounded concurrency. Each close is an
+        // independent object-store upload, and a fan-out writer may hold one
+        // writer per active partition, so bounding the concurrency caps the
+        // number of simultaneous uploads.
+        //
+        // The drain loop uses a plain `buffer_unordered` stream: on the first
+        // failing close the remaining in-flight closes are not cancelled, and
+        // every started close runs to completion before the first error is
+        // surfaced.
+        let writers: Vec<B::R> = self.partition_writers.into_values().collect();
+        let mut close_stream = stream::iter(writers)
+            .map(|mut writer| async move { writer.close().await })
+            .buffer_unordered(DEFAULT_CLOSE_CONCURRENCY_LIMIT);
+
+        let mut first_error = None;
+        while let Some(result) = close_stream.next().await {
+            match result {
+                Ok(output) => self.output.extend(output),
+                Err(error) => {
+                    first_error.get_or_insert(error);
+                }
+            }
+        }
+
+        if let Some(error) = first_error {
+            return Err(error);
         }
         Ok(O::from_iter(self.output))
     }
@@ -130,12 +158,14 @@ where
 mod tests {
     use std::collections::HashMap;
     use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
 
     use arrow_array::{Int32Array, RecordBatch, StringArray};
     use arrow_schema::{DataType, Field, Schema};
     use parquet::arrow::PARQUET_FIELD_ID_META_KEY;
     use parquet::file::properties::WriterProperties;
     use tempfile::TempDir;
+    use tokio::sync::Barrier;
 
     use super::*;
     use crate::io::FileIOBuilder;
@@ -391,6 +421,185 @@ mod tests {
             "Missing ASIA partition"
         );
 
+        Ok(())
+    }
+
+    // A controllable mock writer for asserting the close() concurrency bound
+    // and that no started close is cancelled when one partition fails.
+
+    #[derive(Default)]
+    struct MockCloseState {
+        in_flight: AtomicUsize,
+        max_in_flight: AtomicUsize,
+        started: AtomicUsize,
+        finished: AtomicUsize,
+        next_id: AtomicUsize,
+    }
+
+    struct MockWriterBuilder {
+        state: Arc<MockCloseState>,
+        barrier: Arc<Barrier>,
+        fail_indices: Vec<usize>,
+    }
+
+    struct MockWriter {
+        id: usize,
+        state: Arc<MockCloseState>,
+        barrier: Arc<Barrier>,
+        fail: bool,
+    }
+
+    #[async_trait]
+    impl IcebergWriterBuilder<(), Vec<u32>> for MockWriterBuilder {
+        type R = MockWriter;
+        async fn build(&self, _partition_key: Option<PartitionKey>) -> Result<Self::R> {
+            let id = self.state.next_id.fetch_add(1, Ordering::SeqCst);
+            Ok(MockWriter {
+                id,
+                state: self.state.clone(),
+                barrier: self.barrier.clone(),
+                fail: self.fail_indices.contains(&id),
+            })
+        }
+    }
+
+    #[async_trait]
+    impl IcebergWriter<(), Vec<u32>> for MockWriter {
+        async fn write(&mut self, _input: ()) -> Result<()> {
+            Ok(())
+        }
+
+        async fn close(&mut self) -> Result<Vec<u32>> {
+            // Record ourselves as in-flight, then wait at the shared barrier so
+            // the test can force a deterministic number of overlapping closes.
+            let in_flight = self.state.in_flight.fetch_add(1, Ordering::SeqCst) + 1;
+            self.state
+                .max_in_flight
+                .fetch_max(in_flight, Ordering::SeqCst);
+            self.state.started.fetch_add(1, Ordering::SeqCst);
+
+            self.barrier.wait().await;
+
+            self.state.in_flight.fetch_sub(1, Ordering::SeqCst);
+            self.state.finished.fetch_add(1, Ordering::SeqCst);
+
+            if self.fail {
+                Err(Error::new(
+                    ErrorKind::Unexpected,
+                    format!("mock writer {} close failure", self.id),
+                ))
+            } else {
+                Ok(vec![self.id as u32])
+            }
+        }
+    }
+
+    fn build_schema_and_spec() -> (Arc<crate::spec::Schema>, PartitionSpec) {
+        let schema = Arc::new(
+            crate::spec::Schema::builder()
+                .with_schema_id(1)
+                .with_fields(vec![
+                    NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
+                    NestedField::required(2, "name", Type::Primitive(PrimitiveType::String)).into(),
+                    NestedField::required(3, "region", Type::Primitive(PrimitiveType::String))
+                        .into(),
+                ])
+                .build()
+                .expect("schema builds"),
+        );
+        let spec = PartitionSpec::builder(schema.clone())
+            .build()
+            .expect("partition spec builds");
+        (schema, spec)
+    }
+
+    fn partition_key_for(
+        schema: &Arc<crate::spec::Schema>,
+        spec: &PartitionSpec,
+        region: &str,
+    ) -> PartitionKey {
+        let value = Struct::from_iter([Some(Literal::string(region))]);
+        PartitionKey::new(spec.clone(), schema.clone(), value)
+    }
+
+    #[tokio::test]
+    async fn test_close_bounds_in_flight_closes() -> Result<()> {
+        let (schema, spec) = build_schema_and_spec();
+        let state = Arc::new(MockCloseState::default());
+        let builder = MockWriterBuilder {
+            state: state.clone(),
+            barrier: Arc::new(Barrier::new(DEFAULT_CLOSE_CONCURRENCY_LIMIT)),
+            fail_indices: vec![],
+        };
+        let mut writer = FanoutWriter::<MockWriterBuilder, (), Vec<u32>>::new(builder);
+
+        // Twice as many partitions as the concurrency limit, so the close
+        // stream must flow through two barrier "waves".
+        let num_partitions = DEFAULT_CLOSE_CONCURRENCY_LIMIT * 2;
+        for i in 0..num_partitions {
+            writer
+                .write(partition_key_for(&schema, &spec, &format!("p{i}")), ())
+                .await?;
+        }
+
+        let data = writer.close().await?;
+
+        // The concurrency window fills to the limit and never exceeds it, even
+        // though there are twice as many writers as slots.
+        assert_eq!(
+            state.max_in_flight.load(Ordering::SeqCst),
+            DEFAULT_CLOSE_CONCURRENCY_LIMIT,
+            "close() should run up to the concurrency limit and no more"
+        );
+        assert_eq!(
+            state.finished.load(Ordering::SeqCst),
+            num_partitions,
+            "every partition writer should have been closed"
+        );
+        assert_eq!(data.len(), num_partitions);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_close_drains_remaining_closes_on_error() -> Result<()> {
+        let (schema, spec) = build_schema_and_spec();
+        let state = Arc::new(MockCloseState::default());
+        // Fail the first-built writer. Partition-writer close order follows an
+        // arbitrary HashMap iteration order, so we assert only that the error
+        // propagates and that every started close still completes — not which
+        // partition errored.
+        let builder = MockWriterBuilder {
+            state: state.clone(),
+            barrier: Arc::new(Barrier::new(DEFAULT_CLOSE_CONCURRENCY_LIMIT)),
+            fail_indices: vec![0],
+        };
+        let mut writer = FanoutWriter::<MockWriterBuilder, (), Vec<u32>>::new(builder);
+
+        let num_partitions = DEFAULT_CLOSE_CONCURRENCY_LIMIT * 2;
+        for i in 0..num_partitions {
+            writer
+                .write(partition_key_for(&schema, &spec, &format!("p{i}")), ())
+                .await?;
+        }
+
+        let result = writer.close().await;
+        assert!(
+            result.is_err(),
+            "close() should surface the failing writer's error"
+        );
+
+        // Plain `buffer_unordered` must drain every started close instead of
+        // cancelling the rest on the first error.
+        assert_eq!(
+            state.started.load(Ordering::SeqCst),
+            num_partitions,
+            "all partition writers should have started closing"
+        );
+        assert_eq!(
+            state.finished.load(Ordering::SeqCst),
+            num_partitions,
+            "all started closes should drain to completion (no cancellation)"
+        );
         Ok(())
     }
 }

--- a/crates/iceberg/src/writer/partitioning/fanout_writer.rs
+++ b/crates/iceberg/src/writer/partitioning/fanout_writer.rs
@@ -20,6 +20,8 @@
 use std::collections::HashMap;
 use std::marker::PhantomData;
 
+use futures::future::try_join_all;
+
 use async_trait::async_trait;
 
 use crate::spec::{PartitionKey, Struct};
@@ -116,12 +118,12 @@ where
     }
 
     async fn close(mut self) -> Result<O> {
-        // Close all partition writers
-        for (_, mut writer) in self.partition_writers {
-            self.output.extend(writer.close().await?);
+        let mut writers: Vec<B::R> = self.partition_writers.into_values().collect();
+        let results: Vec<O> =
+            try_join_all(writers.iter_mut().map(|w| w.close())).await?;
+        for result in results {
+            self.output.extend(result);
         }
-
-        // Collect all output items into the output collection type
         Ok(O::from_iter(self.output))
     }
 }

--- a/crates/iceberg/src/writer/partitioning/fanout_writer.rs
+++ b/crates/iceberg/src/writer/partitioning/fanout_writer.rs
@@ -20,9 +20,8 @@
 use std::collections::HashMap;
 use std::marker::PhantomData;
 
-use futures::future::try_join_all;
-
 use async_trait::async_trait;
+use futures::future::try_join_all;
 
 use crate::spec::{PartitionKey, Struct};
 use crate::writer::partitioning::PartitioningWriter;
@@ -119,8 +118,7 @@ where
 
     async fn close(mut self) -> Result<O> {
         let mut writers: Vec<B::R> = self.partition_writers.into_values().collect();
-        let results: Vec<O> =
-            try_join_all(writers.iter_mut().map(|w| w.close())).await?;
+        let results: Vec<O> = try_join_all(writers.iter_mut().map(|w| w.close())).await?;
         for result in results {
             self.output.extend(result);
         }


### PR DESCRIPTION
When closing a `FanoutWriter` with many partitions, each partition writer was closed sequentially. For remote object stores (GCS, S3), each close flushes and uploads a Parquet file, so total commit latency scaled linearly with the number of active partitions (sum of all upload times).

Uploads across different partition files are fully independent, so they are driven concurrently using `try_join_all`. Commit latency now approximates the single slowest upload rather than the cumulative sum.