### PR TITLE
fix: rewrite/overwrite transactions mishandle DELETE manifests

### DIFF
--- a/crates/iceberg/src/spec/manifest/writer.rs
+++ b/crates/iceberg/src/spec/manifest/writer.rs
@@ -381,10 +381,6 @@ impl ManifestWriter {
 
     /// Add an existing manifest entry. This method will update following status of the entry:
     /// - Update the entry status to `Existing`
-    ///
-    /// # TODO
-    /// Remove this allow later
-    #[allow(dead_code)]
     pub(crate) fn add_existing_entry(&mut self, mut entry: ManifestEntry) -> Result<()> {
         self.check_data_file(&entry.data_file)?;
         entry.status = ManifestStatus::Existing;

--- a/crates/iceberg/src/transaction/mod.rs
+++ b/crates/iceberg/src/transaction/mod.rs
@@ -304,10 +304,125 @@ mod tests {
 
     use crate::catalog::MockCatalog;
     use crate::io::FileIOBuilder;
-    use crate::spec::TableMetadata;
+    use crate::spec::{
+        DataContentType, DataFile, DataFileBuilder, DataFileFormat, Literal, MAIN_BRANCH,
+        ManifestListWriter, ManifestWriterBuilder, Operation, Snapshot, SnapshotReference,
+        SnapshotRetention, Struct, Summary, TableMetadata,
+    };
     use crate::table::Table;
     use crate::transaction::{ApplyTransactionAction, Transaction};
     use crate::{Catalog, Error, ErrorKind, TableCreation, TableIdent};
+
+    /// Fixture constants shared by the `overwrite_files` / `rewrite_files` tests.
+    pub const PARENT_SNAPSHOT_ID: i64 = 42;
+    pub const PARENT_SEQUENCE_NUMBER: i64 = 1;
+    pub const REMOVED_DELETE_FILE: &str = "test/removed-position-delete.parquet";
+    pub const RETAINED_DELETE_FILE: &str = "test/retained-position-delete.parquet";
+
+    const TABLE_LOCATION: &str = "memory:///test/location";
+    const MANIFEST_LIST_LOCATION: &str = "memory:///test/location/metadata/manifest-list-1.avro";
+    const DELETE_MANIFEST_LOCATION: &str =
+        "memory:///test/location/metadata/delete-manifest-1.avro";
+
+    pub fn position_delete_file(table: &Table, path: &str) -> DataFile {
+        DataFileBuilder::default()
+            .partition_spec_id(table.metadata().default_partition_spec_id())
+            .content(DataContentType::PositionDeletes)
+            .file_path(path.to_string())
+            .file_format(DataFileFormat::Parquet)
+            .file_size_in_bytes(100)
+            .record_count(1)
+            .partition(Struct::from_iter([Some(Literal::long(300))]))
+            .build()
+            .unwrap()
+    }
+
+    /// A V2 table whose `main` snapshot tracks a single *delete* manifest holding
+    /// both [`REMOVED_DELETE_FILE`] and [`RETAINED_DELETE_FILE`].
+    ///
+    /// The table location is rewritten to a `memory://` path so that actions
+    /// which write new manifests (e.g. `existing_manifest`) can do so through the
+    /// in-memory `FileIO`.
+    pub async fn make_v2_table_with_delete_manifest() -> Table {
+        let base = make_v2_minimal_table();
+        let metadata = base
+            .metadata()
+            .clone()
+            .into_builder(Some("s3://bucket/test/location/metadata/v1.json".into()))
+            .set_location(TABLE_LOCATION.to_string())
+            .build()
+            .unwrap()
+            .metadata;
+        let base = base.with_metadata(Arc::new(metadata));
+
+        let file_io = base.file_io().clone();
+        let mut manifest_writer = ManifestWriterBuilder::new(
+            file_io.new_output(DELETE_MANIFEST_LOCATION).unwrap(),
+            Some(PARENT_SNAPSHOT_ID),
+            None,
+            base.metadata().current_schema().clone(),
+            base.metadata().default_partition_spec().as_ref().clone(),
+        )
+        .build_v2_deletes();
+
+        // `add_existing_file` preserves snapshot id / sequence numbers, which
+        // `delete_entries` unwraps when it rewrites an entry as `Deleted`.
+        for path in [REMOVED_DELETE_FILE, RETAINED_DELETE_FILE] {
+            manifest_writer
+                .add_existing_file(
+                    position_delete_file(&base, path),
+                    PARENT_SNAPSHOT_ID,
+                    PARENT_SEQUENCE_NUMBER,
+                    Some(PARENT_SEQUENCE_NUMBER),
+                )
+                .unwrap();
+        }
+        let delete_manifest = manifest_writer.write_manifest_file().await.unwrap();
+
+        let mut manifest_list_writer = ManifestListWriter::v2(
+            file_io.new_output(MANIFEST_LIST_LOCATION).unwrap(),
+            PARENT_SNAPSHOT_ID,
+            None,
+            PARENT_SEQUENCE_NUMBER,
+        );
+        manifest_list_writer
+            .add_manifests(vec![delete_manifest].into_iter())
+            .unwrap();
+        manifest_list_writer.close().await.unwrap();
+
+        let parent_snapshot = Snapshot::builder()
+            .with_snapshot_id(PARENT_SNAPSHOT_ID)
+            .with_timestamp_ms(base.metadata().last_updated_ms() + 1)
+            .with_sequence_number(PARENT_SEQUENCE_NUMBER)
+            .with_schema_id(0)
+            .with_manifest_list(MANIFEST_LIST_LOCATION)
+            .with_summary(Summary {
+                operation: Operation::Overwrite,
+                additional_properties: HashMap::new(),
+            })
+            .build();
+
+        let metadata = base
+            .metadata()
+            .clone()
+            .into_builder(Some("s3://bucket/test/location/metadata/v1.json".into()))
+            .add_snapshot(parent_snapshot)
+            .unwrap()
+            .set_ref(MAIN_BRANCH, SnapshotReference {
+                snapshot_id: PARENT_SNAPSHOT_ID,
+                retention: SnapshotRetention::Branch {
+                    min_snapshots_to_keep: None,
+                    max_snapshot_age_ms: None,
+                    max_ref_age_ms: None,
+                },
+            })
+            .unwrap()
+            .build()
+            .unwrap()
+            .metadata;
+
+        base.with_metadata(Arc::new(metadata))
+    }
 
     pub fn make_v1_table() -> Table {
         let file = File::open(format!(

--- a/crates/iceberg/src/transaction/overwrite_files.rs
+++ b/crates/iceberg/src/transaction/overwrite_files.rs
@@ -28,8 +28,7 @@ use super::{
 };
 use crate::error::Result;
 use crate::spec::{
-    DataContentType, DataFile, ManifestContentType, ManifestEntry, ManifestFile, ManifestStatus,
-    Operation,
+    DataContentType, DataFile, ManifestEntry, ManifestFile, ManifestStatus, Operation,
 };
 use crate::table::Table;
 use crate::transaction::snapshot::SnapshotProduceOperation;
@@ -293,7 +292,7 @@ impl SnapshotProduceOperation for OverwriteFilesOperation {
                     .any(|entry| !found_deleted_files.contains(entry.data_file().file_path()))
                 {
                     let mut manifest_writer = snapshot_produce.new_manifest_writer(
-                        ManifestContentType::Data,
+                        manifest_file.content,
                         manifest_file.partition_spec_id,
                     )?;
 

--- a/crates/iceberg/src/transaction/overwrite_files.rs
+++ b/crates/iceberg/src/transaction/overwrite_files.rs
@@ -223,11 +223,11 @@ impl SnapshotProduceOperation for OverwriteFilesOperation {
                         deleted_entries.push(gen_manifest_entry(entry));
                     }
 
-                    if entry.content_type() == DataContentType::PositionDeletes
-                        || entry.content_type() == DataContentType::EqualityDeletes
-                            && snapshot_produce
-                                .removed_delete_file_paths
-                                .contains(entry.data_file().file_path())
+                    if (entry.content_type() == DataContentType::PositionDeletes
+                        || entry.content_type() == DataContentType::EqualityDeletes)
+                        && snapshot_produce
+                            .removed_delete_file_paths
+                            .contains(entry.data_file().file_path())
                     {
                         deleted_entries.push(gen_manifest_entry(entry));
                     }
@@ -286,19 +286,22 @@ impl SnapshotProduceOperation for OverwriteFilesOperation {
                 existing_files.push(manifest_file.clone());
             } else {
                 // Rewrite the manifest file without the deleted data files
-                if manifest
-                    .entries()
-                    .iter()
-                    .any(|entry| !found_deleted_files.contains(entry.data_file().file_path()))
-                {
+                let survives = |entry: &ManifestEntry| {
+                    entry.is_alive() && !found_deleted_files.contains(entry.data_file().file_path())
+                };
+
+                if manifest.entries().iter().any(|entry| survives(entry)) {
                     let mut manifest_writer = snapshot_produce.new_manifest_writer(
                         manifest_file.content,
                         manifest_file.partition_spec_id,
                     )?;
 
                     for entry in manifest.entries() {
-                        if !found_deleted_files.contains(entry.data_file().file_path()) {
-                            manifest_writer.add_entry((**entry).clone())?;
+                        // Carry survivors forward as `Existing`: `add_entry` would
+                        // restamp them as `Added` under the new snapshot and drop
+                        // their file sequence number.
+                        if survives(entry) {
+                            manifest_writer.add_existing_entry((**entry).clone())?;
                         }
                     }
 
@@ -359,5 +362,107 @@ impl TransactionAction for OverwriteFilesAction {
 impl Default for OverwriteFilesAction {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use uuid::Uuid;
+
+    use super::OverwriteFilesOperation;
+    use crate::spec::{ManifestContentType, ManifestStatus};
+    use crate::transaction::snapshot::{SnapshotProduceOperation, SnapshotProducer};
+    use crate::transaction::tests::{
+        PARENT_SEQUENCE_NUMBER, PARENT_SNAPSHOT_ID, REMOVED_DELETE_FILE, RETAINED_DELETE_FILE,
+        make_v2_table_with_delete_manifest, position_delete_file,
+    };
+
+    /// Regression test: an overwrite that removes one delete file must not mark
+    /// *unrelated* delete files as deleted.
+    #[tokio::test]
+    async fn test_overwrite_only_marks_removed_delete_files() {
+        let table = make_v2_table_with_delete_manifest().await;
+        let removed = position_delete_file(&table, REMOVED_DELETE_FILE);
+
+        let producer = SnapshotProducer::new(
+            &table,
+            Uuid::now_v7(),
+            None,
+            None,
+            HashMap::new(),
+            vec![],
+            vec![],
+            vec![],
+            vec![removed],
+        );
+
+        let deleted_entries = OverwriteFilesOperation
+            .delete_entries(&producer)
+            .await
+            .unwrap();
+        let deleted_paths: Vec<&str> = deleted_entries
+            .iter()
+            .map(|entry| entry.data_file().file_path())
+            .collect();
+
+        assert_eq!(
+            deleted_paths,
+            vec![REMOVED_DELETE_FILE],
+            "only the removed delete file should be marked deleted; \
+             {RETAINED_DELETE_FILE} must stay live"
+        );
+    }
+
+    /// Regression test: rewriting a partially-deleted *delete* manifest must
+    /// preserve its `Deletes` content type.
+    #[tokio::test]
+    async fn test_overwrite_preserves_delete_manifest_content_type() {
+        let table = make_v2_table_with_delete_manifest().await;
+        let removed = position_delete_file(&table, REMOVED_DELETE_FILE);
+
+        let mut producer = SnapshotProducer::new(
+            &table,
+            Uuid::now_v7(),
+            None,
+            None,
+            HashMap::new(),
+            vec![],
+            vec![],
+            vec![],
+            vec![removed],
+        );
+
+        let existing = OverwriteFilesOperation
+            .existing_manifest(&mut producer)
+            .await
+            .unwrap();
+
+        assert_eq!(existing.len(), 1, "the delete manifest should be rewritten");
+        assert_eq!(
+            existing[0].content,
+            ManifestContentType::Deletes,
+            "a rewritten delete manifest must stay a Deletes manifest"
+        );
+
+        let entries = existing[0].load_manifest(table.file_io()).await.unwrap();
+        let paths: Vec<&str> = entries
+            .entries()
+            .iter()
+            .map(|entry| entry.data_file().file_path())
+            .collect();
+        assert_eq!(paths, vec![RETAINED_DELETE_FILE]);
+
+        // The survivor is carried forward untouched, not restamped as a new
+        // addition of this snapshot.
+        let retained = &entries.entries()[0];
+        assert_eq!(retained.status(), ManifestStatus::Existing);
+        assert_eq!(retained.snapshot_id(), Some(PARENT_SNAPSHOT_ID));
+        assert_eq!(retained.sequence_number(), Some(PARENT_SEQUENCE_NUMBER));
+        assert_eq!(
+            retained.file_sequence_number(),
+            Some(PARENT_SEQUENCE_NUMBER)
+        );
     }
 }

--- a/crates/iceberg/src/transaction/rewrite_files.rs
+++ b/crates/iceberg/src/transaction/rewrite_files.rs
@@ -286,19 +286,22 @@ impl SnapshotProduceOperation for RewriteFilesOperation {
                 existing_files.push(manifest_file.clone());
             } else {
                 // Rewrite the manifest file without the deleted data files
-                if manifest
-                    .entries()
-                    .iter()
-                    .any(|entry| !found_deleted_files.contains(entry.data_file().file_path()))
-                {
+                let survives = |entry: &ManifestEntry| {
+                    entry.is_alive() && !found_deleted_files.contains(entry.data_file().file_path())
+                };
+
+                if manifest.entries().iter().any(|entry| survives(entry)) {
                     let mut manifest_writer = snapshot_produce.new_manifest_writer(
                         manifest_file.content,
                         manifest_file.partition_spec_id,
                     )?;
 
                     for entry in manifest.entries() {
-                        if !found_deleted_files.contains(entry.data_file().file_path()) {
-                            manifest_writer.add_entry((**entry).clone())?;
+                        // Carry survivors forward as `Existing`: `add_entry` would
+                        // restamp them as `Added` under the new snapshot and drop
+                        // their file sequence number.
+                        if survives(entry) {
+                            manifest_writer.add_existing_entry((**entry).clone())?;
                         }
                     }
 
@@ -359,5 +362,107 @@ impl TransactionAction for RewriteFilesAction {
 impl Default for RewriteFilesAction {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use uuid::Uuid;
+
+    use super::RewriteFilesOperation;
+    use crate::spec::{ManifestContentType, ManifestStatus};
+    use crate::transaction::snapshot::{SnapshotProduceOperation, SnapshotProducer};
+    use crate::transaction::tests::{
+        PARENT_SEQUENCE_NUMBER, PARENT_SNAPSHOT_ID, REMOVED_DELETE_FILE, RETAINED_DELETE_FILE,
+        make_v2_table_with_delete_manifest, position_delete_file,
+    };
+
+    /// Regression test: an rewrite that removes one delete file must not mark
+    /// *unrelated* delete files as deleted.
+    #[tokio::test]
+    async fn test_rewrite_only_marks_removed_delete_files() {
+        let table = make_v2_table_with_delete_manifest().await;
+        let removed = position_delete_file(&table, REMOVED_DELETE_FILE);
+
+        let producer = SnapshotProducer::new(
+            &table,
+            Uuid::now_v7(),
+            None,
+            None,
+            HashMap::new(),
+            vec![],
+            vec![],
+            vec![],
+            vec![removed],
+        );
+
+        let deleted_entries = RewriteFilesOperation
+            .delete_entries(&producer)
+            .await
+            .unwrap();
+        let deleted_paths: Vec<&str> = deleted_entries
+            .iter()
+            .map(|entry| entry.data_file().file_path())
+            .collect();
+
+        assert_eq!(
+            deleted_paths,
+            vec![REMOVED_DELETE_FILE],
+            "only the removed delete file should be marked deleted; \
+             {RETAINED_DELETE_FILE} must stay live"
+        );
+    }
+
+    /// Regression test: rewriting a partially-deleted *delete* manifest must
+    /// preserve its `Deletes` content type. See the `overwrite_files` twin.
+    #[tokio::test]
+    async fn test_rewrite_preserves_delete_manifest_content_type() {
+        let table = make_v2_table_with_delete_manifest().await;
+        let removed = position_delete_file(&table, REMOVED_DELETE_FILE);
+
+        let mut producer = SnapshotProducer::new(
+            &table,
+            Uuid::now_v7(),
+            None,
+            None,
+            HashMap::new(),
+            vec![],
+            vec![],
+            vec![],
+            vec![removed],
+        );
+
+        let existing = RewriteFilesOperation
+            .existing_manifest(&mut producer)
+            .await
+            .unwrap();
+
+        assert_eq!(existing.len(), 1, "the delete manifest should be rewritten");
+        assert_eq!(
+            existing[0].content,
+            ManifestContentType::Deletes,
+            "a rewritten delete manifest must stay a Deletes manifest"
+        );
+
+        let entries = existing[0].load_manifest(table.file_io()).await.unwrap();
+        let paths: Vec<&str> = entries
+            .entries()
+            .iter()
+            .map(|entry| entry.data_file().file_path())
+            .collect();
+        assert_eq!(paths, vec![RETAINED_DELETE_FILE]);
+
+        // The survivor is carried forward untouched, not restamped as a new
+        // addition of this snapshot.
+        let retained = &entries.entries()[0];
+        assert_eq!(retained.status(), ManifestStatus::Existing);
+        assert_eq!(retained.snapshot_id(), Some(PARENT_SNAPSHOT_ID));
+        assert_eq!(retained.sequence_number(), Some(PARENT_SEQUENCE_NUMBER));
+        assert_eq!(
+            retained.file_sequence_number(),
+            Some(PARENT_SEQUENCE_NUMBER)
+        );
     }
 }

--- a/crates/iceberg/src/transaction/rewrite_files.rs
+++ b/crates/iceberg/src/transaction/rewrite_files.rs
@@ -28,8 +28,7 @@ use super::{
 };
 use crate::error::Result;
 use crate::spec::{
-    DataContentType, DataFile, ManifestContentType, ManifestEntry, ManifestFile, ManifestStatus,
-    Operation,
+    DataContentType, DataFile, ManifestEntry, ManifestFile, ManifestStatus, Operation,
 };
 use crate::table::Table;
 use crate::transaction::snapshot::SnapshotProduceOperation;
@@ -293,7 +292,7 @@ impl SnapshotProduceOperation for RewriteFilesOperation {
                     .any(|entry| !found_deleted_files.contains(entry.data_file().file_path()))
                 {
                     let mut manifest_writer = snapshot_produce.new_manifest_writer(
-                        ManifestContentType::Data,
+                        manifest_file.content,
                         manifest_file.partition_spec_id,
                     )?;
 


### PR DESCRIPTION
### 1. The rewritten manifest lost its content type

The manifest writer was opened with a hardcoded content type:

```rust
let mut manifest_writer = snapshot_produce.new_manifest_writer(
    ManifestContentType::Data,          // <-- always Data
    manifest_file.partition_spec_id,
)?;
```

**Impact: the commit fails outright.**

```
DataInvalid => Date file at path <...> with manifest content type `data`,
should have DataContentType `Data`, but has `PositionDeletes`
```

### 2. Surviving entries were relabeled as newly added

Entries carried forward into the rewritten manifest were re-added with `add_entry`, which forces `status = Added`, overwrites `snapshot_id` with the new snapshot, and clears `file_sequence_number`.

**Fix:** use `add_existing_entry`, which preserves status, snapshot id, and both sequence numbers.

### 3. Operator precedence in `delete_entries` (`overwrite_files` only)

```rust
if entry.content_type() == DataContentType::PositionDeletes
    || entry.content_type() == DataContentType::EqualityDeletes
        && snapshot_produce.removed_delete_file_paths.contains(...)
```

`&&` binds tighter than `||`, so this parses as `PositionDeletes || (EqualityDeletes && contains)`: **every** position delete entry in the snapshot was marked `Deleted`, regardless of whether its path was in `removed_delete_file_paths` — including when that set is empty. `rewrite_files.rs` already had the correct grouping. Thanks @chenzl25 for catching this.

### Tests

| | `delete_entries` (precedence) | `existing_manifest` (content type + entry status) |
|---|---|---|
| overwrite | `test_overwrite_only_marks_removed_delete_files` | `test_overwrite_preserves_delete_manifest_content_type` |
| rewrite | `test_rewrite_only_marks_removed_delete_files` | `test_rewrite_preserves_delete_manifest_content_type` |
