### PR TITLE
chore: add @silver-ymz to code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -16,4 +16,4 @@
 # under the License.
 
 # Automatically request reviews from these users on all PRs
-* @mwylde @nagraham @Li0k @chenzl25 @vovacf201 @netgusto @agaddis02
+* @mwylde @nagraham @Li0k @chenzl25 @vovacf201 @netgusto @agaddis02 @silver-ymz


### PR DESCRIPTION
## Which issue does this PR close?

- N/A.

## What changes are included in this PR?

- Adds `@silver-ymz` to the global `.github/CODEOWNERS` rule so they are automatically requested for review on all pull requests.

## Are these changes tested?

- `git diff --check`
- Confirmed through the GitHub API that `silver-ymz` has write permission to the repository.