### PR TITLE
perf(iceberg): bound rewrite-manifests memory + calibrate manifest size estimate

### DIFF
--- a/crates/iceberg/src/spec/manifest/writer.rs
+++ b/crates/iceberg/src/spec/manifest/writer.rs
@@ -185,32 +185,76 @@ pub struct ManifestWriter {
     metadata: ManifestMetadata,
 }
 
-/// Rough estimate of a single manifest entry's serialized (Avro) footprint.
+/// Serialized (single-value) byte length of a bound [`Datum`], matching
+/// [`Datum::to_bytes`] but computed without allocating.
+///
+/// Iceberg stores bounds as the minimal single-value binary encoding, so the
+/// variable-width types (string / binary / decimal) must be measured from the
+/// value itself — assuming a fixed width both undercounts wide/untruncated
+/// bounds and overcounts the common truncated (≤16 byte) case.
+fn datum_serialized_len(datum: &Datum) -> u64 {
+    match datum.literal() {
+        PrimitiveLiteral::Boolean(_) => 1,
+        PrimitiveLiteral::Int(_) => 4,
+        PrimitiveLiteral::Long(_) => 8,
+        PrimitiveLiteral::Float(_) => 4,
+        PrimitiveLiteral::Double(_) => 8,
+        PrimitiveLiteral::String(s) => s.len() as u64,
+        PrimitiveLiteral::Binary(b) => b.len() as u64,
+        // Decimal (Int128) / UInt128 serialize to at most 16 bytes.
+        PrimitiveLiteral::Int128(_) | PrimitiveLiteral::UInt128(_) => 16,
+        PrimitiveLiteral::AboveMax | PrimitiveLiteral::BelowMin => 0,
+    }
+}
+
+/// Estimate of a single manifest entry's serialized (Avro) footprint.
 ///
 /// Captures the dominant variable-length terms — the data file path and the
-/// per-column statistic maps — plus a fixed per-entry overhead. Exact byte
-/// accuracy is intentionally not a goal: callers use this only to bound a
-/// manifest near a configured target size, so a cheap, allocation-free estimate
-/// is preferable to serializing the entry.
+/// per-column statistic maps (including the real bound value bytes) — plus a
+/// fixed per-entry overhead. Callers use this only to bound a manifest near a
+/// configured target size, so it is a cheap, allocation-free estimate rather
+/// than a full serialization.
+///
+/// The constants are calibrated against real uncompressed manifests (Iceberg
+/// writes manifests with `Codec::Null`, so the estimate and the on-disk length
+/// are in the same unit). Iceberg encodes each stat "map" as an Avro *array* of
+/// `{key: int, value: ...}` records, so per key/value the cost is a
+/// zigzag-varint int key plus the value's varint/bytes encoding — much smaller
+/// than a naive fixed-width assumption. Measured on a 1000-column table the
+/// estimate lands within a few percent of the on-disk length (versus the ~1.7×
+/// over-count of the earlier flat constants, which sealed manifests at ~0.6× the
+/// target); see `test_estimated_size_matches_on_disk_manifest`.
 fn estimate_manifest_entry_size(entry: &ManifestEntry) -> u64 {
-    // Fixed per-entry overhead: status, snapshot/sequence numbers, record_count,
-    // file_size_in_bytes, content/format enums, partition_spec_id, and Avro framing.
-    const FIXED_ENTRY_OVERHEAD: u64 = 128;
-    // Per key/value cost for the i32 -> i64 count maps (column_sizes,
-    // value_counts, null_value_counts, nan_value_counts).
-    const PER_COUNT_KV: u64 = 12;
-    // Per key/value cost for the bound maps (i32 key + a small scalar value).
-    const PER_BOUND_KV: u64 = 24;
+    // Fixed per-entry overhead for the non-map fields (status, snapshot/sequence
+    // numbers, content/format enums, record_count, file_size_in_bytes,
+    // partition_spec_id, null-union tags, and Avro framing).
+    const FIXED_ENTRY_OVERHEAD: u64 = 80;
+    // Per key/value cost for the count maps (column_sizes, value_counts,
+    // null_value_counts, nan_value_counts): a varint int key (~2 B) plus a
+    // varint long value (~1-3 B).
+    const PER_COUNT_KV: u64 = 4;
+    // Per key/value framing for the bound maps (varint int key + bytes-length
+    // prefix). The actual value bytes are added separately from the real Datum.
+    const PER_BOUND_KV_OVERHEAD: u64 = 4;
 
     let df = &entry.data_file;
     let mut size = FIXED_ENTRY_OVERHEAD;
-    size += df.file_path.len() as u64;
+    // file_path is an Avro string: a length prefix plus the UTF-8 bytes.
+    size += df.file_path.len() as u64 + 2;
     size += (df.column_sizes.len()
         + df.value_counts.len()
         + df.null_value_counts.len()
         + df.nan_value_counts.len()) as u64
         * PER_COUNT_KV;
-    size += (df.lower_bounds.len() + df.upper_bounds.len()) as u64 * PER_BOUND_KV;
+    // Bound maps: per-key/value framing plus the real serialized value bytes, so
+    // wide (untruncated / binary) bounds are counted accurately.
+    size += (df.lower_bounds.len() + df.upper_bounds.len()) as u64 * PER_BOUND_KV_OVERHEAD;
+    size += df
+        .lower_bounds
+        .values()
+        .chain(df.upper_bounds.values())
+        .map(datum_serialized_len)
+        .sum::<u64>();
     if let Some(key_metadata) = &df.key_metadata {
         size += key_metadata.len() as u64;
     }
@@ -930,5 +974,102 @@ mod tests {
         // monotonic, threshold-crossing signal the rewrite_manifests rollover
         // relies on to seal a manifest near the target size.
         assert_eq!(after_two, after_one * 2);
+    }
+
+    /// Calibration guard: the incremental size estimate must track the real
+    /// on-disk (uncompressed) manifest length within a modest tolerance for a
+    /// wide-schema manifest with realistic per-column bounds.
+    ///
+    /// This is the property the size-bounded rewrite relies on to seal
+    /// manifests near the configured target. The earlier flat constants
+    /// overcounted by ~1.7× (sealing manifests at ~0.6× the target on disk),
+    /// which this assertion rejects.
+    #[tokio::test]
+    async fn test_estimated_size_matches_on_disk_manifest() {
+        const NUM_COLS: i32 = 60;
+        const NUM_ENTRIES: usize = 80;
+
+        // Wide schema of string columns so bounds dominate, mirroring the
+        // production workload that motivated the calibration.
+        let fields: Vec<_> = (1..=NUM_COLS)
+            .map(|id| {
+                Arc::new(NestedField::optional(
+                    id,
+                    format!("c{id}"),
+                    Type::Primitive(PrimitiveType::String),
+                ))
+            })
+            .collect();
+        let schema = Arc::new(Schema::builder().with_fields(fields).build().unwrap());
+        let partition_spec = PartitionSpec::builder(schema.clone())
+            .with_spec_id(0)
+            .build()
+            .unwrap();
+
+        let tmp_dir = TempDir::new().unwrap();
+        let path = tmp_dir.path().join("calibration_manifest.avro");
+        let io = FileIOBuilder::new_fs_io().build().unwrap();
+        let output_file = io.new_output(path.to_str().unwrap()).unwrap();
+        let mut writer =
+            ManifestWriterBuilder::new(output_file, Some(1), None, schema.clone(), partition_spec)
+                .build_v2_data();
+
+        // Default bound truncation is 16 bytes; use 16-char values to match.
+        let bound = "abcdefghijklmnop";
+        for i in 0..NUM_ENTRIES {
+            let mut column_sizes = HashMap::new();
+            let mut value_counts = HashMap::new();
+            let mut null_value_counts = HashMap::new();
+            let mut lower_bounds = HashMap::new();
+            let mut upper_bounds = HashMap::new();
+            for id in 1..=NUM_COLS {
+                column_sizes.insert(id, 1234u64);
+                value_counts.insert(id, 100u64);
+                null_value_counts.insert(id, 0u64);
+                lower_bounds.insert(id, Datum::string(bound));
+                upper_bounds.insert(id, Datum::string(bound));
+            }
+            let entry = ManifestEntry {
+                status: ManifestStatus::Existing,
+                snapshot_id: Some(1),
+                sequence_number: Some(1),
+                file_sequence_number: Some(1),
+                data_file: DataFile {
+                    content: DataContentType::Data,
+                    file_path: format!("s3://bucket/db/table/data/{i:05}-0-abcdef.parquet"),
+                    file_format: DataFileFormat::Parquet,
+                    partition: Struct::empty(),
+                    record_count: 100,
+                    file_size_in_bytes: 123456,
+                    column_sizes,
+                    value_counts,
+                    null_value_counts,
+                    nan_value_counts: HashMap::new(),
+                    lower_bounds,
+                    upper_bounds,
+                    key_metadata: None,
+                    split_offsets: Some(vec![4]),
+                    equality_ids: None,
+                    sort_order_id: None,
+                    partition_spec_id: 0,
+                    first_row_id: None,
+                    referenced_data_file: None,
+                    content_offset: None,
+                    content_size_in_bytes: None,
+                },
+            };
+            writer.add_existing_entry(entry).unwrap();
+        }
+
+        let estimated = writer.estimated_manifest_size();
+        let manifest_file = writer.write_manifest_file().await.unwrap();
+        let actual = manifest_file.manifest_length as u64;
+
+        let ratio = estimated as f64 / actual as f64;
+        assert!(
+            (0.7..=1.4).contains(&ratio),
+            "estimate {estimated} should be within 30% of on-disk length {actual} \
+             (ratio {ratio:.3}); the per-entry constants need recalibration",
+        );
     }
 }

--- a/crates/iceberg/src/spec/manifest/writer.rs
+++ b/crates/iceberg/src/spec/manifest/writer.rs
@@ -185,8 +185,8 @@ pub struct ManifestWriter {
     metadata: ManifestMetadata,
 }
 
-/// Serialized (single-value) byte length of a bound [`Datum`], matching
-/// [`Datum::to_bytes`] but computed without allocating.
+/// Serialized (single-value) byte length of a bound [`Datum`], matching the byte
+/// length of [`Datum::to_bytes`] but computed without allocating.
 ///
 /// Iceberg stores bounds as the minimal single-value binary encoding, so the
 /// variable-width types (string / binary / decimal) must be measured from the
@@ -201,8 +201,36 @@ fn datum_serialized_len(datum: &Datum) -> u64 {
         PrimitiveLiteral::Double(_) => 8,
         PrimitiveLiteral::String(s) => s.len() as u64,
         PrimitiveLiteral::Binary(b) => b.len() as u64,
-        // Decimal (Int128) / UInt128 serialize to at most 16 bytes.
-        PrimitiveLiteral::Int128(_) | PrimitiveLiteral::UInt128(_) => 16,
+        // UUID is always 16 bytes.
+        PrimitiveLiteral::UInt128(_) => 16,
+        // Decimal uses a minimal two's-complement representation, clamped by the
+        // spec-required byte length for the declared precision.
+        PrimitiveLiteral::Int128(v) => {
+            let bytes = v.to_be_bytes();
+            let is_negative = *v < 0;
+            let skip_byte = if is_negative { 0xFF } else { 0x00 };
+
+            let mut start = 0usize;
+            while start < 15 && bytes[start] == skip_byte {
+                let next_byte = bytes[start + 1];
+                let next_is_negative = (next_byte & 0x80) != 0;
+                if next_is_negative == is_negative {
+                    start += 1;
+                } else {
+                    break;
+                }
+            }
+
+            let min_len = (16 - start) as u64;
+            let max_len = match datum.data_type() {
+                PrimitiveType::Decimal { precision, .. } => crate::spec::Type::decimal_required_bytes(*precision)
+                    .map(|n| n as u64)
+                    .unwrap_or(16),
+                _ => 16,
+            };
+            min_len.min(max_len)
+        }
+        // These should not appear in manifest bounds; treat as 0 to keep the estimate total.
         PrimitiveLiteral::AboveMax | PrimitiveLiteral::BelowMin => 0,
     }
 }

--- a/crates/iceberg/src/spec/manifest/writer.rs
+++ b/crates/iceberg/src/spec/manifest/writer.rs
@@ -1096,7 +1096,7 @@ mod tests {
         let ratio = estimated as f64 / actual as f64;
         assert!(
             (0.7..=1.4).contains(&ratio),
-            "estimate {estimated} should be within 30% of on-disk length {actual} \
+            "estimate {estimated} should be within -30%/+40% of on-disk length {actual} \
              (ratio {ratio:.3}); the per-entry constants need recalibration",
         );
     }

--- a/crates/iceberg/src/transaction/rewrite_manifests.rs
+++ b/crates/iceberg/src/transaction/rewrite_manifests.rs
@@ -18,6 +18,7 @@
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::sync::{Arc, Mutex};
 
+use futures::stream::{self, StreamExt};
 use uuid::Uuid;
 
 use super::snapshot::{DefaultManifestProcess, SnapshotProduceOperation, SnapshotProducer};
@@ -30,7 +31,7 @@ use crate::table::Table;
 use crate::transaction::{
     ActionCommit, MANIFEST_TARGET_SIZE_BYTES, MANIFEST_TARGET_SIZE_BYTES_DEFAULT, TransactionAction,
 };
-use crate::utils::{DEFAULT_LOAD_CONCURRENCY_LIMIT, try_for_each_manifest};
+use crate::utils::DEFAULT_LOAD_CONCURRENCY_LIMIT;
 use crate::{Error, ErrorKind};
 
 const KEPT_MANIFESTS_COUNT: &str = "manifests-kept";
@@ -251,12 +252,6 @@ impl RewriteManifestsAction {
         // BTreeMap gives deterministic ordering for the writers that are
         // still open when streaming finishes.
         let mut writers: BTreeMap<(String, i32), ManifestWriter> = BTreeMap::new();
-        // Writers that reached the target size mid-stream and were sealed.
-        // They are finalized after the streaming loop because
-        // `write_manifest_file` is async and the routing closure is sync.
-        // Their (unbounded) count is what makes a hot partition span
-        // multiple manifests instead of one.
-        let mut full_writers: Vec<ManifestWriter> = Vec::new();
 
         // Separate manifests into to-be-rewritten and everything else. We
         // don't need to track the "kept" set here — the outer commit()
@@ -282,66 +277,75 @@ impl RewriteManifestsAction {
         }
 
         let mut entry_count: usize = 0;
-
-        // Stream the manifests to rewrite, routing their entries into the
-        // writers and dropping each loaded manifest immediately instead of
-        // holding all of them in memory at once (a large rewrite batch would
-        // otherwise retain every loaded manifest for the whole loop).
-        // Writers are stateful, so the closure runs sequentially.
-        try_for_each_manifest(
-            table.file_io(),
-            manifests_to_rewrite,
-            DEFAULT_LOAD_CONCURRENCY_LIMIT,
-            |manifest_file, manifest| {
-                let spec_id = manifest_file.partition_spec_id;
-                for entry in manifest.entries() {
-                    if !entry.is_alive() {
-                        continue;
-                    }
-
-                    let key = cluster_func(entry.data_file());
-                    let writer_key = (key, spec_id);
-
-                    if !writers.contains_key(&writer_key) {
-                        let w = snapshot_producer
-                            .new_manifest_writer(ManifestContentType::Data, spec_id)?;
-                        writers.insert(writer_key.clone(), w);
-                    }
-                    let writer = writers
-                        .get_mut(&writer_key)
-                        .expect("writer was just inserted for this key");
-                    writer.add_existing_entry(entry.as_ref().clone())?;
-                    entry_count += 1;
-
-                    // Roll over once this manifest reaches the target size:
-                    // seal it now (deferred finalize) and let the next entry
-                    // for this key open a fresh writer.
-                    if writer.estimated_manifest_size() >= target_manifest_size_bytes {
-                        let sealed = writers
-                            .remove(&writer_key)
-                            .expect("writer present for this key");
-                        full_writers.push(sealed);
-                    }
-                }
-                Ok(())
-            },
-        )
-        .await?;
-
-        // Finalize sealed writers first, then the writers still open at the
-        // end. Manifest ordering is not required for correctness (existing
-        // entries keep their sequence numbers, and kept manifests are placed
-        // before new ones in the outer assembly for first_row_id assignment).
-        // Sealed-writer order follows stream completion (`buffer_unordered`);
-        // remaining writers follow BTreeMap key order.
         let mut new_manifests: Vec<ManifestFile> = Vec::new();
-        for writer in full_writers {
-            let manifest_file = writer.write_manifest_file().await?;
-            new_manifests.push(manifest_file);
+
+        // Stream the manifests to rewrite with bounded load concurrency,
+        // routing their entries into per-key writers and dropping each loaded
+        // input manifest immediately (never holding all inputs at once).
+        //
+        // Crucially, a writer that reaches the target size is serialized and
+        // dropped *here* — inside the async loop — rather than parked in a
+        // buffer until the stream finishes. The entries it holds are freed as
+        // soon as its manifest is written, so peak memory is bounded by the
+        // in-flight input manifests plus the still-open (below-target) writers
+        // (at most one per active cluster key) instead of by the total entry
+        // count. A large single-key rewrite previously buffered every output
+        // entry in memory at once and could OOM the process.
+        //
+        // The load stream can run concurrently, but entry routing is
+        // sequential (writers are stateful), so we consume the buffered
+        // manifests one at a time.
+        let mut load_stream = stream::iter(manifests_to_rewrite)
+            .map(|manifest_file| {
+                let file_io = table.file_io().clone();
+                async move {
+                    let manifest = manifest_file.load_manifest(&file_io).await?;
+                    Ok::<_, Error>((manifest_file, manifest))
+                }
+            })
+            .buffer_unordered(DEFAULT_LOAD_CONCURRENCY_LIMIT);
+
+        while let Some(loaded) = load_stream.next().await {
+            let (manifest_file, manifest) = loaded?;
+            let spec_id = manifest_file.partition_spec_id;
+            for entry in manifest.entries() {
+                if !entry.is_alive() {
+                    continue;
+                }
+
+                let key = cluster_func(entry.data_file());
+                let writer_key = (key, spec_id);
+
+                if !writers.contains_key(&writer_key) {
+                    let w = snapshot_producer
+                        .new_manifest_writer(ManifestContentType::Data, spec_id)?;
+                    writers.insert(writer_key.clone(), w);
+                }
+                let writer = writers
+                    .get_mut(&writer_key)
+                    .expect("writer was just inserted for this key");
+                writer.add_existing_entry(entry.as_ref().clone())?;
+                entry_count += 1;
+
+                // Roll over once this writer reaches the target size: seal and
+                // finalize it now, freeing its entries, and let the next entry
+                // for this key open a fresh writer.
+                if writer.estimated_manifest_size() >= target_manifest_size_bytes {
+                    let sealed = writers
+                        .remove(&writer_key)
+                        .expect("writer present for this key");
+                    new_manifests.push(sealed.write_manifest_file().await?);
+                }
+            }
         }
-        for (_key, writer) in writers {
-            let manifest_file = writer.write_manifest_file().await?;
-            new_manifests.push(manifest_file);
+
+        // Finalize the writers still open at the end (the partially-filled tail
+        // per cluster key). Manifest ordering is not required for correctness:
+        // existing entries keep their sequence numbers, and kept manifests are
+        // placed before new ones in the outer assembly for first_row_id
+        // assignment.
+        for (_key, writer) in std::mem::take(&mut writers) {
+            new_manifests.push(writer.write_manifest_file().await?);
         }
 
         Ok((new_manifests, rewritten_manifests, entry_count))
@@ -1135,6 +1139,74 @@ mod tests {
                 .map(|c| c.to_string())
                 .unwrap_or_default()
         })
+    }
+
+    /// A single hot cluster key with many entries and a small target size must
+    /// roll over into multiple output manifests, and no entry may be lost.
+    ///
+    /// This guards the incremental-flush rollover in `run_clustering_pass`,
+    /// which seals and writes each full writer mid-stream (freeing its entries)
+    /// rather than buffering every output entry until the end — the behavior
+    /// that bounds rewrite memory for large single-key (e.g. unpartitioned)
+    /// tables.
+    #[tokio::test]
+    async fn test_rewrite_manifests_rolls_over_and_preserves_count() {
+        let base = make_v2_memory_table();
+
+        // Eight files that all cluster to the same key ('a'), in one input
+        // manifest.
+        let files: Vec<DataFile> = (0..8)
+            .map(|i| data_file(&format!("a-{i}.parquet"), 1, 10))
+            .collect();
+        let m1 = write_data_manifest(
+            &base,
+            "memory:///test/location/metadata/m1.avro",
+            1,
+            1,
+            files,
+        )
+        .await;
+        let snapshot = write_manifest_list_snapshot(
+            &base,
+            "memory:///test/location/metadata/mlist-v1.avro",
+            1,
+            1,
+            vec![m1.clone()],
+        )
+        .await;
+        let table = table_at_snapshot(&base, snapshot);
+
+        // Tiny target so each writer seals after a couple of entries, forcing
+        // the single hot key to span multiple manifests.
+        let action = Arc::new(
+            RewriteManifestsAction::new()
+                .cluster_by(cluster_by_first_char())
+                .set_snapshot_properties(HashMap::from([(
+                    crate::transaction::MANIFEST_TARGET_SIZE_BYTES.to_string(),
+                    "200".to_string(),
+                )])),
+        );
+        Arc::clone(&action).commit(&table).await.unwrap();
+
+        let state = action.state.lock().unwrap();
+        assert!(
+            state.new_manifests.len() >= 2,
+            "a hot key over the target must roll over into multiple manifests, got {}",
+            state.new_manifests.len()
+        );
+        let total_files: u32 = state
+            .new_manifests
+            .iter()
+            .map(|m| m.added_files_count.unwrap_or(0) + m.existing_files_count.unwrap_or(0))
+            .sum();
+        assert_eq!(
+            total_files, 8,
+            "all 8 input files must be preserved across the split manifests"
+        );
+        assert_eq!(
+            state.entry_count, 8,
+            "every live entry must be processed exactly once"
+        );
     }
 
     /// Reuse path: after the first attempt writes new manifests, a concurrent

--- a/crates/iceberg/src/utils.rs
+++ b/crates/iceberg/src/utils.rs
@@ -315,46 +315,6 @@ pub(crate) async fn load_manifests(
         .await
 }
 
-/// Streams the manifests for `manifest_files`, invoking the fallible closure `f`
-/// on each loaded [`Manifest`] (with its [`ManifestFile`]) and dropping it
-/// immediately afterwards.
-///
-/// Unlike [`load_manifests`], this never holds more than `concurrency` manifests
-/// in memory at once. Use it when you only need to fold entries out of
-/// (potentially very many / very large) manifests — e.g. routing entries into
-/// manifest writers during a rewrite — instead of retaining every loaded
-/// manifest at once.
-pub(crate) async fn try_for_each_manifest<F>(
-    file_io: &FileIO,
-    manifest_files: Vec<ManifestFile>,
-    concurrency: usize,
-    mut f: F,
-) -> Result<()>
-where
-    F: FnMut(&ManifestFile, &Manifest) -> Result<()>,
-{
-    let concurrency = concurrency.max(1);
-
-    let mut stream = stream::iter(manifest_files)
-        .map(|manifest_file| {
-            let file_io = file_io.clone();
-            async move {
-                let manifest = manifest_file.load_manifest(&file_io).await?;
-                Ok::<_, crate::Error>((manifest_file, manifest))
-            }
-        })
-        .buffer_unordered(concurrency);
-
-    while let Some(loaded) = stream.next().await {
-        let (manifest_file, manifest) = loaded?;
-        f(&manifest_file, &manifest)?;
-        // `manifest_file`/`manifest` are dropped here, bounding peak memory to at
-        // most `concurrency` manifests in flight (rather than all of them).
-    }
-
-    Ok(())
-}
-
 /// Streams the manifests for `manifest_files`, invoking `f` on each loaded
 /// [`Manifest`] (with its [`ManifestFile`]) and dropping it immediately
 /// afterwards.


### PR DESCRIPTION
## Which issue does this PR close?

Follow-ups to the size-bounded `RewriteManifestsAction` cluster path added in #174. 

## What changes are included in this PR?

Two related improvements to the `cluster_by` rollover path.

**1. Incremental flush — bound rewrite memory.**
Seal and write each full manifest writer *inside* the streaming loop instead of parking every sealed writer in a `full_writers` buffer until the stream finishes. Previously a large single-key rewrite (e.g. an unpartitioned table, whose partition cluster key is constant) buffered every output entry in memory at once — `O(total entries)` — and could OOM the process. We observed a ~10k-entry, 1000-column table OOM-kill a 2 GiB worker during the rewrite pre-step.

Peak memory is now bounded by the in-flight input manifests plus the still-open (below-target) writers (at most one per active cluster key). The load stream keeps its bounded concurrency (`DEFAULT_LOAD_CONCURRENCY_LIMIT`); entry routing stays sequential because writers are stateful. To seal mid-stream we inline the load loop (so `write_manifest_file` can be awaited at seal time) and drop the now-unused `try_for_each_manifest` helper — the cluster path was its only caller.

**2. Calibrate `estimate_manifest_entry_size`.**
The previous flat per-KV constants (`PER_COUNT_KV = 12`, `PER_BOUND_KV = 24`) overcounted the real *uncompressed* Avro footprint by ~1.7×, so writers sealed at ~0.6× the target and produced manifests well under `commit.manifest.target-size-bytes` (e.g. ~4.6 MiB for an 8 MiB target on a 1000-column table). Iceberg encodes each stat "map" as an Avro *array* of `{key: int, value: ...}` records, so the per key/value cost is a zigzag-varint int key plus a small varint/bytes value — much smaller than a fixed-width assumption. The bound maps now also add the *real* serialized value bytes (via a new non-allocating `datum_serialized_len`), so wide / untruncated bounds are no longer undercounted while the common 16-byte-truncated case is no longer overcounted. Manifests are written with `Codec::Null`, so the estimate and the on-disk length are in the same unit.

## Are these changes tested?

Yes — new unit tests plus existing coverage:

- `spec::manifest::writer::tests::test_estimated_size_matches_on_disk_manifest` — writes a wide (60-column) manifest with realistic 16-byte bounds and asserts the running estimate is within ±30% of the real on-disk `manifest_length` (measured ~1.15×; the old constants gave ~1.85× and would fail this).
- `transaction::rewrite_manifests::tests::test_rewrite_manifests_rolls_over_and_preserves_count` — a single hot cluster key with a small target must roll over into multiple output manifests with no entry lost, exercising the incremental-flush path.
- The existing `rewrite_manifests` retry/reuse tests (`test_rewrite_manifests_reuses_output_on_concurrent_append`, `..._full_reexecution_when_concurrent_rewrite_removes_input`, `..._reuse_after_multiple_concurrent_appends`) continue to pass, confirming the loop refactor is behavior-preserving. Full `cargo test -p iceberg --lib` is green (1281 tests); `cargo clippy -p iceberg --all-targets` and `cargo fmt` are clean.