### PR TITLE
fix(spec): decode truncated string metric bounds leniently

### DIFF
--- a/crates/iceberg/src/spec/manifest/writer.rs
+++ b/crates/iceberg/src/spec/manifest/writer.rs
@@ -223,9 +223,11 @@ fn datum_serialized_len(datum: &Datum) -> u64 {
 
             let min_len = (16 - start) as u64;
             let max_len = match datum.data_type() {
-                PrimitiveType::Decimal { precision, .. } => crate::spec::Type::decimal_required_bytes(*precision)
-                    .map(|n| n as u64)
-                    .unwrap_or(16),
+                PrimitiveType::Decimal { precision, .. } => {
+                    crate::spec::Type::decimal_required_bytes(*precision)
+                        .map(|n| n as u64)
+                        .unwrap_or(16)
+                }
                 _ => 16,
             };
             min_len.min(max_len)

--- a/crates/iceberg/src/spec/values/datum.rs
+++ b/crates/iceberg/src/spec/values/datum.rs
@@ -412,7 +412,16 @@ impl Datum {
                 PrimitiveLiteral::Long(i64::from_le_bytes(bytes.try_into()?))
             }
             PrimitiveType::String => {
-                PrimitiveLiteral::String(std::str::from_utf8(bytes)?.to_string())
+                // Decode leniently: string metric bounds (lower/upper bounds in
+                // manifest entries) are truncated to a fixed byte length per the
+                // metrics truncation config (default `truncate(16)`). A non-UTF-8-aware
+                // writer can truncate in the middle of a multi-byte character, leaving
+                // an incomplete UTF-8 sequence in the stored bytes. A strict
+                // `str::from_utf8` would error and make the whole manifest unreadable
+                // (e.g. failing compaction). The value here is only ever used as a
+                // scan-pruning bound, so a lossy decode (invalid tail -> U+FFFD) is
+                // acceptable and keeps the manifest loadable.
+                PrimitiveLiteral::String(String::from_utf8_lossy(bytes).into_owned())
             }
             PrimitiveType::Uuid => {
                 PrimitiveLiteral::UInt128(u128::from_be_bytes(bytes.try_into()?))

--- a/crates/iceberg/src/spec/values/tests.rs
+++ b/crates/iceberg/src/spec/values/tests.rs
@@ -400,6 +400,25 @@ fn avro_bytes_string() {
 }
 
 #[test]
+fn try_from_bytes_string_truncated_utf8_is_lenient() {
+    // A string metric bound truncated to 16 bytes (default `truncate(16)`) can
+    // split a multi-byte UTF-8 character, leaving an incomplete trailing byte.
+    // `try_from_bytes` must decode this leniently instead of erroring, otherwise
+    // the whole manifest becomes unreadable (e.g. breaking compaction).
+    // 15 valid ASCII bytes + 0xC3 (a 2-byte-sequence lead byte with no
+    // continuation) reproduces "incomplete utf-8 byte sequence from index 15".
+    let mut bytes = b"abcdefghijklmno".to_vec();
+    bytes.push(0xC3);
+    assert_eq!(bytes.len(), 16);
+    // Sanity check: these bytes really are invalid UTF-8, so a strict decode would error.
+    assert!(std::str::from_utf8(&bytes).is_err());
+
+    let datum = Datum::try_from_bytes(&bytes, PrimitiveType::String)
+        .expect("truncated utf-8 string bound should decode leniently");
+    assert_eq!(datum, Datum::string("abcdefghijklmno\u{FFFD}"));
+}
+
+#[test]
 fn avro_bytes_decimal() {
     // (input_bytes, decimal_num, expect_scale, expect_precision)
     let cases = vec![


### PR DESCRIPTION
## Problem

Loading a manifest fails hard when a string column's metric bound contains
invalid UTF-8, aborting any operation that reads the manifest (observed in
production breaking **compaction** for an affected table, repeatedly):

```
Failed to load manifest s3://.../metadata/<uuid>-m0.avro
  source: Unexpected => handling invalid utf-8 characters
  source: incomplete utf-8 byte sequence from index 15
```

## Root cause

String lower/upper bounds in manifest entries are truncated to a fixed byte
length by the metrics truncation config (default `truncate(16)`). A writer that
truncates on a raw **byte** boundary rather than a UTF-8 **character** boundary
can split a multi-byte character, leaving an incomplete UTF-8 sequence in the
stored bytes. (`index 15` is the tell-tale of a 16-byte truncation slicing the
16th byte.)

`Datum::try_from_bytes` decoded the `String` case with a strict
`std::str::from_utf8`, which returns `Utf8Error`. That maps to
`ErrorKind::Unexpected` ("handling invalid utf-8 characters") via the blanket
`From<std::str::Utf8Error>` in `error.rs`, and the error propagates up through
`parse_bytes_entry` (`spec/manifest/_serde.rs`) — making the whole manifest
unreadable.

`_serde.rs::parse_bytes_entry` (lower/upper bounds) is the only eager
string-decode site in the manifest-load path; manifest-list `FieldSummary`
bounds are kept as raw `ByteBuf`, so they're unaffected.

## Fix

Decode the `String` case leniently with `String::from_utf8_lossy` (invalid
truncated tail → `U+FFFD`). The value is only ever used as a scan-pruning
bound, so an approximate decoded value is acceptable and keeps the manifest
loadable. This mirrors the `from_utf8_lossy` handling already used for manifest
metadata fields (`schema-id`, `partition-spec-id`, `content`) in
`spec/manifest/metadata.rs`.

## Alternatives considered

- **Take the valid UTF-8 prefix only** (drop the incomplete tail): keeps a
  lower bound correct (`<=` real min) but makes an upper bound too low.
- **`from_utf8_lossy` (this PR)**: appends `U+FFFD`. A single decode function
  can't know whether it's decoding a lower or upper bound, and a truncated
  bound is inherently lossy, so neither approach is universally exact. Lossy
  decode is the minimal, non-crashing choice and matches existing precedent in
  this crate.
- **Keep bounds as raw bytes** (as Java Iceberg does, decoding lazily): the
  fully-correct fix, but a large `ManifestEntry`/`DataFile` API change — out of
  scope here.

Note: because these bounds are only used for scan pruning, a lossy value can in
principle skew predicate pushdown at the margins for a bound that was already
non-spec-compliant. It does not affect data correctness for full scans (e.g.
compaction reads every file).

## Testing

Added `try_from_bytes_string_truncated_utf8_is_lenient`, which reproduces the
exact production signature (15 valid bytes + a `0xC3` lead byte =
"incomplete utf-8 byte sequence from index 15") and asserts it decodes to
`"abcdefghijklmno\u{FFFD}"` instead of erroring.

```
cargo test -p iceberg --lib spec::values   # 89 passed, 0 failed
```
