### PR TITLE
style: fix rustfmt violation in manifest writer

### DIFF
--- a/crates/iceberg/src/spec/manifest/writer.rs
+++ b/crates/iceberg/src/spec/manifest/writer.rs
@@ -223,9 +223,11 @@ fn datum_serialized_len(datum: &Datum) -> u64 {
 
             let min_len = (16 - start) as u64;
             let max_len = match datum.data_type() {
-                PrimitiveType::Decimal { precision, .. } => crate::spec::Type::decimal_required_bytes(*precision)
-                    .map(|n| n as u64)
-                    .unwrap_or(16),
+                PrimitiveType::Decimal { precision, .. } => {
+                    crate::spec::Type::decimal_required_bytes(*precision)
+                        .map(|n| n as u64)
+                        .unwrap_or(16)
+                }
                 _ => 16,
             };
             min_len.min(max_len)


### PR DESCRIPTION
## Problem

`cargo fmt --all -- --check` fails on `dev_rebase_main_20260303`: the decimal arm of `datum_serialized_len` in `crates/iceberg/src/spec/manifest/writer.rs` was left unformatted by #185.

CI has therefore been red on the branch since that commit, and **every PR opened against it inherits the failure**:

- `check (ubuntu-latest)` and `check (macos-latest)` — `make check-fmt`
- `check-rust` (Python bindings workflow) — `cargo fmt --all -- --check` from `bindings/python`, which reaches the same file through its path dependency on `crates/iceberg`

Verified by bisecting with the pinned toolchain: `08a18f4` (#184) is fmt-clean, `0b65d71` (#185) is not.

## Fix

`cargo fmt --all` with the pinned `nightly-2025-10-27` toolchain from `rust-toolchain.toml`. One hunk, formatting only, no functional change.

After this, both workspaces are clean:

```
$ cargo fmt --all -- --check                      # root
$ cd bindings/python && cargo fmt --all -- --check # bindings
```

## Note

`check-python` in the bindings workflow is also failing on the branch, but that is a Python/ruff matter and is out of scope here — this PR touches no Python.

Found while opening #188, whose `check` failures are entirely this pre-existing breakage (its `Tests (default)`, `Tests (doc)`, `Verify MSRV` and all `build` jobs pass).