### PR TITLE
feat(scan): port incremental scan integration APIs

### DIFF
--- a/crates/iceberg/public-api.txt
+++ b/crates/iceberg/public-api.txt
@@ -1335,10 +1335,12 @@ pub fn iceberg::scan::TableScan::fmt(&self, f: &mut core::fmt::Formatter<'_>) ->
 pub struct iceberg::scan::TableScanBuilder<'a>
 impl<'a> iceberg::scan::TableScanBuilder<'a>
 pub fn iceberg::scan::TableScanBuilder<'a>::build(self) -> iceberg::Result<iceberg::scan::TableScan>
+pub fn iceberg::scan::TableScanBuilder<'a>::from_snapshot_id(self, snapshot_id: i64) -> Self
 pub fn iceberg::scan::TableScanBuilder<'a>::select(self, column_names: impl core::iter::traits::collect::IntoIterator<Item = impl alloc::string::ToString>) -> Self
 pub fn iceberg::scan::TableScanBuilder<'a>::select_all(self) -> Self
 pub fn iceberg::scan::TableScanBuilder<'a>::select_empty(self) -> Self
 pub fn iceberg::scan::TableScanBuilder<'a>::snapshot_id(self, snapshot_id: i64) -> Self
+pub fn iceberg::scan::TableScanBuilder<'a>::to_snapshot_id(self, snapshot_id: i64) -> Self
 pub fn iceberg::scan::TableScanBuilder<'a>::with_batch_size(self, batch_size: core::option::Option<usize>) -> Self
 pub fn iceberg::scan::TableScanBuilder<'a>::with_case_sensitive(self, case_sensitive: bool) -> Self
 pub fn iceberg::scan::TableScanBuilder<'a>::with_concurrency_limit(self, limit: usize) -> Self
@@ -2390,6 +2392,16 @@ pub fn iceberg::spec::SchemaBuilder::with_identifier_field_ids(self, ids: impl c
 pub fn iceberg::spec::SchemaBuilder::with_schema_id(self, schema_id: i32) -> Self
 impl core::fmt::Debug for iceberg::spec::SchemaBuilder
 pub fn iceberg::spec::SchemaBuilder::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub struct iceberg::spec::SerializedDataFile(_)
+impl iceberg::spec::SerializedDataFile
+pub fn iceberg::spec::SerializedDataFile::try_from(data_file: iceberg::spec::DataFile, partition_type: &iceberg::spec::StructType, format_version: iceberg::spec::FormatVersion) -> iceberg::Result<Self>
+pub fn iceberg::spec::SerializedDataFile::try_into(self, partition_spec_id: i32, partition_type: &iceberg::spec::StructType, schema: &iceberg::spec::Schema) -> iceberg::Result<iceberg::spec::DataFile>
+impl core::clone::Clone for iceberg::spec::SerializedDataFile
+pub fn iceberg::spec::SerializedDataFile::clone(&self) -> iceberg::spec::SerializedDataFile
+impl serde_core::ser::Serialize for iceberg::spec::SerializedDataFile
+pub fn iceberg::spec::SerializedDataFile::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for iceberg::spec::SerializedDataFile
+pub fn iceberg::spec::SerializedDataFile::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
 pub struct iceberg::spec::Snapshot
 impl iceberg::spec::Snapshot
 pub fn iceberg::spec::Snapshot::added_rows_count(&self) -> core::option::Option<u64>

--- a/crates/iceberg/src/scan/context.rs
+++ b/crates/iceberg/src/scan/context.rs
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use std::collections::HashSet;
 use std::sync::Arc;
 
 use futures::channel::mpsc::Sender;
@@ -28,10 +29,41 @@ use crate::scan::{
     PartitionFilterCache,
 };
 use crate::spec::{
-    ManifestContentType, ManifestEntryRef, ManifestFile, ManifestList, NameMapping,
-    PartitionSpecRef, SchemaRef, SnapshotRef, TableMetadataRef,
+    DataContentType, ManifestContentType, ManifestEntryRef, ManifestFile, ManifestList,
+    ManifestStatus, NameMapping, Operation, PartitionSpecRef, SchemaRef, SnapshotRef,
+    TableMetadataRef,
 };
+use crate::util::snapshot::ancestors_between;
 use crate::{Error, ErrorKind, Result};
+
+#[derive(Clone, Debug)]
+pub(crate) struct IncrementalScanRange {
+    pub(crate) from_snapshot_id: Option<i64>,
+    pub(crate) to_snapshot_id: i64,
+}
+
+#[derive(Clone, Default)]
+enum ManifestEntryFilter {
+    #[default]
+    All,
+    IncrementalAddedData(Arc<HashSet<i64>>),
+}
+
+impl ManifestEntryFilter {
+    fn matches(&self, entry: &ManifestEntryRef) -> bool {
+        match self {
+            Self::All => true,
+            Self::IncrementalAddedData(snapshot_ids) => {
+                entry.status() == ManifestStatus::Added
+                    && entry.data_file().content_type() == DataContentType::Data
+                    && entry
+                        .snapshot_id()
+                        .map(|id| snapshot_ids.contains(&id))
+                        .unwrap_or(true)
+            }
+        }
+    }
+}
 
 /// Wraps a [`ManifestFile`] alongside the objects that are needed
 /// to process it in a thread-safe manner
@@ -49,6 +81,7 @@ pub(crate) struct ManifestFileContext {
     name_mapping: Option<Arc<NameMapping>>,
     case_sensitive: bool,
     partition_spec: Option<PartitionSpecRef>,
+    entry_filter: ManifestEntryFilter,
 }
 
 /// Wraps a [`ManifestEntryRef`] alongside the objects that are needed
@@ -83,11 +116,16 @@ impl ManifestFileContext {
             name_mapping,
             case_sensitive,
             partition_spec,
+            entry_filter,
         } = self;
 
         let manifest = object_cache.get_manifest(&manifest_file).await?;
 
-        for manifest_entry in manifest.entries() {
+        for manifest_entry in manifest
+            .entries()
+            .iter()
+            .filter(|entry| entry_filter.matches(entry))
+        {
             let manifest_entry_context = ManifestEntryContext {
                 // TODO: refactor to avoid the expensive ManifestEntry clone
                 manifest_entry: manifest_entry.clone(),
@@ -165,6 +203,7 @@ pub(crate) struct PlanContext {
     pub partition_filter_cache: Arc<PartitionFilterCache>,
     pub manifest_evaluator_cache: Arc<ManifestEvaluatorCache>,
     pub expression_evaluator_cache: Arc<ExpressionEvaluatorCache>,
+    pub incremental_scan: Option<IncrementalScanRange>,
 }
 
 impl PlanContext {
@@ -198,14 +237,67 @@ impl PlanContext {
         Ok(partition_filter)
     }
 
-    pub(crate) fn build_manifest_file_contexts(
+    pub(crate) async fn build_manifest_file_contexts(
         &self,
         manifest_list: Arc<ManifestList>,
         tx_data: Sender<ManifestEntryContext>,
         delete_file_idx: DeleteFileIndex,
         delete_file_tx: Sender<ManifestEntryContext>,
     ) -> Result<Box<impl Iterator<Item = Result<ManifestFileContext>> + 'static>> {
-        let mut manifest_files = manifest_list.entries().iter().collect::<Vec<_>>();
+        let (mut manifest_files, entry_filter) =
+            if let Some(incremental_scan) = &self.incremental_scan {
+                let snapshots = ancestors_between(
+                    &self.table_metadata,
+                    incremental_scan.to_snapshot_id,
+                    incremental_scan.from_snapshot_id,
+                )
+                .filter(|snapshot| {
+                    matches!(
+                        snapshot.summary().operation,
+                        Operation::Append | Operation::Overwrite
+                    )
+                })
+                .collect::<Vec<_>>();
+                let snapshot_ids = Arc::new(
+                    snapshots
+                        .iter()
+                        .map(|snapshot| snapshot.snapshot_id())
+                        .collect::<HashSet<_>>(),
+                );
+
+                let mut manifest_files = Vec::new();
+                let mut manifest_paths = HashSet::new();
+                for snapshot in snapshots {
+                    let snapshot_manifest_list =
+                        if snapshot.snapshot_id() == self.snapshot.snapshot_id() {
+                            manifest_list.clone()
+                        } else {
+                            self.object_cache
+                                .get_manifest_list(&snapshot, &self.table_metadata)
+                                .await?
+                        };
+
+                    manifest_files.extend(
+                        snapshot_manifest_list
+                            .entries()
+                            .iter()
+                            .filter(|manifest| {
+                                manifest.content == ManifestContentType::Data
+                                    && manifest.added_snapshot_id == snapshot.snapshot_id()
+                                    && manifest_paths.insert(manifest.manifest_path.clone())
+                            })
+                            .cloned(),
+                    );
+                }
+
+                (
+                    manifest_files,
+                    ManifestEntryFilter::IncrementalAddedData(snapshot_ids),
+                )
+            } else {
+                (manifest_list.entries().to_vec(), ManifestEntryFilter::All)
+            };
+
         // Sort manifest files to process delete manifests first.
         // This avoids a deadlock where the producer blocks on sending data manifest entries
         // (because the data channel is full) while the delete manifest consumer is waiting
@@ -219,7 +311,7 @@ impl PlanContext {
 
         // TODO: Ideally we could ditch this intermediate Vec as we return an iterator.
         let mut filtered_mfcs = vec![];
-        for manifest_file in manifest_files {
+        for manifest_file in &manifest_files {
             let tx = if manifest_file.content == ManifestContentType::Deletes {
                 delete_file_tx.clone()
             } else {
@@ -252,6 +344,7 @@ impl PlanContext {
                 partition_bound_predicate,
                 tx,
                 delete_file_idx.clone(),
+                entry_filter.clone(),
             );
 
             filtered_mfcs.push(Ok(mfc));
@@ -266,6 +359,7 @@ impl PlanContext {
         partition_filter: Option<Arc<BoundPredicate>>,
         sender: Sender<ManifestEntryContext>,
         delete_file_index: DeleteFileIndex,
+        entry_filter: ManifestEntryFilter,
     ) -> ManifestFileContext {
         let bound_predicates =
             if let (Some(ref partition_bound_predicate), Some(snapshot_bound_predicate)) =
@@ -294,6 +388,7 @@ impl PlanContext {
                 .table_metadata
                 .partition_spec_by_id(manifest_file.partition_spec_id)
                 .cloned(),
+            entry_filter,
         }
     }
 }

--- a/crates/iceberg/src/scan/mod.rs
+++ b/crates/iceberg/src/scan/mod.rs
@@ -42,6 +42,7 @@ use crate::runtime::Runtime;
 use crate::spec::{DEFAULT_SCHEMA_NAME_MAPPING, DataContentType, NameMapping, SnapshotRef};
 use crate::table::Table;
 use crate::util::available_parallelism;
+use crate::util::snapshot::ancestors_of;
 use crate::{Error, ErrorKind, Result};
 
 /// A stream of arrow [`RecordBatch`]es.
@@ -53,6 +54,10 @@ pub struct TableScanBuilder<'a> {
     // Defaults to none which means select all columns
     column_names: Option<Vec<String>>,
     snapshot_id: Option<i64>,
+    // Exclusive lower bound for an incremental scan.
+    from_snapshot_id: Option<i64>,
+    // Inclusive upper bound for an incremental scan.
+    to_snapshot_id: Option<i64>,
     batch_size: Option<usize>,
     case_sensitive: bool,
     filter: Option<Predicate>,
@@ -71,6 +76,8 @@ impl<'a> TableScanBuilder<'a> {
             table,
             column_names: None,
             snapshot_id: None,
+            from_snapshot_id: None,
+            to_snapshot_id: None,
             batch_size: None,
             case_sensitive: true,
             filter: None,
@@ -132,6 +139,24 @@ impl<'a> TableScanBuilder<'a> {
         self
     }
 
+    /// Set the exclusive starting snapshot for an incremental scan.
+    ///
+    /// [`Self::to_snapshot_id`] must also be set.
+    pub fn from_snapshot_id(mut self, snapshot_id: i64) -> Self {
+        self.from_snapshot_id = Some(snapshot_id);
+        self
+    }
+
+    /// Set the inclusive ending snapshot for an incremental scan.
+    ///
+    /// The scan plans data files added by append and overwrite snapshots in
+    /// `(from_snapshot_id, to_snapshot_id]`. Delete files and replace
+    /// snapshots are not returned.
+    pub fn to_snapshot_id(mut self, snapshot_id: i64) -> Self {
+        self.to_snapshot_id = Some(snapshot_id);
+        self
+    }
+
     /// Sets the concurrency limit for both manifest files and manifest
     /// entries for this scan
     pub fn with_concurrency_limit(mut self, limit: usize) -> Self {
@@ -187,7 +212,33 @@ impl<'a> TableScanBuilder<'a> {
 
     /// Build the table scan.
     pub fn build(self) -> Result<TableScan> {
-        let snapshot = match self.snapshot_id {
+        let incremental_scan = match (self.from_snapshot_id, self.to_snapshot_id) {
+            (Some(_), None) => {
+                return Err(Error::new(
+                    ErrorKind::DataInvalid,
+                    "Incremental scan requires to_snapshot_id to be set",
+                ));
+            }
+            (from_snapshot_id, Some(to_snapshot_id)) => {
+                if self.snapshot_id.is_some() {
+                    return Err(Error::new(
+                        ErrorKind::DataInvalid,
+                        "snapshot_id cannot be combined with an incremental scan",
+                    ));
+                }
+                Some(IncrementalScanRange {
+                    from_snapshot_id,
+                    to_snapshot_id,
+                })
+            }
+            (None, None) => None,
+        };
+
+        let selected_snapshot_id = incremental_scan
+            .as_ref()
+            .map(|range| range.to_snapshot_id)
+            .or(self.snapshot_id);
+        let snapshot = match selected_snapshot_id {
             Some(snapshot_id) => self
                 .table
                 .metadata()
@@ -217,6 +268,20 @@ impl<'a> TableScanBuilder<'a> {
                 current_snapshot_id.clone()
             }
         };
+
+        if let Some(incremental_scan) = &incremental_scan
+            && let Some(from_snapshot_id) = incremental_scan.from_snapshot_id
+            && !ancestors_of(&self.table.metadata_ref(), incremental_scan.to_snapshot_id)
+                .any(|snapshot| snapshot.snapshot_id() == from_snapshot_id)
+        {
+            return Err(Error::new(
+                ErrorKind::DataInvalid,
+                format!(
+                    "Snapshot with id {from_snapshot_id} is not an ancestor of snapshot {}",
+                    incremental_scan.to_snapshot_id
+                ),
+            ));
+        }
 
         let schema = snapshot.schema(self.table.metadata())?;
 
@@ -313,6 +378,7 @@ impl<'a> TableScanBuilder<'a> {
             partition_filter_cache: Arc::new(PartitionFilterCache::new()),
             manifest_evaluator_cache: Arc::new(ManifestEvaluatorCache::new()),
             expression_evaluator_cache: Arc::new(ExpressionEvaluatorCache::new()),
+            incremental_scan,
         };
 
         Ok(TableScan {
@@ -384,12 +450,14 @@ impl TableScan {
         // get the [`ManifestFile`]s from the [`ManifestList`], filtering out any
         // whose partitions cannot match this
         // scan's filter
-        let manifest_file_contexts = plan_context.build_manifest_file_contexts(
-            manifest_list,
-            manifest_entry_data_ctx_tx,
-            delete_file_idx.clone(),
-            manifest_entry_delete_ctx_tx,
-        )?;
+        let manifest_file_contexts = plan_context
+            .build_manifest_file_contexts(
+                manifest_list,
+                manifest_entry_data_ctx_tx,
+                delete_file_idx.clone(),
+                manifest_entry_delete_ctx_tx,
+            )
+            .await?;
 
         let mut channel_for_manifest_error = file_scan_task_tx.clone();
         let mut channel_for_data_manifest_entry_error = file_scan_task_tx.clone();
@@ -651,7 +719,7 @@ pub mod tests {
     use crate::scan::FileScanTask;
     use crate::spec::{
         DEFAULT_SCHEMA_NAME_MAPPING, DataContentType, DataFileBuilder, DataFileFormat, Datum,
-        Literal, MAIN_BRANCH, ManifestEntry, ManifestListWriter, ManifestStatus,
+        Literal, MAIN_BRANCH, ManifestEntry, ManifestFile, ManifestListWriter, ManifestStatus,
         ManifestWriterBuilder, NestedField, Operation, PartitionSpec, PrimitiveType, Schema,
         Snapshot, Struct, StructType, Summary, TableMetadata, TableMetadataBuilder, Type,
         UnboundPartitionSpec,
@@ -871,6 +939,95 @@ pub mod tests {
                     Uuid::new_v4()
                 ))
                 .unwrap()
+        }
+
+        pub async fn add_snapshot_with_data_file(
+            &mut self,
+            snapshot_id: i64,
+            operation: Operation,
+            manifests: &mut Vec<ManifestFile>,
+        ) {
+            let metadata = self.table.metadata();
+            let schema = metadata.current_schema();
+            let partition_spec = metadata.default_partition_spec();
+            let parent_snapshot_id = metadata.current_snapshot().map(|s| s.snapshot_id());
+            let sequence_number = metadata.last_sequence_number() + 1;
+
+            let mut manifest_writer = ManifestWriterBuilder::new(
+                self.next_manifest_file(),
+                Some(snapshot_id),
+                schema.clone(),
+                partition_spec.as_ref().clone(),
+            )
+            .build_v2_data();
+            manifest_writer
+                .add_entry(
+                    ManifestEntry::builder()
+                        .status(ManifestStatus::Added)
+                        .data_file(
+                            DataFileBuilder::default()
+                                .partition_spec_id(partition_spec.spec_id())
+                                .content(DataContentType::Data)
+                                .file_path(format!(
+                                    "{}/data/{snapshot_id}.parquet",
+                                    self.table_location
+                                ))
+                                .file_format(DataFileFormat::Parquet)
+                                .file_size_in_bytes(100)
+                                .record_count(1)
+                                .partition(Struct::from_iter([Some(Literal::long(snapshot_id))]))
+                                .build()
+                                .unwrap(),
+                        )
+                        .build(),
+                )
+                .unwrap();
+            let mut manifest = manifest_writer.write_manifest_file().await.unwrap();
+            manifest.sequence_number = sequence_number;
+            manifest.min_sequence_number = sequence_number;
+            manifests.push(manifest);
+
+            let manifest_list_path =
+                format!("{}/metadata/snap-{snapshot_id}.avro", self.table_location);
+            let manifest_list_writer = self
+                .table
+                .file_io()
+                .new_output(&manifest_list_path)
+                .unwrap()
+                .writer()
+                .await
+                .unwrap();
+            let mut manifest_list_writer = ManifestListWriter::v2(
+                manifest_list_writer,
+                snapshot_id,
+                parent_snapshot_id,
+                sequence_number,
+            );
+            manifest_list_writer
+                .add_manifests(manifests.iter().cloned())
+                .unwrap();
+            manifest_list_writer.close().await.unwrap();
+
+            let snapshot = Snapshot::builder()
+                .with_snapshot_id(snapshot_id)
+                .with_parent_snapshot_id(parent_snapshot_id)
+                .with_sequence_number(sequence_number)
+                .with_timestamp_ms(metadata.last_updated_ms + 1)
+                .with_schema_id(metadata.current_schema_id())
+                .with_manifest_list(manifest_list_path)
+                .with_summary(Summary {
+                    operation,
+                    additional_properties: HashMap::new(),
+                })
+                .build();
+            let metadata =
+                TableMetadataBuilder::new_from_metadata(self.table.metadata().clone(), None)
+                    .set_branch_snapshot(snapshot, MAIN_BRANCH)
+                    .unwrap()
+                    .build()
+                    .unwrap()
+                    .metadata;
+            self.table = self.table.clone().with_metadata(Arc::new(metadata));
         }
 
         pub async fn setup_manifest_files(&mut self) {
@@ -1687,6 +1844,114 @@ pub mod tests {
             table_scan.snapshot().unwrap().snapshot_id(),
             3051729675574597004
         );
+    }
+
+    #[test]
+    fn test_incremental_scan_requires_to_snapshot() {
+        let table = TableTestFixture::new().table;
+
+        let error = table
+            .scan()
+            .from_snapshot_id(3051729675574597004)
+            .build()
+            .unwrap_err();
+        assert_eq!(error.kind(), ErrorKind::DataInvalid);
+        assert!(error.to_string().contains("requires to_snapshot_id"));
+    }
+
+    #[test]
+    fn test_incremental_scan_rejects_snapshot_id() {
+        let table = TableTestFixture::new().table;
+
+        let error = table
+            .scan()
+            .snapshot_id(3051729675574597004)
+            .to_snapshot_id(3051729675574597004)
+            .build()
+            .unwrap_err();
+        assert_eq!(error.kind(), ErrorKind::DataInvalid);
+        assert!(error.to_string().contains("cannot be combined"));
+    }
+
+    #[test]
+    fn test_incremental_scan_rejects_non_ancestor() {
+        let table = TableTestFixture::new().table;
+
+        let error = table
+            .scan()
+            .from_snapshot_id(999)
+            .to_snapshot_id(3051729675574597004)
+            .build()
+            .unwrap_err();
+        assert_eq!(error.kind(), ErrorKind::DataInvalid);
+        assert!(error.to_string().contains("is not an ancestor"));
+    }
+
+    #[tokio::test]
+    async fn test_incremental_scan_plans_each_added_file_once() {
+        let mut fixture = TableTestFixture::new_empty();
+        let mut manifests = Vec::new();
+        fixture
+            .add_snapshot_with_data_file(101, Operation::Append, &mut manifests)
+            .await;
+        fixture
+            .add_snapshot_with_data_file(102, Operation::Append, &mut manifests)
+            .await;
+        fixture
+            .add_snapshot_with_data_file(103, Operation::Overwrite, &mut manifests)
+            .await;
+
+        let scan = fixture
+            .table
+            .scan()
+            .from_snapshot_id(101)
+            .to_snapshot_id(103)
+            .build()
+            .unwrap();
+        assert_eq!(scan.snapshot().unwrap().snapshot_id(), 103);
+
+        let mut paths = scan
+            .plan_files()
+            .await
+            .unwrap()
+            .map_ok(|task| task.data_file_path)
+            .try_collect::<Vec<_>>()
+            .await
+            .unwrap();
+        paths.sort();
+
+        assert_eq!(paths, vec![
+            format!("{}/data/102.parquet", fixture.table_location),
+            format!("{}/data/103.parquet", fixture.table_location),
+        ]);
+    }
+
+    #[tokio::test]
+    async fn test_incremental_scan_ignores_replace_snapshots() {
+        let mut fixture = TableTestFixture::new_empty();
+        let mut manifests = Vec::new();
+        fixture
+            .add_snapshot_with_data_file(101, Operation::Append, &mut manifests)
+            .await;
+        fixture
+            .add_snapshot_with_data_file(102, Operation::Replace, &mut manifests)
+            .await;
+
+        let tasks = fixture
+            .table
+            .scan()
+            .from_snapshot_id(101)
+            .to_snapshot_id(102)
+            .build()
+            .unwrap()
+            .plan_files()
+            .await
+            .unwrap()
+            .try_collect::<Vec<_>>()
+            .await
+            .unwrap();
+
+        assert!(tasks.is_empty());
     }
 
     fn table_with_property(key: &str, value: &str) -> Table {

--- a/crates/iceberg/src/spec/manifest/_serde.rs
+++ b/crates/iceberg/src/spec/manifest/_serde.rs
@@ -97,7 +97,7 @@ impl ManifestEntryV1 {
 }
 
 #[serde_as]
-#[derive(Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize)]
 pub(super) struct DataFileSerde {
     #[serde(default)]
     content: i32,
@@ -235,7 +235,7 @@ impl DataFileSerde {
 }
 
 #[serde_as]
-#[derive(Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize)]
 #[cfg_attr(test, derive(Debug, PartialEq, Eq))]
 struct BytesEntry {
     key: i32,
@@ -281,7 +281,7 @@ fn to_bytes_entry(v: impl IntoIterator<Item = (i32, Datum)>) -> Result<Vec<Bytes
     Ok(bs)
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize)]
 #[cfg_attr(test, derive(Debug, PartialEq, Eq))]
 struct I64Entry {
     key: i32,

--- a/crates/iceberg/src/spec/manifest/mod.rs
+++ b/crates/iceberg/src/spec/manifest/mod.rs
@@ -19,6 +19,8 @@ mod _serde;
 
 mod data_file;
 pub use data_file::*;
+mod serialized_data_file;
+pub use serialized_data_file::*;
 mod entry;
 pub use entry::*;
 mod metadata;

--- a/crates/iceberg/src/spec/manifest/serialized_data_file.rs
+++ b/crates/iceberg/src/spec/manifest/serialized_data_file.rs
@@ -1,0 +1,91 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use serde::{Deserialize, Serialize};
+
+use super::_serde::DataFileSerde;
+use super::DataFile;
+use crate::Result;
+use crate::spec::{FormatVersion, Schema, StructType};
+
+/// A serde-compatible representation of an Iceberg [`DataFile`].
+///
+/// The partition spec id is intentionally not embedded because it belongs to
+/// the manifest containing the data file. Callers must persist it alongside
+/// this value and supply it when converting back to [`DataFile`].
+#[derive(Clone, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct SerializedDataFile(DataFileSerde);
+
+impl SerializedDataFile {
+    /// Convert a [`DataFile`] into its stable serialized representation.
+    pub fn try_from(
+        data_file: DataFile,
+        partition_type: &StructType,
+        format_version: FormatVersion,
+    ) -> Result<Self> {
+        Ok(Self(DataFileSerde::try_from(
+            data_file,
+            partition_type,
+            format_version,
+        )?))
+    }
+
+    /// Materialize a [`DataFile`] using its manifest context.
+    pub fn try_into(
+        self,
+        partition_spec_id: i32,
+        partition_type: &StructType,
+        schema: &Schema,
+    ) -> Result<DataFile> {
+        self.0.try_into(partition_spec_id, partition_type, schema)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::spec::{DataContentType, DataFileBuilder, DataFileFormat, Schema, StructType};
+
+    #[test]
+    fn test_json_round_trip_preserves_v3_fields() {
+        let schema = Schema::builder().build().unwrap();
+        let partition_type = StructType::new(vec![]);
+        let data_file = DataFileBuilder::default()
+            .content(DataContentType::PositionDeletes)
+            .file_path("s3://bucket/table/data/deletes.puffin".to_string())
+            .file_format(DataFileFormat::Puffin)
+            .record_count(3)
+            .file_size_in_bytes(128)
+            .partition_spec_id(7)
+            .referenced_data_file(Some("s3://bucket/table/data/data.parquet".to_string()))
+            .content_offset(Some(16))
+            .content_size_in_bytes(Some(48))
+            .key_metadata(Some(vec![1, 2, 3]))
+            .build()
+            .unwrap();
+
+        let serialized =
+            SerializedDataFile::try_from(data_file.clone(), &partition_type, FormatVersion::V3)
+                .unwrap();
+        let json = serde_json::to_string(&serialized).unwrap();
+        let decoded: SerializedDataFile = serde_json::from_str(&json).unwrap();
+        let actual = decoded.try_into(7, &partition_type, &schema).unwrap();
+
+        assert_eq!(actual, data_file);
+    }
+}

--- a/crates/iceberg/src/spec/values/serde.rs
+++ b/crates/iceberg/src/spec/values/serde.rs
@@ -28,7 +28,7 @@ pub(crate) mod _serde {
     use crate::spec::{MAP_KEY_FIELD_NAME, MAP_VALUE_FIELD_NAME, PrimitiveType, Type};
     use crate::{Error, ErrorKind};
 
-    #[derive(SerializeDerive, DeserializeDerive, Debug)]
+    #[derive(Clone, SerializeDerive, DeserializeDerive, Debug)]
     #[serde(transparent)]
     /// Raw literal representation used for serde. The serialize way is used for Avro serializer.
     pub struct RawLiteral(RawLiteralEnum);


### PR DESCRIPTION
## Which issue does this PR close?

- Part of #191.

## What changes are included in this PR?

- Port incremental scans with an exclusive `from_snapshot_id` and inclusive
  `to_snapshot_id`.
- Plan only data files added by `Append` and `Overwrite` snapshots. Ignore delete
  files and `Replace` snapshots.
- Validate the snapshot lineage and select the `to_snapshot_id` snapshot as the
  scan/schema anchor.
- Avoid emitting carried manifests more than once when scanning across multiple
  snapshots.
- Expose a stable, serde-compatible `SerializedDataFile` wrapper for persisted
  RisingWave sink metadata without exposing Iceberg's internal Avro fields.

This deliberately keeps upstream's lightweight `FileScanTaskDeleteFile` model.
The RisingWave persisted split DTO will be adapted when switching its dependency;
we do not restore nested full scan tasks or blanket-serialize partition/name
mapping state and plaintext encryption key metadata.

## Are these changes tested?

- Added incremental scan validation, multi-snapshot deduplication, and
  `Replace`-snapshot regression tests.
- Added a `SerializedDataFile` V3 round-trip test covering deletion-vector fields
  and key metadata.
- `cargo test -p iceberg --lib --locked` (1476 passed)
- `cargo clippy -p iceberg --all-targets --all-features --locked -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
