### PR TITLE
feat: port shared metadata cache integration APIs

### DIFF
--- a/crates/iceberg/public-api.txt
+++ b/crates/iceberg/public-api.txt
@@ -689,6 +689,14 @@ pub fn iceberg::inspect::SnapshotsTable<'a>::new(table: &'a iceberg::table::Tabl
 pub async fn iceberg::inspect::SnapshotsTable<'a>::scan(&self) -> iceberg::Result<iceberg::scan::ArrowRecordBatchStream>
 pub fn iceberg::inspect::SnapshotsTable<'a>::schema(&self) -> iceberg::spec::Schema
 pub mod iceberg::io
+pub mod iceberg::io::object_cache
+pub struct iceberg::io::object_cache::ObjectCache
+impl iceberg::io::object_cache::ObjectCache
+pub async fn iceberg::io::object_cache::ObjectCache::get_manifest_list(&self, snapshot: &iceberg::spec::SnapshotRef, table_metadata: &iceberg::spec::TableMetadataRef) -> iceberg::Result<alloc::sync::Arc<iceberg::spec::ManifestList>>
+impl core::clone::Clone for iceberg::io::object_cache::ObjectCache
+pub fn iceberg::io::object_cache::ObjectCache::clone(&self) -> iceberg::io::object_cache::ObjectCache
+impl core::fmt::Debug for iceberg::io::object_cache::ObjectCache
+pub fn iceberg::io::object_cache::ObjectCache::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub struct iceberg::io::AzdlsConfig
 pub iceberg::io::AzdlsConfig::account_key: core::option::Option<alloc::string::String>
 pub iceberg::io::AzdlsConfig::account_name: core::option::Option<alloc::string::String>
@@ -1833,6 +1841,7 @@ pub fn iceberg::spec::DataFile::null_value_counts(&self) -> &std::collections::h
 pub fn iceberg::spec::DataFile::partition(&self) -> &iceberg::spec::Struct
 pub fn iceberg::spec::DataFile::record_count(&self) -> u64
 pub fn iceberg::spec::DataFile::referenced_data_file(&self) -> core::option::Option<alloc::string::String>
+pub fn iceberg::spec::DataFile::set_partition(&mut self, partition: iceberg::spec::Struct)
 pub fn iceberg::spec::DataFile::sort_order_id(&self) -> core::option::Option<i32>
 pub fn iceberg::spec::DataFile::split_offsets(&self) -> core::option::Option<&[i64]>
 pub fn iceberg::spec::DataFile::upper_bounds(&self) -> &std::collections::hash::map::HashMap<i32, iceberg::spec::Datum>
@@ -3113,9 +3122,11 @@ pub fn iceberg::table::Table::metadata(&self) -> &iceberg::spec::TableMetadata
 pub fn iceberg::table::Table::metadata_location(&self) -> core::option::Option<&str>
 pub fn iceberg::table::Table::metadata_location_result(&self) -> iceberg::Result<&str>
 pub fn iceberg::table::Table::metadata_ref(&self) -> iceberg::spec::TableMetadataRef
+pub fn iceberg::table::Table::object_cache(&self) -> alloc::sync::Arc<iceberg::io::object_cache::ObjectCache>
 pub fn iceberg::table::Table::reader_builder(&self) -> iceberg::arrow::ArrowReaderBuilder
 pub fn iceberg::table::Table::readonly(&self) -> bool
 pub fn iceberg::table::Table::scan(&self) -> iceberg::scan::TableScanBuilder<'_>
+pub fn iceberg::table::Table::with_object_cache(self, object_cache: alloc::sync::Arc<iceberg::io::object_cache::ObjectCache>) -> Self
 impl core::clone::Clone for iceberg::table::Table
 pub fn iceberg::table::Table::clone(&self) -> iceberg::table::Table
 impl core::fmt::Debug for iceberg::table::Table

--- a/crates/iceberg/src/io/mod.rs
+++ b/crates/iceberg/src/io/mod.rs
@@ -55,7 +55,8 @@ mod storage;
 pub use file_io::*;
 pub use storage::*;
 
-pub(crate) mod object_cache;
+/// Object cache interfaces and implementations.
+pub mod object_cache;
 
 pub(crate) fn is_truthy(value: &str) -> bool {
     ["true", "t", "1", "on"].contains(&value.to_lowercase().as_str())

--- a/crates/iceberg/src/io/object_cache.rs
+++ b/crates/iceberg/src/io/object_cache.rs
@@ -15,18 +15,20 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use std::mem::size_of_val;
+use std::collections::HashMap;
+use std::mem::{size_of, size_of_val};
 use std::sync::Arc;
 
 use crate::encryption::EncryptionManager;
 use crate::io::FileIO;
 use crate::spec::{
-    FormatVersion, Manifest, ManifestFile, ManifestList, ManifestListReader, SchemaId, SnapshotRef,
-    TableMetadataRef,
+    DataFile, Datum, FieldSummary, FormatVersion, Literal, Manifest, ManifestEntry, ManifestFile,
+    ManifestList, ManifestListReader, PrimitiveLiteral, SchemaId, SnapshotRef, TableMetadataRef,
 };
 use crate::{Error, ErrorKind, Result};
 
 const DEFAULT_CACHE_SIZE_BYTES: u64 = 32 * 1024 * 1024; // 32MB
+const ARC_ALLOCATION_OVERHEAD: usize = size_of::<usize>() * 2;
 
 #[derive(Clone, Debug)]
 pub(crate) enum CachedItem {
@@ -38,6 +40,138 @@ pub(crate) enum CachedItem {
 pub(crate) enum CachedObjectKey {
     ManifestList((String, FormatVersion, SchemaId)),
     Manifest(String),
+}
+
+fn estimated_hashmap_heap_size<K, V>(map: &HashMap<K, V>) -> usize {
+    // Account for the bucket values and approximately one control byte per
+    // bucket. The exact layout is intentionally left to the standard library.
+    map.capacity()
+        .saturating_mul(size_of::<(K, V)>().saturating_add(1))
+}
+
+fn estimated_primitive_literal_heap_size(literal: &PrimitiveLiteral) -> usize {
+    match literal {
+        PrimitiveLiteral::String(value) => value.capacity(),
+        PrimitiveLiteral::Binary(value) => value.capacity(),
+        _ => 0,
+    }
+}
+
+fn estimated_datum_heap_size(datum: &Datum) -> usize {
+    estimated_primitive_literal_heap_size(datum.literal())
+}
+
+fn estimated_data_file_heap_size(data_file: &DataFile) -> usize {
+    let partition_heap_size = size_of_val(data_file.partition.fields())
+        + data_file
+            .partition
+            .fields()
+            .iter()
+            .flatten()
+            .map(|literal| match literal {
+                Literal::Primitive(value) => estimated_primitive_literal_heap_size(value),
+                _ => 0,
+            })
+            .sum::<usize>();
+
+    data_file.file_path.capacity()
+        + partition_heap_size
+        + estimated_hashmap_heap_size(&data_file.column_sizes)
+        + estimated_hashmap_heap_size(&data_file.value_counts)
+        + estimated_hashmap_heap_size(&data_file.null_value_counts)
+        + estimated_hashmap_heap_size(&data_file.nan_value_counts)
+        + estimated_hashmap_heap_size(&data_file.lower_bounds)
+        + data_file
+            .lower_bounds
+            .values()
+            .map(estimated_datum_heap_size)
+            .sum::<usize>()
+        + estimated_hashmap_heap_size(&data_file.upper_bounds)
+        + data_file
+            .upper_bounds
+            .values()
+            .map(estimated_datum_heap_size)
+            .sum::<usize>()
+        + data_file
+            .key_metadata
+            .as_ref()
+            .map_or(0, |value| value.capacity())
+        + data_file
+            .split_offsets
+            .as_ref()
+            .map_or(0, |value| value.capacity() * size_of::<i64>())
+        + data_file
+            .equality_ids
+            .as_ref()
+            .map_or(0, |value| value.capacity() * size_of::<i32>())
+        + data_file
+            .referenced_data_file
+            .as_ref()
+            .map_or(0, |value| value.capacity())
+}
+
+fn estimated_manifest_file_heap_size(manifest_file: &ManifestFile) -> usize {
+    manifest_file.manifest_path.capacity()
+        + manifest_file.partitions.as_ref().map_or(0, |partitions| {
+            partitions.capacity() * size_of::<FieldSummary>()
+                + partitions
+                    .iter()
+                    .map(|summary| {
+                        summary.lower_bound.as_ref().map_or(0, |value| value.len())
+                            + summary.upper_bound.as_ref().map_or(0, |value| value.len())
+                    })
+                    .sum::<usize>()
+        })
+        + manifest_file
+            .key_metadata
+            .as_ref()
+            .map_or(0, |value| value.capacity())
+}
+
+fn estimated_manifest_list_heap_size(manifest_list: &ManifestList) -> usize {
+    ARC_ALLOCATION_OVERHEAD
+        + size_of::<ManifestList>()
+        + size_of_val(manifest_list.entries())
+        + manifest_list
+            .entries()
+            .iter()
+            .map(estimated_manifest_file_heap_size)
+            .sum::<usize>()
+}
+
+fn estimated_manifest_heap_size(manifest: &Manifest) -> usize {
+    ARC_ALLOCATION_OVERHEAD
+        + size_of::<Manifest>()
+        + size_of_val(manifest.entries())
+        + manifest
+            .entries()
+            .iter()
+            .map(|entry| {
+                ARC_ALLOCATION_OVERHEAD
+                    + size_of::<ManifestEntry>()
+                    + estimated_data_file_heap_size(entry.data_file())
+            })
+            .sum::<usize>()
+}
+
+fn estimated_cache_key_heap_size(key: &CachedObjectKey) -> usize {
+    match key {
+        CachedObjectKey::ManifestList((path, _, _)) | CachedObjectKey::Manifest(path) => {
+            path.capacity()
+        }
+    }
+}
+
+fn cache_entry_weight(key: &CachedObjectKey, value: &CachedItem) -> u32 {
+    let value_size = match value {
+        CachedItem::ManifestList(value) => estimated_manifest_list_heap_size(value),
+        CachedItem::Manifest(value) => estimated_manifest_heap_size(value),
+    };
+    (size_of::<CachedObjectKey>()
+        + estimated_cache_key_heap_size(key)
+        + size_of::<CachedItem>()
+        + value_size)
+        .min(u32::MAX as usize) as u32
 }
 
 /// Caches metadata objects deserialized from immutable files
@@ -68,10 +202,7 @@ impl ObjectCache {
         } else {
             Self {
                 cache: moka::future::Cache::builder()
-                    .weigher(|_, val: &CachedItem| match val {
-                        CachedItem::ManifestList(item) => size_of_val(item.as_ref()),
-                        CachedItem::Manifest(item) => size_of_val(item.as_ref()),
-                    } as u32)
+                    .weigher(cache_entry_weight)
                     .max_capacity(cache_size_bytes)
                     .build(),
                 file_io,
@@ -91,6 +222,19 @@ impl ObjectCache {
             cache: moka::future::Cache::new(0),
             file_io,
             cache_disabled: true,
+            encryption_manager,
+        }
+    }
+
+    pub(crate) fn share_entries_with(
+        &self,
+        file_io: FileIO,
+        encryption_manager: Option<Arc<EncryptionManager>>,
+    ) -> Self {
+        Self {
+            cache: self.cache.clone(),
+            file_io,
+            cache_disabled: self.cache_disabled,
             encryption_manager,
         }
     }
@@ -132,7 +276,7 @@ impl ObjectCache {
 
     /// Retrieves an Arc [`ManifestList`] from the cache
     /// or retrieves one from FileIO and parses it if not present
-    pub(crate) async fn get_manifest_list(
+    pub async fn get_manifest_list(
         &self,
         snapshot: &SnapshotRef,
         table_metadata: &TableMetadataRef,
@@ -152,7 +296,9 @@ impl ObjectCache {
         let key = CachedObjectKey::ManifestList((
             snapshot.manifest_list().to_string(),
             table_metadata.format_version,
-            snapshot.schema_id().unwrap(),
+            snapshot
+                .schema_id()
+                .unwrap_or_else(|| table_metadata.current_schema_id()),
         ));
         let cache_entry = self
             .cache
@@ -402,6 +548,16 @@ mod tests {
 
         assert_eq!(result_manifest_list.entries().len(), 1);
 
+        let shared_cache = object_cache.share_entries_with(fixture.table.file_io().clone(), None);
+        let shared_manifest_list = shared_cache
+            .get_manifest_list(
+                fixture.table.metadata().current_snapshot().unwrap(),
+                &fixture.table.metadata_ref(),
+            )
+            .await
+            .unwrap();
+        assert!(Arc::ptr_eq(&result_manifest_list, &shared_manifest_list));
+
         let manifest_file = result_manifest_list.entries().first().unwrap();
 
         // not in cache
@@ -433,5 +589,128 @@ mod tests {
                 .unwrap(),
             "1.parquet"
         );
+    }
+
+    #[tokio::test]
+    async fn test_get_manifest_list_for_v1_snapshot_without_schema_id() {
+        let tmp_dir = TempDir::new().unwrap();
+        let table_location = tmp_dir.path().join("table1");
+        let manifest_list_location = table_location.join("metadata/manifest-list.avro");
+        let table_metadata_location = table_location.join("metadata/v1.json");
+        let file_io = FileIO::new_with_fs();
+
+        let template_json = fs::read_to_string(format!(
+            "{}/testdata/example_table_metadata_v1.json",
+            env!("CARGO_MANIFEST_DIR")
+        ))
+        .unwrap();
+        let metadata_json = render_template(&template_json, context! {
+            table_location => &table_location,
+            manifest_list_location => &manifest_list_location,
+            table_metadata_location => &table_metadata_location,
+        });
+        let table = Table::builder()
+            .metadata(serde_json::from_str::<TableMetadata>(&metadata_json).unwrap())
+            .identifier(TableIdent::from_strs(["db", "table1"]).unwrap())
+            .file_io(file_io)
+            .metadata_location(table_metadata_location.to_string_lossy())
+            .runtime(test_runtime())
+            .build()
+            .unwrap();
+        let snapshot = table.metadata().current_snapshot().unwrap();
+        assert_eq!(snapshot.schema_id(), None);
+
+        let mut manifest_writer = ManifestWriterBuilder::new(
+            table
+                .file_io()
+                .new_output(
+                    table_location
+                        .join("metadata/manifest.avro")
+                        .to_string_lossy(),
+                )
+                .unwrap(),
+            Some(snapshot.snapshot_id()),
+            snapshot.schema(table.metadata()).unwrap(),
+            table.metadata().default_partition_spec().as_ref().clone(),
+        )
+        .build_v1();
+        manifest_writer
+            .add_entry(
+                ManifestEntry::builder()
+                    .status(ManifestStatus::Added)
+                    .data_file(
+                        DataFileBuilder::default()
+                            .content(DataContentType::Data)
+                            .file_path(
+                                table_location
+                                    .join("1.parquet")
+                                    .to_string_lossy()
+                                    .into_owned(),
+                            )
+                            .file_format(DataFileFormat::Parquet)
+                            .file_size_in_bytes(100)
+                            .record_count(1)
+                            .partition(Struct::from_iter([Some(Literal::long(100))]))
+                            .build()
+                            .unwrap(),
+                    )
+                    .build(),
+            )
+            .unwrap();
+        let manifest_file = manifest_writer.write_manifest_file().await.unwrap();
+
+        let writer = table
+            .file_io()
+            .new_output(snapshot.manifest_list())
+            .unwrap()
+            .writer()
+            .await
+            .unwrap();
+        let mut manifest_list_writer = ManifestListWriter::v1(
+            writer,
+            snapshot.snapshot_id(),
+            snapshot.parent_snapshot_id(),
+        );
+        manifest_list_writer
+            .add_manifests([manifest_file].into_iter())
+            .unwrap();
+        manifest_list_writer.close().await.unwrap();
+
+        let manifest_list = table
+            .object_cache()
+            .get_manifest_list(snapshot, &table.metadata_ref())
+            .await
+            .unwrap();
+        assert_eq!(manifest_list.entries().len(), 1);
+    }
+
+    #[test]
+    fn test_data_file_weight_includes_column_statistics() {
+        use std::collections::HashMap;
+
+        let data_file = |columns| {
+            let values = (0..columns).map(|id| (id, 1)).collect::<HashMap<_, _>>();
+            DataFileBuilder::default()
+                .content(DataContentType::Data)
+                .file_path("s3://bucket/table/data.parquet".to_string())
+                .file_format(DataFileFormat::Parquet)
+                .file_size_in_bytes(100)
+                .record_count(1)
+                .partition(Struct::empty())
+                .column_sizes(values.clone())
+                .value_counts(values.clone())
+                .null_value_counts(values.clone())
+                .nan_value_counts(values)
+                .build()
+                .unwrap()
+        };
+
+        let small = estimated_data_file_heap_size(&data_file(1));
+        let large = estimated_data_file_heap_size(&data_file(100));
+        assert!(
+            large > small * 10,
+            "{large} should be much larger than {small}"
+        );
+        assert!(large > size_of::<DataFile>());
     }
 }

--- a/crates/iceberg/src/spec/manifest/data_file.rs
+++ b/crates/iceberg/src/spec/manifest/data_file.rs
@@ -201,6 +201,10 @@ impl DataFile {
     pub fn partition(&self) -> &Struct {
         &self.partition
     }
+    /// Replaces the partition tuple of this data file.
+    pub fn set_partition(&mut self, partition: Struct) {
+        self.partition = partition;
+    }
     /// Get the record count in the data file.
     pub fn record_count(&self) -> u64 {
         self.record_count
@@ -415,7 +419,8 @@ impl std::fmt::Display for DataFileFormat {
 
 #[cfg(test)]
 mod test {
-    use crate::spec::DataContentType;
+    use crate::spec::{DataContentType, DataFileBuilder, DataFileFormat, Literal, Struct};
+
     #[test]
     fn test_data_content_type_default() {
         assert_eq!(DataContentType::default(), DataContentType::Data);
@@ -424,5 +429,23 @@ mod test {
     #[test]
     fn test_data_content_type_default_value() {
         assert_eq!(DataContentType::default() as i32, 0);
+    }
+
+    #[test]
+    fn test_set_partition() {
+        let mut data_file = DataFileBuilder::default()
+            .content(DataContentType::Data)
+            .file_path("s3://bucket/data.parquet".to_string())
+            .file_format(DataFileFormat::Parquet)
+            .file_size_in_bytes(100)
+            .record_count(1)
+            .partition(Struct::empty())
+            .build()
+            .unwrap();
+        let partition = Struct::from_iter([Some(Literal::long(42))]);
+
+        data_file.set_partition(partition.clone());
+
+        assert_eq!(data_file.partition(), &partition);
     }
 }

--- a/crates/iceberg/src/table.rs
+++ b/crates/iceberg/src/table.rs
@@ -260,9 +260,19 @@ impl Table {
         &self.file_io
     }
 
-    /// Returns this table's object cache
-    pub(crate) fn object_cache(&self) -> Arc<ObjectCache> {
+    /// Returns this table's object cache.
+    pub fn object_cache(&self) -> Arc<ObjectCache> {
         self.object_cache.clone()
+    }
+
+    /// Returns a new [`Table`] instance sharing entries with the provided object cache.
+    ///
+    /// The returned table retains its own file IO and encryption context for cache misses.
+    pub fn with_object_cache(mut self, object_cache: Arc<ObjectCache>) -> Self {
+        self.object_cache = Arc::new(
+            object_cache.share_entries_with(self.file_io.clone(), self.encryption_manager.clone()),
+        );
+        self
     }
 
     /// Returns the [`EncryptionManager`] for this table, if encryption is

--- a/crates/iceberg/testdata/example_table_metadata_v1.json
+++ b/crates/iceberg/testdata/example_table_metadata_v1.json
@@ -1,0 +1,35 @@
+{
+  "format-version": 1,
+  "table-uuid": "d20125c8-7284-442c-9aea-15fee620737c",
+  "location": "{{ table_location }}",
+  "last-updated-ms": 1602638573874,
+  "last-column-id": 3,
+  "schema": {
+    "type": "struct",
+    "fields": [
+      {"id": 1, "name": "x", "required": true, "type": "long"}
+    ]
+  },
+  "partition-spec": [
+    {
+      "name": "x",
+      "transform": "identity",
+      "source-id": 1,
+      "field-id": 1000
+    }
+  ],
+  "properties": {},
+  "current-snapshot-id": 3051729675574597004,
+  "snapshots": [
+    {
+      "snapshot-id": 3051729675574597004,
+      "timestamp-ms": 1515100955770,
+      "summary": {"operation": "append"},
+      "manifest-list": "{{ manifest_list_location }}"
+    }
+  ],
+  "snapshot-log": [
+    {"snapshot-id": 3051729675574597004, "timestamp-ms": 1515100955770}
+  ],
+  "metadata-log": [{"metadata-file": "{{ table_metadata_location }}", "timestamp-ms": 1515100}]
+}


### PR DESCRIPTION
## Which issue does this PR close?

- Part of #191.

## What changes are included in this PR?

- Exposes `ObjectCache`, `Table::object_cache`, `Table::with_object_cache`, and manifest-list loading for RisingWave integrations.
- Shares the underlying metadata entries across table reloads while retaining each new table's current `FileIO` and `EncryptionManager`. This adapts the old fork API to upstream's encryption support.
- Handles Iceberg V1 snapshots without `schema_id` by using the table's current schema ID in the cache key.
- Replaces the shallow `size_of_val` cache weight with an estimate that includes manifest entries, paths, partitions, column-stat maps, bounds, and other heap allocations.
- Restores `DataFile::set_partition` for metadata restoration.
- Updates the checked-in public API snapshot.

## Are these changes tested?

- `cargo test -p iceberg --lib --locked` (1473 passed)
- `cargo clippy -p iceberg --all-targets --all-features --locked -- -D warnings`
- focused V1, shared-cache, heap-weight, and partition setter regressions
- generated public API matches `crates/iceberg/public-api.txt`
- `cargo fmt --all -- --check`
- `git diff --check`
