### PR TITLE
feat(transaction): port unified replace-files stack

### DIFF
--- a/crates/iceberg/public-api.txt
+++ b/crates/iceberg/public-api.txt
@@ -3147,13 +3147,38 @@ pub fn iceberg::transaction::AddColumn::optional(name: impl alloc::string::ToStr
 pub fn iceberg::transaction::AddColumn::required(name: impl alloc::string::ToString, field_type: iceberg::spec::Type, initial_default: iceberg::spec::Literal) -> Self
 impl iceberg::transaction::AddColumn
 pub fn iceberg::transaction::AddColumn::builder() -> AddColumnBuilder<((), (), (), (), (), (), ())>
+pub struct iceberg::transaction::FastAppendAction
+impl iceberg::transaction::FastAppendAction
+pub fn iceberg::transaction::FastAppendAction::add_data_files(self, data_files: impl core::iter::traits::collect::IntoIterator<Item = iceberg::spec::DataFile>) -> Self
+pub fn iceberg::transaction::FastAppendAction::generate_snapshot_id(table: &iceberg::table::Table) -> i64
+pub fn iceberg::transaction::FastAppendAction::set_check_duplicate(self, v: bool) -> Self
+pub fn iceberg::transaction::FastAppendAction::set_commit_uuid(self, commit_uuid: uuid::Uuid) -> Self
+pub fn iceberg::transaction::FastAppendAction::set_snapshot_id(self, snapshot_id: i64) -> Self
+pub fn iceberg::transaction::FastAppendAction::set_snapshot_properties(self, snapshot_properties: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>) -> Self
+pub fn iceberg::transaction::FastAppendAction::set_target_branch(self, target_branch: alloc::string::String) -> Self
+pub fn iceberg::transaction::FastAppendAction::with_check_duplicate(self, v: bool) -> Self
+pub struct iceberg::transaction::ManifestFilterManager
+impl iceberg::transaction::ManifestFilterManager
+pub fn iceberg::transaction::ManifestFilterManager::contains_deletes(&self) -> bool
+pub fn iceberg::transaction::ManifestFilterManager::delete_file(&mut self, file: iceberg::spec::DataFile) -> iceberg::Result<()>
+pub fn iceberg::transaction::ManifestFilterManager::fail_any_delete(self) -> Self
+pub fn iceberg::transaction::ManifestFilterManager::fail_missing_delete_paths(self) -> Self
+pub fn iceberg::transaction::ManifestFilterManager::files_to_be_deleted(&self) -> alloc::vec::Vec<&iceberg::spec::DataFile>
+pub async fn iceberg::transaction::ManifestFilterManager::filter_manifests(&mut self, table_schema: &iceberg::spec::Schema, manifests: alloc::vec::Vec<iceberg::spec::ManifestFile>) -> iceberg::Result<alloc::vec::Vec<iceberg::spec::ManifestFile>>
+pub fn iceberg::transaction::ManifestFilterManager::new(file_io: iceberg::io::FileIO, writer_context: iceberg::transaction::ManifestWriterContext) -> Self
+pub struct iceberg::transaction::ManifestWriterContext
+impl iceberg::transaction::ManifestWriterContext
+pub fn iceberg::transaction::ManifestWriterContext::new(metadata_location: alloc::string::String, commit_uuid: uuid::Uuid, manifest_counter: alloc::sync::Arc<core::sync::atomic::AtomicU64>, format_version: iceberg::spec::FormatVersion, snapshot_id: i64, file_io: iceberg::io::FileIO, encryption_manager: core::option::Option<alloc::sync::Arc<iceberg::encryption::EncryptionManager>>) -> Self
+pub fn iceberg::transaction::ManifestWriterContext::new_manifest_writer(&self, content_type: iceberg::spec::ManifestContentType, table_schema: &iceberg::spec::Schema, partition_spec: &iceberg::spec::PartitionSpec) -> iceberg::Result<iceberg::spec::ManifestWriter>
 pub struct iceberg::transaction::Transaction
 impl iceberg::transaction::Transaction
 pub async fn iceberg::transaction::Transaction::commit(self, catalog: &dyn iceberg::Catalog) -> iceberg::Result<iceberg::table::Table>
 pub fn iceberg::transaction::Transaction::expire_snapshots(&self) -> iceberg::transaction::expire_snapshots::ExpireSnapshotsAction
-pub fn iceberg::transaction::Transaction::fast_append(&self) -> iceberg::transaction::append::FastAppendAction
+pub fn iceberg::transaction::Transaction::fast_append(&self) -> iceberg::transaction::FastAppendAction
 pub fn iceberg::transaction::Transaction::new(table: &iceberg::table::Table) -> Self
+pub fn iceberg::transaction::Transaction::overwrite_files(&self) -> iceberg::transaction::OverwriteFilesAction
 pub fn iceberg::transaction::Transaction::replace_sort_order(&self) -> iceberg::transaction::sort_order::ReplaceSortOrderAction
+pub fn iceberg::transaction::Transaction::rewrite_files(&self) -> iceberg::transaction::RewriteFilesAction
 pub fn iceberg::transaction::Transaction::update_location(&self) -> iceberg::transaction::update_location::UpdateLocationAction
 pub fn iceberg::transaction::Transaction::update_schema(&self) -> iceberg::transaction::update_schema::UpdateSchemaAction
 pub fn iceberg::transaction::Transaction::update_statistics(&self) -> iceberg::transaction::update_statistics::UpdateStatisticsAction
@@ -3164,7 +3189,9 @@ pub fn iceberg::transaction::Transaction::clone(&self) -> iceberg::transaction::
 pub trait iceberg::transaction::ApplyTransactionAction
 pub fn iceberg::transaction::ApplyTransactionAction::apply(self, tx: iceberg::transaction::Transaction) -> iceberg::Result<iceberg::transaction::Transaction>
 impl<T: TransactionAction + 'static> iceberg::transaction::ApplyTransactionAction for T
-pub fn T::apply(self, tx: iceberg::transaction::Transaction) -> iceberg::Result<iceberg::transaction::Transaction> where Self: core::marker::Sized
+pub fn T::apply(self, tx: iceberg::transaction::Transaction) -> core::result::Result<iceberg::transaction::Transaction, iceberg::Error>
+pub type iceberg::transaction::OverwriteFilesAction = iceberg::transaction::replace_files::ReplaceFilesAction<iceberg::transaction::replace_files::Overwrite>
+pub type iceberg::transaction::RewriteFilesAction = iceberg::transaction::replace_files::ReplaceFilesAction<iceberg::transaction::replace_files::Rewrite>
 pub mod iceberg::transform
 pub trait iceberg::transform::TransformFunction: core::marker::Send + core::marker::Sync + core::fmt::Debug
 pub fn iceberg::transform::TransformFunction::transform(&self, input: arrow_array::array::ArrayRef) -> iceberg::Result<arrow_array::array::ArrayRef>

--- a/crates/iceberg/src/spec/snapshot_summary.rs
+++ b/crates/iceberg/src/spec/snapshot_summary.rs
@@ -338,6 +338,7 @@ pub(crate) fn update_snapshot_summaries(
     if summary.operation != Operation::Append
         && summary.operation != Operation::Overwrite
         && summary.operation != Operation::Delete
+        && summary.operation != Operation::Replace
     {
         return Err(Error::new(
             ErrorKind::DataInvalid,

--- a/crates/iceberg/src/table.rs
+++ b/crates/iceberg/src/table.rs
@@ -275,6 +275,10 @@ impl Table {
         self.encryption_manager.as_deref()
     }
 
+    pub(crate) fn encryption_manager_ref(&self) -> Option<Arc<EncryptionManager>> {
+        self.encryption_manager.clone()
+    }
+
     /// Creates a table scan.
     pub fn scan(&self) -> TableScanBuilder<'_> {
         TableScanBuilder::new(self)

--- a/crates/iceberg/src/transaction/append.rs
+++ b/crates/iceberg/src/transaction/append.rs
@@ -25,7 +25,7 @@ use crate::error::Result;
 use crate::spec::{DataFile, ManifestEntry, ManifestFile, Operation};
 use crate::table::Table;
 use crate::transaction::snapshot::{
-    DefaultManifestProcess, SnapshotProduceOperation, SnapshotProducer,
+    DefaultManifestProcess, SnapshotProduceOperation, SnapshotProducer, data_file_identity,
 };
 use crate::transaction::{ActionCommit, TransactionAction};
 
@@ -34,8 +34,11 @@ pub struct FastAppendAction {
     check_duplicate: bool,
     // below are properties used to create SnapshotProducer when commit
     commit_uuid: Option<Uuid>,
+    snapshot_id: Option<i64>,
     snapshot_properties: HashMap<String, String>,
     added_data_files: Vec<DataFile>,
+    added_delete_files: Vec<DataFile>,
+    target_branch: Option<String>,
 }
 
 impl FastAppendAction {
@@ -43,8 +46,11 @@ impl FastAppendAction {
         Self {
             check_duplicate: true,
             commit_uuid: None,
+            snapshot_id: None,
             snapshot_properties: HashMap::default(),
             added_data_files: vec![],
+            added_delete_files: vec![],
+            target_branch: None,
         }
     }
 
@@ -54,9 +60,28 @@ impl FastAppendAction {
         self
     }
 
+    /// Set whether to check files against the target branch before committing.
+    pub fn set_check_duplicate(self, v: bool) -> Self {
+        self.with_check_duplicate(v)
+    }
+
+    /// Set the branch this append commits to.
+    pub fn set_target_branch(mut self, target_branch: String) -> Self {
+        self.target_branch = Some(target_branch);
+        self
+    }
+
     /// Add data files to the snapshot.
     pub fn add_data_files(mut self, data_files: impl IntoIterator<Item = DataFile>) -> Self {
-        self.added_data_files.extend(data_files);
+        for file in data_files {
+            match file.content_type() {
+                crate::spec::DataContentType::Data => self.added_data_files.push(file),
+                crate::spec::DataContentType::PositionDeletes
+                | crate::spec::DataContentType::EqualityDeletes => {
+                    self.added_delete_files.push(file);
+                }
+            }
+        }
         self
     }
 
@@ -72,35 +97,75 @@ impl FastAppendAction {
         self
     }
 
-    /// Collapse files sharing a path to their first occurrence, so a single
-    /// manifest never references the same file twice. Always runs (unlike the
+    /// Set the snapshot ID before committing, for exactly-once integrations.
+    pub fn set_snapshot_id(mut self, snapshot_id: i64) -> Self {
+        self.snapshot_id = Some(snapshot_id);
+        self
+    }
+
+    /// Generate a snapshot ID that can be persisted before commit.
+    pub fn generate_snapshot_id(table: &Table) -> i64 {
+        SnapshotProducer::generate_unique_snapshot_id(table)
+    }
+
+    /// Collapse duplicate file identities to their first occurrence.
+    ///
+    /// Deletion vectors use `(path, offset, length)` identity because multiple
+    /// vectors may share one Puffin file. This always runs (unlike the
     /// `check_duplicate`-gated cross-snapshot check) since it is in-memory only.
-    fn dedupe_added_files(&self) -> Vec<DataFile> {
-        let mut seen = HashSet::with_capacity(self.added_data_files.len());
-        self.added_data_files
+    fn dedupe_added_files(&self) -> (Vec<DataFile>, Vec<DataFile>) {
+        let mut seen =
+            HashSet::with_capacity(self.added_data_files.len() + self.added_delete_files.len());
+        let data_files = self
+            .added_data_files
             .iter()
-            .filter(|data_file| seen.insert(data_file.file_path.as_str()))
+            .filter(|file| seen.insert(data_file_identity(file)))
             .cloned()
-            .collect()
+            .collect();
+        let delete_files = self
+            .added_delete_files
+            .iter()
+            .filter(|file| seen.insert(data_file_identity(file)))
+            .cloned()
+            .collect();
+        (data_files, delete_files)
     }
 }
 
 #[async_trait]
 impl TransactionAction for FastAppendAction {
     async fn commit(self: Arc<Self>, table: &Table) -> Result<ActionCommit> {
-        let snapshot_producer = SnapshotProducer::new(
+        if let Some(snapshot_id) = self.snapshot_id
+            && table.metadata().snapshot_by_id(snapshot_id).is_some()
+        {
+            return Err(crate::Error::new(
+                crate::ErrorKind::DataInvalid,
+                format!("Snapshot id {snapshot_id} already exists"),
+            ));
+        }
+
+        let (added_data_files, added_delete_files) = self.dedupe_added_files();
+        let mut snapshot_producer = SnapshotProducer::new(
             table,
             self.commit_uuid.unwrap_or_else(Uuid::now_v7),
+            self.snapshot_id,
             self.snapshot_properties.clone(),
-            self.dedupe_added_files(),
+            added_data_files,
+            added_delete_files,
+            vec![],
+            vec![],
         );
 
-        // validate added files
-        snapshot_producer.validate_added_data_files()?;
+        if let Some(target_branch) = &self.target_branch {
+            snapshot_producer.set_target_branch(target_branch.clone());
+        }
+
+        snapshot_producer.validate_added_files(&snapshot_producer.added_data_files)?;
+        snapshot_producer.validate_added_files(&snapshot_producer.added_delete_files)?;
 
         // Checks duplicate files
         if self.check_duplicate {
-            snapshot_producer.validate_duplicate_files().await?;
+            snapshot_producer.validate_data_file_changes().await?;
         }
 
         snapshot_producer
@@ -125,9 +190,13 @@ impl SnapshotProduceOperation for FastAppendOperation {
 
     async fn existing_manifest(
         &self,
-        snapshot_produce: &SnapshotProducer<'_>,
+        snapshot_produce: &mut SnapshotProducer<'_>,
     ) -> Result<Vec<ManifestFile>> {
-        let Some(snapshot) = snapshot_produce.table.metadata().current_snapshot() else {
+        let Some(snapshot) = snapshot_produce
+            .table
+            .metadata()
+            .snapshot_for_ref(snapshot_produce.target_branch())
+        else {
             return Ok(vec![]);
         };
 
@@ -166,13 +235,15 @@ mod tests {
     use crate::io::FileIO;
     use crate::spec::{
         DataContentType, DataFile, DataFileBuilder, DataFileFormat, Literal, MAIN_BRANCH,
-        ManifestEntry, ManifestListWriter, ManifestStatus, ManifestWriterBuilder, SnapshotRef,
-        Struct, TableMetadata,
+        ManifestContentType, ManifestEntry, ManifestListWriter, ManifestStatus,
+        ManifestWriterBuilder, SnapshotRef, Struct, TableMetadata,
     };
     use crate::table::Table;
     use crate::test_utils::test_runtime;
-    use crate::transaction::tests::{make_encrypted_table, make_v2_minimal_table};
-    use crate::transaction::{Transaction, TransactionAction};
+    use crate::transaction::tests::{
+        make_encrypted_table, make_v2_minimal_table, make_v3_minimal_table,
+    };
+    use crate::transaction::{FastAppendAction, Transaction, TransactionAction};
     use crate::{TableIdent, TableRequirement, TableUpdate};
 
     fn render_template(template: &str, ctx: Value) -> String {
@@ -920,5 +991,139 @@ mod tests {
             manifest.entries()[0].snapshot_id().unwrap()
         );
         assert_eq!(data_file, *manifest.entries()[0].data_file());
+    }
+
+    #[tokio::test]
+    async fn test_fast_append_uses_pre_generated_id_and_target_branch() {
+        let table = make_v2_minimal_table();
+        let snapshot_id = FastAppendAction::generate_snapshot_id(&table);
+        let target_branch = "staging";
+        let data_file = DataFileBuilder::default()
+            .content(DataContentType::Data)
+            .file_path("test/branch.parquet".to_string())
+            .file_format(DataFileFormat::Parquet)
+            .file_size_in_bytes(100)
+            .record_count(1)
+            .partition_spec_id(table.metadata().default_partition_spec_id())
+            .partition(Struct::from_iter([Some(Literal::long(300))]))
+            .build()
+            .unwrap();
+
+        let action = Transaction::new(&table)
+            .fast_append()
+            .set_snapshot_id(snapshot_id)
+            .set_target_branch(target_branch.to_string())
+            .add_data_files([data_file]);
+        let mut action_commit = Arc::new(action).commit(&table).await.unwrap();
+        let updates = action_commit.take_updates();
+        let requirements = action_commit.take_requirements();
+
+        assert!(matches!(
+            &updates[..],
+            [
+                TableUpdate::AddSnapshot { snapshot },
+                TableUpdate::SetSnapshotRef {
+                    ref_name,
+                    reference
+                }
+            ] if snapshot.snapshot_id() == snapshot_id
+                && ref_name == target_branch
+                && reference.snapshot_id == snapshot_id
+        ));
+        assert_eq!(requirements, vec![
+            TableRequirement::UuidMatch {
+                uuid: table.metadata().uuid(),
+            },
+            TableRequirement::RefSnapshotIdMatch {
+                r#ref: target_branch.to_string(),
+                snapshot_id: None,
+            },
+        ]);
+    }
+
+    #[tokio::test]
+    async fn test_fast_append_writes_delete_manifest() {
+        let table = make_v2_minimal_table();
+        let delete_file =
+            crate::transaction::tests::position_delete_file(&table, "test/delete.parquet");
+        let action = Transaction::new(&table)
+            .fast_append()
+            .add_data_files([delete_file.clone()]);
+        let mut action_commit = Arc::new(action).commit(&table).await.unwrap();
+        let updates = action_commit.take_updates();
+        let TableUpdate::AddSnapshot { snapshot } = &updates[0] else {
+            unreachable!()
+        };
+        let manifest_list = table
+            .manifest_list_reader(&SnapshotRef::new(snapshot.clone()))
+            .load()
+            .await
+            .unwrap();
+
+        assert_eq!(manifest_list.entries().len(), 1);
+        assert_eq!(
+            manifest_list.entries()[0].content,
+            ManifestContentType::Deletes
+        );
+        let manifest = manifest_list.entries()[0]
+            .load_manifest(table.file_io())
+            .await
+            .unwrap();
+        assert_eq!(manifest.entries().len(), 1);
+        assert_eq!(manifest.entries()[0].data_file(), &delete_file);
+        assert_eq!(
+            snapshot
+                .summary()
+                .additional_properties
+                .get("added-delete-files")
+                .map(String::as_str),
+            Some("1")
+        );
+    }
+
+    #[tokio::test]
+    async fn test_fast_append_keeps_distinct_deletion_vectors_in_shared_puffin() {
+        let table = make_v3_minimal_table();
+        let make_dv = |referenced_data_file: &str, offset: i64| {
+            DataFileBuilder::default()
+                .content(DataContentType::PositionDeletes)
+                .file_path("test/shared.puffin".to_string())
+                .file_format(DataFileFormat::Puffin)
+                .file_size_in_bytes(256)
+                .record_count(1)
+                .partition_spec_id(table.metadata().default_partition_spec_id())
+                .partition(Struct::from_iter([Some(Literal::long(300))]))
+                .referenced_data_file(Some(referenced_data_file.to_string()))
+                .content_offset(Some(offset))
+                .content_size_in_bytes(Some(64))
+                .build()
+                .unwrap()
+        };
+        let action = Transaction::new(&table).fast_append().add_data_files([
+            make_dv("test/data-a.parquet", 4),
+            make_dv("test/data-b.parquet", 68),
+        ]);
+        let mut action_commit = Arc::new(action).commit(&table).await.unwrap();
+        let updates = action_commit.take_updates();
+        let TableUpdate::AddSnapshot { snapshot } = &updates[0] else {
+            unreachable!()
+        };
+        let manifest_list = table
+            .manifest_list_reader(&SnapshotRef::new(snapshot.clone()))
+            .load()
+            .await
+            .unwrap();
+        let manifest = manifest_list.entries()[0]
+            .load_manifest(table.file_io())
+            .await
+            .unwrap();
+        let mut offsets = manifest
+            .entries()
+            .iter()
+            .map(|entry| entry.data_file().content_offset().unwrap())
+            .collect::<Vec<_>>();
+        offsets.sort_unstable();
+
+        assert_eq!(offsets, vec![4, 68]);
     }
 }

--- a/crates/iceberg/src/transaction/manifest_filter.rs
+++ b/crates/iceberg/src/transaction/manifest_filter.rs
@@ -1,0 +1,1653 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use uuid::Uuid;
+
+use crate::encryption::EncryptionManager;
+use crate::error::Result;
+use crate::io::FileIO;
+use crate::spec::{
+    DataContentType, DataFile, DataFileFormat, FormatVersion, ManifestContentType, ManifestFile,
+    ManifestStatus, ManifestWriter, ManifestWriterBuilder, PartitionSpec, Schema,
+};
+use crate::transaction::snapshot::{
+    DataFileIdentity, data_file_identity, format_data_file_identity,
+};
+use crate::{Error, ErrorKind};
+
+/// Context for creating manifest writers during filtering operations
+pub struct ManifestWriterContext {
+    metadata_location: String,
+    commit_uuid: Uuid,
+    manifest_counter: Arc<AtomicU64>,
+    format_version: FormatVersion,
+    snapshot_id: i64,
+    file_io: FileIO,
+    encryption_manager: Option<Arc<EncryptionManager>>,
+}
+
+impl ManifestWriterContext {
+    /// Create a new ManifestWriterContext
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        metadata_location: String,
+        commit_uuid: Uuid,
+        manifest_counter: Arc<AtomicU64>,
+        format_version: FormatVersion,
+        snapshot_id: i64,
+        file_io: FileIO,
+        encryption_manager: Option<Arc<EncryptionManager>>,
+    ) -> Self {
+        Self {
+            metadata_location,
+            commit_uuid,
+            manifest_counter,
+            format_version,
+            snapshot_id,
+            file_io,
+            encryption_manager,
+        }
+    }
+
+    /// Create a manifest writer for the specified content type
+    pub fn new_manifest_writer(
+        &self,
+        content_type: ManifestContentType,
+        table_schema: &Schema,
+        partition_spec: &PartitionSpec,
+    ) -> Result<ManifestWriter> {
+        let new_manifest_path = format!(
+            "{}/{}-m{}.{}",
+            self.metadata_location,
+            self.commit_uuid,
+            self.manifest_counter.fetch_add(1, Ordering::SeqCst),
+            DataFileFormat::Avro,
+        );
+
+        let output = self.file_io.new_output(&new_manifest_path)?;
+        let builder = match &self.encryption_manager {
+            Some(manager) => ManifestWriterBuilder::new_from_encrypted(
+                manager.encrypt(output),
+                Some(self.snapshot_id),
+                table_schema.clone().into(),
+                partition_spec.clone(),
+            )?,
+            None => ManifestWriterBuilder::new(
+                output,
+                Some(self.snapshot_id),
+                table_schema.clone().into(),
+                partition_spec.clone(),
+            ),
+        };
+
+        match self.format_version {
+            FormatVersion::V1 => Ok(builder.build_v1()),
+            FormatVersion::V2 => match content_type {
+                ManifestContentType::Data => Ok(builder.build_v2_data()),
+                ManifestContentType::Deletes => Ok(builder.build_v2_deletes()),
+            },
+            FormatVersion::V3 => match content_type {
+                ManifestContentType::Data => Ok(builder.build_v3_data()),
+                ManifestContentType::Deletes => Ok(builder.build_v3_deletes()),
+            },
+        }
+    }
+}
+
+/// Manager for filtering manifest files and handling delete operations
+pub struct ManifestFilterManager {
+    /// Files or Puffin blobs to be deleted by identity.
+    files_to_delete: HashMap<DataFileIdentity, DataFile>,
+
+    /// Minimum sequence number for removing old delete files
+    min_sequence_number: i64,
+    /// Whether to fail if any delete operation is attempted
+    fail_any_delete: bool,
+    /// Whether to fail if required delete file identities are missing
+    fail_missing_delete_paths: bool,
+    /// Cache of filtered manifests to avoid reprocessing
+    filtered_manifests: HashMap<String, ManifestFile>, // manifest_path -> filtered_manifest
+    /// Tracking where files were deleted to validate retries quickly
+    filtered_manifest_to_deleted_files: HashMap<String, Vec<DataFileIdentity>>,
+    ///    this is only being used for the DeleteManifestFilterManager to detect orphaned deletes for removed data file paths
+    removed_data_file_path: HashSet<String>,
+
+    file_io: FileIO,
+    writer_context: ManifestWriterContext,
+}
+
+impl ManifestFilterManager {
+    /// Create a new ManifestFilterManager
+    pub fn new(file_io: FileIO, writer_context: ManifestWriterContext) -> Self {
+        Self {
+            files_to_delete: HashMap::new(),
+            min_sequence_number: 0,
+            fail_any_delete: false,
+            fail_missing_delete_paths: false,
+            filtered_manifests: HashMap::new(),
+            filtered_manifest_to_deleted_files: HashMap::new(),
+            removed_data_file_path: HashSet::new(),
+            file_io,
+            writer_context,
+        }
+    }
+
+    /// Set whether to fail if any delete operation is attempted
+    pub fn fail_any_delete(mut self) -> Self {
+        self.fail_any_delete = true;
+        self
+    }
+
+    /// Get files marked for deletion
+    pub fn files_to_be_deleted(&self) -> Vec<&DataFile> {
+        self.files_to_delete.values().collect()
+    }
+
+    /// Set minimum sequence number for removing old delete files
+    pub(crate) fn drop_delete_files_older_than(&mut self, sequence_number: i64) {
+        assert!(
+            sequence_number >= 0,
+            "Invalid minimum data sequence number: {sequence_number}",
+        );
+        self.min_sequence_number = sequence_number;
+    }
+
+    /// Set whether to fail if required delete file identities are missing
+    pub fn fail_missing_delete_paths(mut self) -> Self {
+        self.fail_missing_delete_paths = true;
+        self
+    }
+
+    /// Mark a data file for deletion
+    pub fn delete_file(&mut self, file: DataFile) -> Result<()> {
+        // Todo: check all deletes references in manifests?
+        self.files_to_delete.insert(data_file_identity(&file), file);
+
+        Ok(())
+    }
+
+    /// Check if this manager contains any delete operations
+    pub fn contains_deletes(&self) -> bool {
+        !self.files_to_delete.is_empty()
+    }
+
+    /// Filter manifest files, removing entries marked for deletion
+    pub async fn filter_manifests(
+        &mut self,
+        table_schema: &Schema,
+        manifests: Vec<ManifestFile>,
+    ) -> Result<Vec<ManifestFile>> {
+        if manifests.is_empty() {
+            self.validate_required_deletes(&[])?;
+            return Ok(vec![]);
+        }
+
+        let mut filtered = Vec::with_capacity(manifests.len());
+
+        for manifest in manifests {
+            let filtered_manifest = self.filter_manifest(table_schema, manifest).await?;
+            filtered.push(filtered_manifest);
+        }
+
+        self.validate_required_deletes(&filtered)?;
+        Ok(filtered)
+    }
+
+    /// Filter a single manifest file
+    async fn filter_manifest(
+        &mut self,
+        table_schema: &Schema,
+        manifest: ManifestFile,
+    ) -> Result<ManifestFile> {
+        // Check cache first
+        if let Some(cached) = self.filtered_manifests.get(&manifest.manifest_path) {
+            return Ok(cached.clone());
+        }
+
+        // Check if this manifest can contain files to delete
+        if !self.can_contain_deleted_files(&manifest) {
+            self.filtered_manifests
+                .insert(manifest.manifest_path.clone(), manifest.clone());
+            return Ok(manifest);
+        }
+
+        if self.manifest_has_deleted_files(&manifest).await? {
+            // Load and filter the manifest
+            self.filter_manifest_with_deleted_files(table_schema, manifest)
+                .await
+        } else {
+            // If no deleted files are found, just return the original manifest
+            self.filtered_manifests
+                .insert(manifest.manifest_path.clone(), manifest.clone());
+            Ok(manifest)
+        }
+    }
+
+    /// Check if a manifest can potentially contain files that need to be deleted
+    fn can_contain_deleted_files(&self, manifest: &ManifestFile) -> bool {
+        // If manifest has no live files, it can't contain files to delete
+        if Self::manifest_has_no_live_files(manifest) {
+            return false;
+        }
+
+        let may_contain_expired_delete = manifest.content == ManifestContentType::Deletes
+            && manifest.min_sequence_number != crate::spec::UNASSIGNED_SEQUENCE_NUMBER
+            && manifest.min_sequence_number > 0
+            && manifest.min_sequence_number < self.min_sequence_number;
+
+        // Explicit path deletes and dangling-delete checks require inspecting live
+        // entries. Sequence cleanup does too, even when no path-based delete exists.
+        !self.files_to_delete.is_empty()
+            || !self.removed_data_file_path.is_empty()
+            || may_contain_expired_delete
+    }
+
+    /// Filter a manifest that is known to contain files to delete
+    async fn filter_manifest_with_deleted_files(
+        &mut self,
+        table_schema: &Schema,
+        manifest: ManifestFile,
+    ) -> Result<ManifestFile> {
+        // Load the original manifest
+        let original_manifest = manifest.load_manifest(&self.file_io).await?;
+
+        let (entries, manifest_meta_data) = original_manifest.into_parts();
+
+        // Check if this is a delete manifest
+        let is_delete = manifest.content == ManifestContentType::Deletes;
+
+        // Track deleted files for duplicate detection
+        let mut deleted_files = HashMap::new();
+
+        // Create an output path for the filtered manifest using writer context
+        let partition_spec = manifest_meta_data.partition_spec.clone();
+
+        // Create the manifest writer using the writer context
+        let mut writer = self.writer_context.new_manifest_writer(
+            manifest.content,
+            table_schema,
+            &partition_spec,
+        )?;
+
+        // Process each live entry in the manifest
+        for entry in &entries {
+            if !entry.is_alive() {
+                continue;
+            }
+
+            let entry = entry.as_ref();
+            let file = entry.data_file();
+
+            // Why an entry is removed matters, so keep the reasons separate.
+            //
+            // An explicit delete, or the sequence-number rule, condemns this file identity.
+            // Danglingness is different: it is a property of a single deletion-vector
+            // *blob*. Several DVs can share one Puffin file, distinguished by
+            // (`file_path`, `content_offset`, `content_size_in_bytes`), so a dangling blob
+            // says nothing about its neighbours in the same file.
+            let identity = data_file_identity(file);
+            let explicitly_deleted = self.files_to_delete.contains_key(&identity);
+            // For delete manifests, check sequence number for old delete files
+            let superseded_by_sequence_number = is_delete
+                && matches!(entry.sequence_number(), Some(seq_num) if seq_num != crate::spec::UNASSIGNED_SEQUENCE_NUMBER
+                             && seq_num > 0
+                             && seq_num < self.min_sequence_number);
+            // For delete manifests, drop deletes whose referenced data file is gone
+            let dangling_delete = is_delete && self.is_dangling_delete(file);
+
+            let marked_for_delete =
+                explicitly_deleted || superseded_by_sequence_number || dangling_delete;
+
+            // TODO: Add expression evaluation logic
+            if marked_for_delete {
+                // Check if all rows match
+                let all_rows_match = marked_for_delete;
+
+                // Validation check: cannot delete file where some, but not all, rows match filter
+                // unless it's a delete file (ignore delete files where some records may not match)
+                if !all_rows_match && !is_delete {
+                    return Err(Error::new(
+                        ErrorKind::DataInvalid,
+                        format!(
+                            "Cannot delete file where some, but not all, rows match filter: {}",
+                            file.file_path()
+                        ),
+                    ));
+                }
+
+                if all_rows_match {
+                    // Mark this entry as deleted
+                    writer.add_delete_entry(entry.clone())?;
+
+                    // A dangling decision must not be promoted into `files_to_delete`: it is
+                    // consulted for every later entry
+                    // in this and every later manifest, so recording a shared Puffin here
+                    // would drop the *live* deletion vectors of data files that were never
+                    // rewritten -- silently resurrecting their deleted rows. Dropping this
+                    // one entry is the whole effect we want.
+                    if explicitly_deleted || superseded_by_sequence_number {
+                        // Create a copy of the file without stats
+                        let file_copy = file.clone();
+
+                        // For file that it was deleted using an expression
+                        self.files_to_delete
+                            .insert(identity.clone(), file_copy.clone());
+
+                        // TODO: add file to removed_data_file_path once we implement drop_partition
+
+                        // Track each identity once so retry validation and snapshot
+                        // summaries do not double-count duplicate manifest entries.
+                        deleted_files.entry(identity).or_insert(file_copy);
+                    }
+                } else {
+                    // Keep the entry as existing
+                    writer.add_existing_entry(entry.clone())?;
+                }
+            } else {
+                // Keep the entry as existing
+                writer.add_existing_entry(entry.clone())?;
+            }
+        }
+
+        // Write the filtered manifest
+        let filtered_manifest = writer.write_manifest_file().await?;
+
+        // Update caches
+        self.filtered_manifests
+            .insert(manifest.manifest_path.clone(), filtered_manifest.clone());
+
+        // Track deleted files for validation - convert HashSet to Vec of file paths
+        let deleted_file_identities: Vec<DataFileIdentity> =
+            deleted_files.keys().cloned().collect();
+
+        self.filtered_manifest_to_deleted_files.insert(
+            filtered_manifest.manifest_path.clone(),
+            deleted_file_identities,
+        );
+
+        Ok(filtered_manifest)
+    }
+
+    /// Validate that all required delete operations were found
+    fn validate_required_deletes(&self, manifests: &[ManifestFile]) -> Result<()> {
+        if self.fail_missing_delete_paths {
+            let deleted_files = self.deleted_files(manifests);
+            // check deleted_files contains all files in self.delete_files
+
+            for identity in self.files_to_delete.keys() {
+                if !deleted_files.contains(identity) {
+                    return Err(Error::new(
+                        ErrorKind::DataInvalid,
+                        format!(
+                            "Required delete file missing: {}",
+                            format_data_file_identity(identity)
+                        ),
+                    ));
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn deleted_files(&self, manifests: &[ManifestFile]) -> HashSet<DataFileIdentity> {
+        let mut deleted_files = HashSet::new();
+        for manifest in manifests {
+            if let Some(deleted) = self
+                .filtered_manifest_to_deleted_files
+                .get(manifest.manifest_path.as_str())
+            {
+                deleted_files.extend(deleted.clone());
+            }
+        }
+        deleted_files
+    }
+
+    fn manifest_has_no_live_files(manifest: &ManifestFile) -> bool {
+        !manifest.has_added_files() && !manifest.has_existing_files()
+    }
+
+    async fn manifest_has_deleted_files(&self, manifest_file: &ManifestFile) -> Result<bool> {
+        let manifest = manifest_file.load_manifest(&self.file_io).await?;
+
+        let is_delete = manifest_file.content == ManifestContentType::Deletes;
+
+        for entry in manifest.entries() {
+            let entry = entry.as_ref();
+
+            // Skip entries that are already deleted
+            if entry.status() == ManifestStatus::Deleted {
+                continue;
+            }
+
+            let file = entry.data_file();
+
+            // Check if file is marked for deletion based on various criteria.
+            // Mirrors the decision in `filter_manifest_with_deleted_files`; see the comment
+            // there for why the dangling-delete case is deliberately per-blob.
+            let marked_for_delete =
+                // Check if file path is in files to delete
+                self.files_to_delete.contains_key(&data_file_identity(file)) ||
+                // For delete manifests, check sequence number for old delete files
+                (is_delete &&
+                 entry.status() != ManifestStatus::Deleted &&
+                  matches!(entry.sequence_number(), Some(seq_num) if seq_num != crate::spec::UNASSIGNED_SEQUENCE_NUMBER
+                             && seq_num > 0
+                             && seq_num < self.min_sequence_number)) ||
+                // For delete manifests, drop deletes whose referenced data file is gone
+                (is_delete && self.is_dangling_delete(file));
+
+            // TODO: Add expression evaluation logic
+            if marked_for_delete {
+                // Check if all rows match
+                let all_rows_match = marked_for_delete; // || evaluator.rowsMustMatch(file) equivalent
+
+                // Validation check: cannot delete file where some, but not all, rows match filter
+                // unless it's a delete file
+                if !all_rows_match && !is_delete {
+                    return Err(Error::new(
+                        ErrorKind::DataInvalid,
+                        format!(
+                            "Cannot delete file where some, but not all, rows match filter: {}",
+                            file.file_path()
+                        ),
+                    ));
+                }
+
+                if all_rows_match {
+                    // Check fail_any_delete flag
+                    if self.fail_any_delete {
+                        return Err(Error::new(
+                            ErrorKind::DataInvalid,
+                            "Operation would delete existing data".to_string(),
+                        ));
+                    }
+
+                    // As soon as a deleted file is detected, stop scanning and return true
+                    return Ok(true);
+                }
+            }
+        }
+
+        Ok(false)
+    }
+
+    pub(crate) fn remove_dangling_deletes_for(&mut self, file_paths: &HashSet<String>) {
+        self.removed_data_file_path
+            .extend(file_paths.iter().cloned());
+    }
+
+    /// Returns `true` if `file` is a delete file that can no longer apply to anything,
+    /// because the single data file it references is being removed in this commit.
+    ///
+    /// This covers deletes that target exactly one data file and therefore can be
+    /// *proven* dangling:
+    ///
+    /// * **Deletion vectors** (v3): a Puffin blob carrying the deleted row positions for
+    ///   one data file, identified by `referenced-data-file`.
+    /// * **Position delete files** (v2) that set `referenced-data-file`.
+    ///
+    /// Deletes without `referenced-data-file` (equality deletes, or position deletes that
+    /// span several data files) may still apply to surviving data files, so they are never
+    /// reported as dangling here. The sequence-number rule in
+    /// [`Self::drop_delete_files_older_than`] is what eventually retires those.
+    ///
+    /// Without this check a rewrite (e.g. compaction) that replaces a data file leaves its
+    /// deletion vector live in the delete manifests forever: it applies to nothing, but it
+    /// keeps the Puffin file reachable, so snapshot expiration cannot reclaim it either and
+    /// the delete manifests grow monotonically with every rewrite.
+    fn is_dangling_delete(&self, file: &DataFile) -> bool {
+        if self.removed_data_file_path.is_empty() {
+            return false;
+        }
+
+        if file.content_type() == DataContentType::Data {
+            return false;
+        }
+
+        file.referenced_data_file()
+            .is_some_and(|referenced| self.removed_data_file_path.contains(&referenced))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
+    use tempfile::TempDir;
+    use uuid::Uuid;
+
+    use super::*;
+    use crate::io::FileIO;
+    use crate::spec::{
+        DataContentType, DataFileFormat, FormatVersion, ManifestContentType, ManifestEntry,
+        ManifestFile, ManifestStatus, ManifestWriterBuilder, NestedField, PartitionSpec,
+        PrimitiveType, Schema, Struct, Type,
+    };
+
+    // Helper function to create a test schema
+    fn create_test_schema() -> Schema {
+        Schema::builder()
+            .with_schema_id(1)
+            .with_fields(vec![
+                Arc::new(NestedField::required(
+                    1,
+                    "id",
+                    Type::Primitive(PrimitiveType::Long),
+                )),
+                Arc::new(NestedField::optional(
+                    2,
+                    "name",
+                    Type::Primitive(PrimitiveType::String),
+                )),
+            ])
+            .build()
+            .unwrap()
+    }
+
+    // Helper function to create a test DataFile
+    fn create_test_data_file(file_path: &str, partition_spec_id: i32) -> DataFile {
+        DataFile {
+            content: DataContentType::Data,
+            file_path: file_path.to_string(),
+            file_format: DataFileFormat::Parquet,
+            partition: Struct::empty(),
+            partition_spec_id,
+            record_count: 100,
+            file_size_in_bytes: 1024,
+            column_sizes: HashMap::new(),
+            value_counts: HashMap::new(),
+            null_value_counts: HashMap::new(),
+            nan_value_counts: HashMap::new(),
+            lower_bounds: HashMap::new(),
+            upper_bounds: HashMap::new(),
+            key_metadata: None,
+            split_offsets: None,
+            equality_ids: None,
+            sort_order_id: None,
+            first_row_id: None,
+            referenced_data_file: None,
+            content_offset: None,
+            content_size_in_bytes: None,
+        }
+    }
+
+    // Helper function to create a deletion vector sharing a Puffin file with others.
+    // Real DVs are addressed by (file_path, content_offset, content_size_in_bytes), so a
+    // single Puffin can hold the vectors of many data files.
+    fn create_test_deletion_vector_at(
+        file_path: &str,
+        referenced_data_file: &str,
+        content_offset: i64,
+    ) -> DataFile {
+        let mut dv = create_test_deletion_vector(file_path, referenced_data_file);
+        dv.content_offset = Some(content_offset);
+        dv
+    }
+
+    // Helper function to create a deletion vector (Puffin position-delete) DataFile that
+    // carries the deleted row positions for exactly one referenced data file.
+    fn create_test_deletion_vector(file_path: &str, referenced_data_file: &str) -> DataFile {
+        DataFile {
+            content: DataContentType::PositionDeletes,
+            file_path: file_path.to_string(),
+            file_format: DataFileFormat::Puffin,
+            partition: Struct::empty(),
+            partition_spec_id: 0,
+            record_count: 3,
+            file_size_in_bytes: 128,
+            column_sizes: HashMap::new(),
+            value_counts: HashMap::new(),
+            null_value_counts: HashMap::new(),
+            nan_value_counts: HashMap::new(),
+            lower_bounds: HashMap::new(),
+            upper_bounds: HashMap::new(),
+            key_metadata: None,
+            split_offsets: None,
+            equality_ids: None,
+            sort_order_id: None,
+            first_row_id: None,
+            referenced_data_file: Some(referenced_data_file.to_string()),
+            content_offset: Some(4),
+            content_size_in_bytes: Some(64),
+        }
+    }
+
+    // Helper function to create a test ManifestFile with default values
+    fn create_test_manifest_file(
+        manifest_path: &str,
+        content: ManifestContentType,
+    ) -> ManifestFile {
+        create_manifest_with_counts(manifest_path, content, 10, 5, 0)
+    }
+
+    // Helper function to create a ManifestFile with custom counts
+    fn create_manifest_with_counts(
+        manifest_path: &str,
+        content: ManifestContentType,
+        added_files: u32,
+        existing_files: u32,
+        deleted_files: u32,
+    ) -> ManifestFile {
+        ManifestFile {
+            manifest_path: manifest_path.to_string(),
+            manifest_length: 5000,
+            partition_spec_id: 0,
+            content,
+            sequence_number: 1,
+            min_sequence_number: 1,
+            added_snapshot_id: 12345,
+            added_files_count: Some(added_files),
+            existing_files_count: Some(existing_files),
+            deleted_files_count: Some(deleted_files),
+            added_rows_count: Some(added_files as u64 * 100),
+            existing_rows_count: Some(existing_files as u64 * 100),
+            deleted_rows_count: Some(deleted_files as u64 * 100),
+            partitions: None,
+            key_metadata: None,
+            first_row_id: None,
+        }
+    }
+
+    // Helper function to create a ManifestFile with specific sequence numbers
+    fn create_manifest_with_sequence(
+        manifest_path: &str,
+        content: ManifestContentType,
+        sequence_number: i64,
+        min_sequence_number: i64,
+    ) -> ManifestFile {
+        let mut manifest = create_test_manifest_file(manifest_path, content);
+        manifest.sequence_number = sequence_number;
+        manifest.min_sequence_number = min_sequence_number;
+        manifest
+    }
+
+    // Helper function to setup test environment
+    fn setup_test_manager() -> (ManifestFilterManager, TempDir) {
+        let temp_dir = TempDir::new().unwrap();
+        let file_io = FileIO::new_with_fs();
+        let metadata_location = temp_dir.path().to_string_lossy().to_string();
+
+        let writer_context = ManifestWriterContext::new(
+            metadata_location,
+            Uuid::new_v4(),
+            Arc::new(AtomicU64::new(0)),
+            FormatVersion::V2,
+            1,
+            file_io.clone(),
+            None,
+        );
+
+        let manager = ManifestFilterManager::new(file_io, writer_context);
+
+        (manager, temp_dir)
+    }
+
+    // Helper function to write manifest entries to file
+    async fn write_manifest_with_entries(
+        manager: &ManifestFilterManager,
+        manifest_path: &str,
+        schema: &Schema,
+        entries: Vec<ManifestEntry>,
+        snapshot_id: i64,
+    ) -> Result<()> {
+        let partition_spec = PartitionSpec::unpartition_spec();
+        let output_file = manager.file_io.new_output(manifest_path)?;
+        let mut writer = ManifestWriterBuilder::new(
+            output_file,
+            Some(snapshot_id),
+            schema.clone().into(),
+            partition_spec,
+        )
+        .build_v2_data();
+
+        for entry in entries {
+            writer.add_entry(entry)?;
+        }
+        writer.write_manifest_file().await?;
+        Ok(())
+    }
+
+    // Helper function to write delete-manifest entries to file. Deletion vectors live in
+    // delete manifests, so the dangling-delete tests need the `deletes` writer variant.
+    async fn write_delete_manifest_with_entries(
+        manager: &ManifestFilterManager,
+        manifest_path: &str,
+        schema: &Schema,
+        entries: Vec<ManifestEntry>,
+        snapshot_id: i64,
+    ) -> Result<()> {
+        let partition_spec = PartitionSpec::unpartition_spec();
+        let output_file = manager.file_io.new_output(manifest_path)?;
+        let mut writer = ManifestWriterBuilder::new(
+            output_file,
+            Some(snapshot_id),
+            schema.clone().into(),
+            partition_spec,
+        )
+        .build_v2_deletes();
+
+        for entry in entries {
+            writer.add_entry(entry)?;
+        }
+        writer.write_manifest_file().await?;
+        Ok(())
+    }
+
+    // Helper function to create manifest entries from data files
+    fn create_entries_from_files(files: Vec<DataFile>) -> Vec<ManifestEntry> {
+        files
+            .into_iter()
+            .map(|file| {
+                ManifestEntry::builder()
+                    .status(ManifestStatus::Added)
+                    .data_file(file)
+                    .build()
+            })
+            .collect()
+    }
+
+    // Helper function to create a full manifest file metadata
+    fn create_manifest_metadata(
+        manifest_path: &str,
+        content: ManifestContentType,
+        sequence_number: i64,
+        snapshot_id: i64,
+        file_counts: (u32, u32, u32), // (added, existing, deleted)
+    ) -> ManifestFile {
+        let (added, existing, deleted) = file_counts;
+        ManifestFile {
+            manifest_path: manifest_path.to_string(),
+            manifest_length: 1000,
+            partition_spec_id: 0,
+            content,
+            sequence_number,
+            min_sequence_number: sequence_number,
+            added_snapshot_id: snapshot_id,
+            added_files_count: Some(added),
+            existing_files_count: Some(existing),
+            deleted_files_count: Some(deleted),
+            added_rows_count: Some(added as u64 * 100),
+            existing_rows_count: Some(existing as u64 * 100),
+            deleted_rows_count: Some(deleted as u64 * 100),
+            partitions: None,
+            key_metadata: None,
+            first_row_id: None,
+        }
+    }
+
+    #[test]
+    fn test_new_manifest_filter_manager() {
+        let (manager, _temp_dir) = setup_test_manager();
+
+        // Test initial state
+        assert!(!manager.contains_deletes());
+        assert_eq!(manager.min_sequence_number, 0);
+        assert!(!manager.fail_any_delete);
+        assert!(!manager.fail_missing_delete_paths);
+        assert!(manager.files_to_delete.is_empty());
+    }
+
+    #[test]
+    fn test_configuration_flags() {
+        let (manager, _temp_dir) = setup_test_manager();
+
+        let mut configured_manager = manager.fail_any_delete().fail_missing_delete_paths();
+        configured_manager.drop_delete_files_older_than(100);
+
+        assert!(configured_manager.fail_any_delete);
+        assert!(configured_manager.fail_missing_delete_paths);
+        assert_eq!(configured_manager.min_sequence_number, 100);
+    }
+
+    #[test]
+    fn test_delete_file() {
+        let (mut manager, _temp_dir) = setup_test_manager();
+
+        // Test 1: Delete file by path
+        let file_path = "/test/path/file.parquet";
+        let test_file1 = create_test_data_file(file_path, 0);
+        let identity1 = data_file_identity(&test_file1);
+
+        // Initially no deletes
+        assert!(!manager.contains_deletes());
+
+        // Add file to delete
+        manager.delete_file(test_file1).unwrap();
+
+        // Should now contain deletes
+        assert!(manager.contains_deletes());
+        assert!(manager.files_to_delete.contains_key(&identity1));
+
+        // Test 2: Delete another file and verify tracking
+        let test_file2 = create_test_data_file("/test/data/file2.parquet", 0);
+        let identity2 = data_file_identity(&test_file2);
+        manager.delete_file(test_file2).unwrap();
+
+        // Should track both files for deletion
+        let deleted_files = manager.files_to_be_deleted();
+        assert_eq!(deleted_files.len(), 2);
+        assert!(manager.files_to_delete.contains_key(&identity2));
+    }
+
+    #[test]
+    fn test_manifest_has_no_live_files() {
+        // Test manifest with no live files
+        let manifest_no_live =
+            create_manifest_with_counts("/test/manifest1.avro", ManifestContentType::Data, 0, 0, 5);
+        assert!(ManifestFilterManager::manifest_has_no_live_files(
+            &manifest_no_live
+        ));
+
+        // Test manifest with live files
+        let manifest_with_live =
+            create_test_manifest_file("/test/manifest2.avro", ManifestContentType::Data);
+        assert!(!ManifestFilterManager::manifest_has_no_live_files(
+            &manifest_with_live
+        ));
+    }
+
+    #[test]
+    fn test_can_contain_deleted_files() {
+        let (mut manager, _temp_dir) = setup_test_manager();
+
+        // Manifest with no live files should not contain deleted files
+        let manifest_no_live =
+            create_manifest_with_counts("/test/manifest1.avro", ManifestContentType::Data, 0, 0, 5);
+        assert!(!manager.can_contain_deleted_files(&manifest_no_live));
+
+        // Manifest with live files but no deletes
+        let manifest_with_live =
+            create_test_manifest_file("/test/manifest2.avro", ManifestContentType::Data);
+        assert!(!manager.can_contain_deleted_files(&manifest_with_live));
+
+        // Add deletes and test again
+        let test_file = create_test_data_file("/test/file.parquet", 0);
+        manager.delete_file(test_file).unwrap();
+        assert!(manager.can_contain_deleted_files(&manifest_with_live));
+    }
+
+    #[tokio::test]
+    async fn test_filter_manifests_empty_input() {
+        let (mut manager, _temp_dir) = setup_test_manager();
+        let schema = create_test_schema();
+
+        let result = manager.filter_manifests(&schema, vec![]).await.unwrap();
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_validate_required_deletes_success() {
+        let (manager, _temp_dir) = setup_test_manager();
+
+        // Test validation with no required deletes
+        let manifests = vec![create_test_manifest_file(
+            "/test/manifest.avro",
+            ManifestContentType::Data,
+        )];
+        let result = manager.validate_required_deletes(&manifests);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_validate_required_deletes_failure() {
+        let (mut manager, _temp_dir) = setup_test_manager();
+
+        // Enable fail_missing_delete_paths
+        manager.fail_missing_delete_paths = true;
+
+        // Add a required delete file that won't be found
+        let missing_file = create_test_data_file("/missing/file.parquet", 0);
+        manager.delete_file(missing_file).unwrap();
+
+        let manifests = vec![create_test_manifest_file(
+            "/test/manifest.avro",
+            ManifestContentType::Data,
+        )];
+        let result = manager.validate_required_deletes(&manifests);
+
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("Required delete file missing")
+        );
+    }
+
+    #[tokio::test]
+    async fn test_comprehensive_deletion_logic() {
+        let (mut manager, temp_dir) = setup_test_manager();
+        let schema = create_test_schema();
+
+        // Create test data files
+        let keep_file = create_test_data_file("/test/keep_me.parquet", 0);
+        let delete_file = create_test_data_file("/test/delete_me.parquet", 0);
+        manager.delete_file(delete_file.clone()).unwrap();
+
+        // Write manifest with both files
+        let manifest_path = temp_dir.path().join("test_manifest.avro");
+        let manifest_path_str = manifest_path.to_str().unwrap();
+        let entries = create_entries_from_files(vec![keep_file.clone(), delete_file.clone()]);
+        write_manifest_with_entries(&manager, manifest_path_str, &schema, entries, 12345)
+            .await
+            .unwrap();
+
+        // Create ManifestFile metadata
+        let manifest = create_manifest_metadata(
+            manifest_path_str,
+            ManifestContentType::Data,
+            10,
+            12345,
+            (2, 0, 0),
+        );
+
+        // Verify manifest filtering capabilities
+        assert!(manager.can_contain_deleted_files(&manifest));
+        assert!(manager.manifest_has_deleted_files(&manifest).await.unwrap());
+        assert!(
+            manager
+                .files_to_delete
+                .contains_key(&data_file_identity(&delete_file))
+        );
+        assert!(
+            !manager
+                .files_to_delete
+                .contains_key(&data_file_identity(&keep_file))
+        );
+
+        // Verify manager state
+        assert!(manager.contains_deletes());
+        let files_to_delete = manager.files_to_be_deleted();
+        assert_eq!(files_to_delete.len(), 1);
+        assert_eq!(files_to_delete[0].file_path, delete_file.file_path);
+    }
+
+    #[test]
+    fn test_min_sequence_number_logic() {
+        let (mut manager, _temp_dir) = setup_test_manager();
+        manager.min_sequence_number = 5;
+
+        // Test basic sequence number comparison logic
+        assert_eq!(manager.min_sequence_number, 5);
+        let (old_sequence, new_sequence) = (3, 10);
+        assert!(old_sequence < manager.min_sequence_number);
+        assert!(new_sequence >= manager.min_sequence_number);
+
+        // Create manifests with different sequence numbers
+        let old_manifest = create_manifest_with_sequence(
+            "/test/old.avro",
+            ManifestContentType::Data,
+            old_sequence,
+            old_sequence,
+        );
+        let new_manifest = create_manifest_with_sequence(
+            "/test/new.avro",
+            ManifestContentType::Data,
+            new_sequence,
+            new_sequence,
+        );
+
+        // Add files to delete for testing
+        manager
+            .delete_file(create_test_data_file("/test/file.parquet", 0))
+            .unwrap();
+
+        // Both manifests should be able to contain deleted files (key filtering behavior)
+        assert!(manager.can_contain_deleted_files(&old_manifest));
+        assert!(manager.can_contain_deleted_files(&new_manifest));
+
+        // Verify sequence number properties
+        assert!(old_manifest.min_sequence_number < manager.min_sequence_number);
+        assert!(new_manifest.min_sequence_number >= manager.min_sequence_number);
+    }
+
+    #[tokio::test]
+    async fn test_filter_manifests_drops_old_delete_without_path_filter() {
+        let (mut manager, temp_dir) = setup_test_manager();
+        let schema = create_test_schema();
+        let delete_file =
+            create_test_deletion_vector("/test/old-delete.puffin", "/test/data.parquet");
+        let manifest_path = temp_dir
+            .path()
+            .join("old-delete-manifest.avro")
+            .to_string_lossy()
+            .to_string();
+
+        write_delete_manifest_with_entries(
+            &manager,
+            &manifest_path,
+            &schema,
+            create_entries_from_files(vec![delete_file]),
+            12345,
+        )
+        .await
+        .unwrap();
+
+        let input_manifest = create_manifest_metadata(
+            &manifest_path,
+            ManifestContentType::Deletes,
+            1,
+            12345,
+            (1, 0, 0),
+        );
+        manager.drop_delete_files_older_than(2);
+
+        let filtered = manager
+            .filter_manifests(&schema, vec![input_manifest.clone()])
+            .await
+            .unwrap();
+
+        assert_ne!(filtered[0].manifest_path, input_manifest.manifest_path);
+        let manifest = filtered[0].load_manifest(&manager.file_io).await.unwrap();
+        assert_eq!(manifest.entries()[0].status(), ManifestStatus::Deleted);
+    }
+
+    #[test]
+    fn test_deletion_tracking_and_validation() {
+        let (mut manager, _temp_dir) = setup_test_manager();
+
+        let delete_file = create_test_data_file("/test/delete_me.parquet", 0);
+
+        // Initially no deletes
+        assert!(!manager.contains_deletes());
+        assert_eq!(manager.files_to_be_deleted().len(), 0);
+
+        // Add the file to be deleted
+        manager.delete_file(delete_file.clone()).unwrap();
+
+        // Verify deletion tracking
+        assert!(manager.contains_deletes());
+        assert_eq!(manager.files_to_be_deleted().len(), 1);
+        assert_eq!(
+            manager.files_to_be_deleted()[0].file_path,
+            delete_file.file_path
+        );
+
+        // Create a manifest that could contain deleted files
+        let manifest = create_manifest_with_sequence(
+            "/test/test_manifest.avro",
+            ManifestContentType::Data,
+            10,
+            1,
+        );
+
+        // Verify manifest can contain deleted files
+        assert!(manager.can_contain_deleted_files(&manifest));
+        assert!(
+            manager
+                .files_to_delete
+                .contains_key(&data_file_identity(&delete_file))
+        );
+
+        // Validation should pass when no required deletes are set
+        assert!(manager.validate_required_deletes(&[manifest]).is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_filter_manifests_with_entries_and_rewrite() {
+        let (mut manager, temp_dir) = setup_test_manager();
+        let schema = create_test_schema();
+
+        // Create test files
+        let files_to_keep = [
+            create_test_data_file("/test/keep1.parquet", 0),
+            create_test_data_file("/test/keep2.parquet", 0),
+        ];
+        let files_to_delete = vec![
+            create_test_data_file("/test/delete1.parquet", 0),
+            create_test_data_file("/test/delete2.parquet", 0),
+        ];
+
+        // Mark files for deletion
+        for file in &files_to_delete {
+            manager.delete_file(file.clone()).unwrap();
+        }
+
+        // Create two manifests with mixed files
+        let manifest_paths: Vec<_> = (1..=2)
+            .map(|i| {
+                temp_dir
+                    .path()
+                    .join(format!("manifest{i}.avro"))
+                    .to_string_lossy()
+                    .to_string()
+            })
+            .collect();
+
+        for (idx, path) in manifest_paths.iter().enumerate() {
+            let entries = create_entries_from_files(vec![
+                files_to_keep[idx].clone(),
+                files_to_delete[idx].clone(),
+            ]);
+            write_manifest_with_entries(&manager, path, &schema, entries, 12345 + idx as i64)
+                .await
+                .unwrap();
+        }
+
+        // Create ManifestFile metadata objects
+        let input_manifests: Vec<_> = manifest_paths
+            .iter()
+            .enumerate()
+            .map(|(idx, path)| {
+                create_manifest_metadata(
+                    path,
+                    ManifestContentType::Data,
+                    10,
+                    12345 + idx as i64,
+                    (2, 0, 0),
+                )
+            })
+            .collect();
+
+        // Filter manifests
+        let filtered_manifests = manager
+            .filter_manifests(&schema, input_manifests.clone())
+            .await
+            .unwrap();
+
+        // Verify results
+        assert_eq!(filtered_manifests.len(), 2);
+        assert_ne!(
+            filtered_manifests[0].manifest_path,
+            input_manifests[0].manifest_path
+        );
+        assert_ne!(
+            filtered_manifests[1].manifest_path,
+            input_manifests[1].manifest_path
+        );
+
+        // Verify deletion tracking
+        assert_eq!(manager.files_to_be_deleted().len(), 2);
+        let deleted_paths: HashSet<_> = manager
+            .files_to_be_deleted()
+            .into_iter()
+            .map(|f| f.file_path.clone())
+            .collect();
+        for file in &files_to_delete {
+            assert!(deleted_paths.contains(&file.file_path));
+        }
+
+        // Verify filtered manifest entries
+        let filtered_manifest1 = filtered_manifests[0]
+            .load_manifest(&manager.file_io)
+            .await
+            .unwrap();
+        let (entries_filtered, _) = filtered_manifest1.into_parts();
+
+        let (live_count, deleted_count) =
+            entries_filtered
+                .iter()
+                .fold((0, 0), |(live, deleted), entry| match entry.status() {
+                    ManifestStatus::Added | ManifestStatus::Existing => (live + 1, deleted),
+                    ManifestStatus::Deleted => (live, deleted + 1),
+                });
+
+        assert_eq!(live_count, 1);
+        assert_eq!(deleted_count, 1);
+
+        // Verify cache and tracking
+        assert!(
+            manager
+                .filtered_manifests
+                .contains_key(&input_manifests[0].manifest_path)
+        );
+        assert!(
+            manager
+                .filtered_manifest_to_deleted_files
+                .contains_key(&filtered_manifests[0].manifest_path)
+        );
+    }
+
+    #[test]
+    fn test_unassigned_sequence_number_handling() {
+        let (mut manager, _temp_dir) = setup_test_manager();
+        manager.drop_delete_files_older_than(100);
+
+        // Create manifest with UNASSIGNED_SEQUENCE_NUMBER and no live files
+        let manifest_unassigned = create_manifest_with_sequence(
+            "/test/unassigned.avro",
+            ManifestContentType::Deletes,
+            crate::spec::UNASSIGNED_SEQUENCE_NUMBER,
+            crate::spec::UNASSIGNED_SEQUENCE_NUMBER,
+        );
+
+        // Manifest with no live files should not contain deleted files
+        assert!(!manager.can_contain_deleted_files(&manifest_unassigned));
+    }
+
+    #[tokio::test]
+    async fn test_cache_behavior() {
+        let (mut manager, temp_dir) = setup_test_manager();
+        let schema = create_test_schema();
+
+        // Create and write a manifest without deleted files
+        let manifest_path = temp_dir.path().join("cache_test.avro");
+        let manifest_path_str = manifest_path.to_str().unwrap();
+
+        let entries =
+            create_entries_from_files(vec![create_test_data_file("/test/keep.parquet", 0)]);
+        write_manifest_with_entries(&manager, manifest_path_str, &schema, entries, 12345)
+            .await
+            .unwrap();
+
+        let manifest = create_manifest_metadata(
+            manifest_path_str,
+            ManifestContentType::Data,
+            10,
+            12345,
+            (1, 0, 0),
+        );
+
+        // First and second calls should return the same cached result
+        let result1 = manager
+            .filter_manifest(&schema, manifest.clone())
+            .await
+            .unwrap();
+        let result2 = manager
+            .filter_manifest(&schema, manifest.clone())
+            .await
+            .unwrap();
+
+        assert_eq!(result1.manifest_path, result2.manifest_path);
+        assert!(
+            manager
+                .filtered_manifests
+                .contains_key(&manifest.manifest_path)
+        );
+    }
+
+    #[test]
+    fn test_batch_delete_operations() {
+        let (mut manager, _temp_dir) = setup_test_manager();
+
+        assert!(!manager.contains_deletes());
+
+        // Add multiple files for deletion
+        for i in 1..=3 {
+            manager
+                .delete_file(create_test_data_file(&format!("/test/batch{i}.parquet"), 0))
+                .unwrap();
+        }
+
+        // Verify all files are tracked
+        assert!(manager.contains_deletes());
+        assert_eq!(manager.files_to_be_deleted().len(), 3);
+
+        let deleted_paths: HashSet<_> = manager
+            .files_to_be_deleted()
+            .iter()
+            .map(|f| f.file_path.as_str())
+            .collect();
+        assert!(deleted_paths.contains("/test/batch1.parquet"));
+        assert!(deleted_paths.contains("/test/batch2.parquet"));
+        assert!(deleted_paths.contains("/test/batch3.parquet"));
+    }
+
+    #[test]
+    fn test_edge_case_empty_partition_specs() {
+        let (mut manager, _temp_dir) = setup_test_manager();
+
+        // Create a data file with different partition spec
+        let file_with_different_spec = DataFile {
+            content: crate::spec::DataContentType::Data,
+            file_path: "/test/different_spec.parquet".to_string(),
+            file_format: crate::spec::DataFileFormat::Parquet,
+            partition: Struct::empty(),
+            partition_spec_id: 999, // Different spec ID
+            record_count: 100,
+            file_size_in_bytes: 1024,
+            column_sizes: HashMap::new(),
+            value_counts: HashMap::new(),
+            null_value_counts: HashMap::new(),
+            nan_value_counts: HashMap::new(),
+            lower_bounds: HashMap::new(),
+            upper_bounds: HashMap::new(),
+            key_metadata: None,
+            split_offsets: None,
+            equality_ids: None,
+            sort_order_id: None,
+            first_row_id: None,
+            referenced_data_file: None,
+            content_offset: None,
+            content_size_in_bytes: None,
+        };
+
+        // Should be able to add file with different partition spec
+        manager.delete_file(file_with_different_spec).unwrap();
+        assert!(manager.contains_deletes());
+        assert_eq!(manager.files_to_be_deleted().len(), 1);
+    }
+
+    #[test]
+    fn test_is_dangling_delete() {
+        let (mut manager, _temp_dir) = setup_test_manager();
+
+        let dv = create_test_deletion_vector("/test/deletes.puffin", "/test/data1.parquet");
+
+        // Nothing removed yet -> nothing can be dangling.
+        assert!(!manager.is_dangling_delete(&dv));
+
+        manager.remove_dangling_deletes_for(&HashSet::from(["/test/data1.parquet".to_string()]));
+
+        // The DV references a data file that is being removed -> dangling.
+        assert!(manager.is_dangling_delete(&dv));
+
+        // A DV for a data file that survives is NOT dangling.
+        let other_dv = create_test_deletion_vector("/test/deletes2.puffin", "/test/data2.parquet");
+        assert!(!manager.is_dangling_delete(&other_dv));
+
+        // A data file is never a dangling delete, even if it is itself being removed.
+        let data_file = create_test_data_file("/test/data1.parquet", 0);
+        assert!(!manager.is_dangling_delete(&data_file));
+
+        // A delete file without `referenced_data_file` (e.g. an equality delete, or a
+        // position delete spanning several data files) can still apply to surviving data
+        // files, so it must never be reported as dangling.
+        let mut unreferenced_delete = dv.clone();
+        unreferenced_delete.referenced_data_file = None;
+        assert!(!manager.is_dangling_delete(&unreferenced_delete));
+    }
+
+    #[tokio::test]
+    async fn test_filter_manifests_drops_dangling_deletion_vector() {
+        let (mut manager, temp_dir) = setup_test_manager();
+        let schema = create_test_schema();
+
+        // Two deletion vectors: one for a data file that this commit rewrites away, one for
+        // a data file that survives.
+        let dangling_dv =
+            create_test_deletion_vector("/test/dangling.puffin", "/test/rewritten.parquet");
+        let live_dv = create_test_deletion_vector("/test/live.puffin", "/test/surviving.parquet");
+
+        let manifest_path = temp_dir
+            .path()
+            .join("delete-manifest.avro")
+            .to_string_lossy()
+            .to_string();
+
+        write_delete_manifest_with_entries(
+            &manager,
+            &manifest_path,
+            &schema,
+            create_entries_from_files(vec![dangling_dv.clone(), live_dv.clone()]),
+            12345,
+        )
+        .await
+        .unwrap();
+
+        let input_manifest = create_manifest_metadata(
+            &manifest_path,
+            ManifestContentType::Deletes,
+            10,
+            12345,
+            (2, 0, 0),
+        );
+
+        // The rewrite removed `/test/rewritten.parquet`.
+        manager
+            .remove_dangling_deletes_for(&HashSet::from(["/test/rewritten.parquet".to_string()]));
+
+        let filtered = manager
+            .filter_manifests(&schema, vec![input_manifest.clone()])
+            .await
+            .unwrap();
+
+        assert_eq!(filtered.len(), 1);
+        assert_ne!(
+            filtered[0].manifest_path, input_manifest.manifest_path,
+            "manifest must be rewritten when it contains a dangling delete"
+        );
+
+        let filtered_manifest = filtered[0].load_manifest(&manager.file_io).await.unwrap();
+        let statuses: HashMap<&str, ManifestStatus> = filtered_manifest
+            .entries()
+            .iter()
+            .map(|entry| (entry.data_file().file_path(), entry.status()))
+            .collect();
+
+        assert_eq!(
+            statuses.get("/test/dangling.puffin"),
+            Some(&ManifestStatus::Deleted),
+            "the deletion vector of a rewritten data file must be dropped"
+        );
+        assert_eq!(
+            statuses.get("/test/live.puffin"),
+            Some(&ManifestStatus::Existing),
+            "the deletion vector of a surviving data file must be kept"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_filter_manifests_keeps_deletion_vectors_when_nothing_removed() {
+        let (mut manager, temp_dir) = setup_test_manager();
+        let schema = create_test_schema();
+
+        let dv = create_test_deletion_vector("/test/live.puffin", "/test/surviving.parquet");
+
+        let manifest_path = temp_dir
+            .path()
+            .join("delete-manifest-untouched.avro")
+            .to_string_lossy()
+            .to_string();
+
+        write_delete_manifest_with_entries(
+            &manager,
+            &manifest_path,
+            &schema,
+            create_entries_from_files(vec![dv]),
+            12345,
+        )
+        .await
+        .unwrap();
+
+        let input_manifest = create_manifest_metadata(
+            &manifest_path,
+            ManifestContentType::Deletes,
+            10,
+            12345,
+            (1, 0, 0),
+        );
+
+        // No data files removed in this commit -> the delete manifest must be returned
+        // untouched (no rewrite, no new manifest file).
+        let filtered = manager
+            .filter_manifests(&schema, vec![input_manifest.clone()])
+            .await
+            .unwrap();
+
+        assert_eq!(filtered.len(), 1);
+        assert_eq!(
+            filtered[0].manifest_path, input_manifest.manifest_path,
+            "delete manifest must not be rewritten when no data files were removed"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_explicit_delete_only_removes_selected_puffin_blob() {
+        let (mut manager, temp_dir) = setup_test_manager();
+        let schema = create_test_schema();
+        let removed_blob =
+            create_test_deletion_vector_at("/test/shared.puffin", "/test/data-a.parquet", 4);
+        let retained_blob =
+            create_test_deletion_vector_at("/test/shared.puffin", "/test/data-b.parquet", 68);
+        let manifest_path = temp_dir
+            .path()
+            .join("explicit-shared-puffin-delete.avro")
+            .to_string_lossy()
+            .to_string();
+
+        write_delete_manifest_with_entries(
+            &manager,
+            &manifest_path,
+            &schema,
+            create_entries_from_files(vec![removed_blob.clone(), retained_blob]),
+            12345,
+        )
+        .await
+        .unwrap();
+        let input_manifest = create_manifest_metadata(
+            &manifest_path,
+            ManifestContentType::Deletes,
+            10,
+            12345,
+            (2, 0, 0),
+        );
+        manager.delete_file(removed_blob).unwrap();
+
+        let filtered = manager
+            .filter_manifests(&schema, vec![input_manifest])
+            .await
+            .unwrap();
+        let manifest = filtered[0].load_manifest(&manager.file_io).await.unwrap();
+        let statuses = manifest
+            .entries()
+            .iter()
+            .map(|entry| (entry.data_file().content_offset().unwrap(), entry.status()))
+            .collect::<HashMap<_, _>>();
+
+        assert_eq!(statuses.get(&4), Some(&ManifestStatus::Deleted));
+        assert_eq!(statuses.get(&68), Some(&ManifestStatus::Existing));
+    }
+
+    /// Regression test for the shared-Puffin hazard raised in review of #188.
+    ///
+    /// Several deletion vectors may live in ONE Puffin file, distinguished by
+    /// (`file_path`, `content_offset`, `content_size_in_bytes`). Danglingness is therefore a
+    /// per-blob property. An earlier version of this code promoted a dangling blob into the
+    /// old path-keyed `files_to_delete` set, which then matched every other entry with the
+    /// same Puffin path -- dropping the *live* deletion vectors of data files that were
+    /// never rewritten and silently resurrecting their deleted rows.
+    #[tokio::test]
+    async fn test_shared_puffin_keeps_live_deletion_vectors() {
+        let (mut manager, temp_dir) = setup_test_manager();
+        let schema = create_test_schema();
+
+        // One Puffin, two blobs: one for a data file this commit rewrites away, one for a
+        // data file that survives.
+        const PUFFIN: &str = "/test/shared.puffin";
+        let dangling_blob = create_test_deletion_vector_at(PUFFIN, "/test/rewritten.parquet", 4);
+        let live_blob = create_test_deletion_vector_at(PUFFIN, "/test/surviving.parquet", 128);
+
+        // A second manifest holds another live blob in the SAME Puffin, to prove the
+        // path-level set cannot leak across manifests either (the manager is reused for
+        // every manifest in `filter_manifests`).
+        let other_live_blob =
+            create_test_deletion_vector_at(PUFFIN, "/test/surviving-2.parquet", 256);
+
+        let manifest_a = temp_dir
+            .path()
+            .join("delete-manifest-a.avro")
+            .to_string_lossy()
+            .to_string();
+        let manifest_b = temp_dir
+            .path()
+            .join("delete-manifest-b.avro")
+            .to_string_lossy()
+            .to_string();
+
+        write_delete_manifest_with_entries(
+            &manager,
+            &manifest_a,
+            &schema,
+            create_entries_from_files(vec![dangling_blob, live_blob]),
+            12345,
+        )
+        .await
+        .unwrap();
+        write_delete_manifest_with_entries(
+            &manager,
+            &manifest_b,
+            &schema,
+            create_entries_from_files(vec![other_live_blob]),
+            12346,
+        )
+        .await
+        .unwrap();
+
+        let inputs = vec![
+            create_manifest_metadata(
+                &manifest_a,
+                ManifestContentType::Deletes,
+                10,
+                12345,
+                (2, 0, 0),
+            ),
+            create_manifest_metadata(
+                &manifest_b,
+                ManifestContentType::Deletes,
+                10,
+                12346,
+                (1, 0, 0),
+            ),
+        ];
+
+        manager
+            .remove_dangling_deletes_for(&HashSet::from(["/test/rewritten.parquet".to_string()]));
+
+        let filtered = manager.filter_manifests(&schema, inputs).await.unwrap();
+        assert_eq!(filtered.len(), 2);
+
+        // Manifest A: only the blob whose data file is gone may be dropped. Both entries
+        // share a path, so identify them by their blob offset.
+        let manifest_a_out = filtered[0].load_manifest(&manager.file_io).await.unwrap();
+        let statuses: HashMap<(Option<i64>, Option<String>), ManifestStatus> = manifest_a_out
+            .entries()
+            .iter()
+            .map(|entry| {
+                (
+                    (
+                        entry.data_file().content_offset(),
+                        entry.data_file().referenced_data_file(),
+                    ),
+                    entry.status(),
+                )
+            })
+            .collect();
+
+        assert_eq!(
+            statuses.get(&(Some(4), Some("/test/rewritten.parquet".to_string()))),
+            Some(&ManifestStatus::Deleted),
+            "the blob for the rewritten data file must be dropped"
+        );
+        assert_eq!(
+            statuses.get(&(Some(128), Some("/test/surviving.parquet".to_string()))),
+            Some(&ManifestStatus::Existing),
+            "a live blob sharing the Puffin must survive -- dropping it would resurrect \
+             deleted rows for a data file that was never rewritten"
+        );
+
+        // Manifest B must be untouched: the path-level set must not have been contaminated.
+        assert_eq!(
+            filtered[1].manifest_path, manifest_b,
+            "a manifest holding only live blobs of the shared Puffin must not be rewritten"
+        );
+
+        // And the Puffin itself must never be queued for deletion while blobs still live.
+        assert!(
+            !manager
+                .files_to_be_deleted()
+                .iter()
+                .any(|f| f.file_path() == PUFFIN),
+            "a partially-dangling Puffin must not be promoted to a path-level delete"
+        );
+    }
+}

--- a/crates/iceberg/src/transaction/mod.rs
+++ b/crates/iceberg/src/transaction/mod.rs
@@ -55,6 +55,8 @@ mod action;
 pub use action::*;
 mod append;
 mod expire_snapshots;
+mod manifest_filter;
+mod replace_files;
 mod snapshot;
 mod sort_order;
 mod update_location;
@@ -66,14 +68,16 @@ mod upgrade_format_version;
 use std::sync::Arc;
 use std::time::Duration;
 
+pub use append::FastAppendAction;
 use backon::{BackoffBuilder, ExponentialBackoff, ExponentialBuilder, RetryableWithContext};
+pub use manifest_filter::{ManifestFilterManager, ManifestWriterContext};
+pub use replace_files::{OverwriteFilesAction, RewriteFilesAction};
 pub use update_schema::AddColumn;
 
 use crate::error::Result;
 use crate::spec::TableProperties;
 use crate::table::Table;
 use crate::transaction::action::BoxedTransactionAction;
-use crate::transaction::append::FastAppendAction;
 use crate::transaction::expire_snapshots::ExpireSnapshotsAction;
 use crate::transaction::sort_order::ReplaceSortOrderAction;
 use crate::transaction::update_location::UpdateLocationAction;
@@ -149,6 +153,16 @@ impl Transaction {
     /// Creates a fast append action.
     pub fn fast_append(&self) -> FastAppendAction {
         FastAppendAction::new()
+    }
+
+    /// Creates an action that rewrites files without changing table data.
+    pub fn rewrite_files(&self) -> RewriteFilesAction {
+        RewriteFilesAction::new()
+    }
+
+    /// Creates an action that replaces files as a logical overwrite.
+    pub fn overwrite_files(&self) -> OverwriteFilesAction {
+        OverwriteFilesAction::new()
     }
 
     /// Creates replace sort order action.
@@ -264,12 +278,126 @@ mod tests {
     use crate::io::FileIO;
     use crate::memory::tests::new_memory_catalog;
     use crate::spec::{
-        DataContentType, DataFileBuilder, DataFileFormat, Literal, Struct, TableMetadata,
+        DataContentType, DataFile, DataFileBuilder, DataFileFormat, Literal, MAIN_BRANCH,
+        ManifestListWriter, ManifestWriterBuilder, Operation, Snapshot, SnapshotReference,
+        SnapshotRetention, Struct, Summary, TableMetadata,
     };
     use crate::table::Table;
     use crate::test_utils::test_runtime;
     use crate::transaction::{ApplyTransactionAction, Transaction};
     use crate::{Catalog, Error, ErrorKind, TableCreation, TableIdent};
+
+    pub const PARENT_SNAPSHOT_ID: i64 = 42;
+    pub const PARENT_SEQUENCE_NUMBER: i64 = 1;
+    pub const REMOVED_DELETE_FILE: &str = "test/removed-position-delete.parquet";
+    pub const RETAINED_DELETE_FILE: &str = "test/retained-position-delete.parquet";
+
+    const TABLE_LOCATION: &str = "memory:///test/location";
+    const MANIFEST_LIST_LOCATION: &str = "memory:///test/location/metadata/manifest-list-1.avro";
+    const DELETE_MANIFEST_LOCATION: &str =
+        "memory:///test/location/metadata/delete-manifest-1.avro";
+
+    pub fn position_delete_file(table: &Table, path: &str) -> DataFile {
+        DataFileBuilder::default()
+            .partition_spec_id(table.metadata().default_partition_spec_id())
+            .content(DataContentType::PositionDeletes)
+            .file_path(path.to_string())
+            .file_format(DataFileFormat::Parquet)
+            .file_size_in_bytes(100)
+            .record_count(1)
+            .partition(Struct::from_iter([Some(Literal::long(300))]))
+            .build()
+            .unwrap()
+    }
+
+    pub async fn make_v2_table_with_delete_manifest() -> Table {
+        let base = make_v2_minimal_table();
+        let metadata = base
+            .metadata()
+            .clone()
+            .into_builder(Some("s3://bucket/test/location/metadata/v1.json".into()))
+            .set_location(TABLE_LOCATION.to_string())
+            .build()
+            .unwrap()
+            .metadata;
+        let base = base.with_metadata(Arc::new(metadata));
+        let file_io = base.file_io().clone();
+
+        let mut manifest_writer = ManifestWriterBuilder::new(
+            file_io.new_output(DELETE_MANIFEST_LOCATION).unwrap(),
+            Some(PARENT_SNAPSHOT_ID),
+            base.metadata().current_schema().clone(),
+            base.metadata().default_partition_spec().as_ref().clone(),
+        )
+        .build_v2_deletes();
+
+        for path in [REMOVED_DELETE_FILE, RETAINED_DELETE_FILE] {
+            manifest_writer
+                .add_existing_file(
+                    position_delete_file(&base, path),
+                    PARENT_SNAPSHOT_ID,
+                    PARENT_SEQUENCE_NUMBER,
+                    Some(PARENT_SEQUENCE_NUMBER),
+                )
+                .unwrap();
+        }
+        let delete_manifest = manifest_writer.write_manifest_file().await.unwrap();
+
+        let manifest_list_output = file_io
+            .new_output(MANIFEST_LIST_LOCATION)
+            .unwrap()
+            .writer()
+            .await
+            .unwrap();
+        let mut manifest_list_writer = ManifestListWriter::v2(
+            manifest_list_output,
+            PARENT_SNAPSHOT_ID,
+            None,
+            PARENT_SEQUENCE_NUMBER,
+        );
+        manifest_list_writer
+            .add_manifests(vec![delete_manifest].into_iter())
+            .unwrap();
+        manifest_list_writer.close().await.unwrap();
+
+        let parent_snapshot = Snapshot::builder()
+            .with_snapshot_id(PARENT_SNAPSHOT_ID)
+            .with_timestamp_ms(base.metadata().last_updated_ms() + 1)
+            .with_sequence_number(PARENT_SEQUENCE_NUMBER)
+            .with_schema_id(0)
+            .with_manifest_list(MANIFEST_LIST_LOCATION)
+            .with_summary(Summary {
+                operation: Operation::Overwrite,
+                additional_properties: [
+                    ("total-delete-files".to_string(), "2".to_string()),
+                    ("total-position-deletes".to_string(), "2".to_string()),
+                    ("total-files-size".to_string(), "200".to_string()),
+                ]
+                .into_iter()
+                .collect(),
+            })
+            .build();
+
+        let metadata = base
+            .metadata()
+            .clone()
+            .into_builder(Some("s3://bucket/test/location/metadata/v1.json".into()))
+            .add_snapshot(parent_snapshot)
+            .unwrap()
+            .set_ref(
+                MAIN_BRANCH,
+                SnapshotReference::new(
+                    PARENT_SNAPSHOT_ID,
+                    SnapshotRetention::branch(None, None, None),
+                ),
+            )
+            .unwrap()
+            .build()
+            .unwrap()
+            .metadata;
+
+        base.with_metadata(Arc::new(metadata))
+    }
 
     pub fn make_v1_table() -> Table {
         let file = File::open(format!(
@@ -324,6 +452,26 @@ mod tests {
         Table::builder()
             .metadata(resp)
             .metadata_location("s3://bucket/test/location/metadata/v1.json")
+            .identifier(TableIdent::from_strs(["ns1", "test1"]).unwrap())
+            .file_io(FileIO::new_with_memory())
+            .runtime(test_runtime())
+            .build()
+            .unwrap()
+    }
+
+    pub fn make_v3_minimal_table() -> Table {
+        let file = File::open(format!(
+            "{}/testdata/table_metadata/{}",
+            env!("CARGO_MANIFEST_DIR"),
+            "TableMetadataV3ValidMinimal.json"
+        ))
+        .unwrap();
+        let reader = BufReader::new(file);
+        let metadata = serde_json::from_reader::<_, TableMetadata>(reader).unwrap();
+
+        Table::builder()
+            .metadata(metadata)
+            .metadata_location("memory:///test/location/metadata/v1.json")
             .identifier(TableIdent::from_strs(["ns1", "test1"]).unwrap())
             .file_io(FileIO::new_with_memory())
             .runtime(test_runtime())

--- a/crates/iceberg/src/transaction/replace_files.rs
+++ b/crates/iceberg/src/transaction/replace_files.rs
@@ -1,0 +1,1316 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::collections::{HashMap, HashSet};
+use std::marker::PhantomData;
+use std::sync::Arc;
+
+use uuid::Uuid;
+
+use super::snapshot::{DefaultManifestProcess, SnapshotProducer, data_file_identity};
+use crate::error::Result;
+use crate::spec::{
+    DataContentType, DataFile, ManifestEntry, ManifestFile, ManifestStatus, Operation,
+};
+use crate::table::Table;
+use crate::transaction::snapshot::SnapshotProduceOperation;
+use crate::transaction::{ActionCommit, TransactionAction};
+
+/// Which snapshot [`Operation`] a file replacement records.
+///
+/// `rewrite_files` and `overwrite_files` differ only in this value
+pub(crate) trait ReplaceFilesMode: Send + Sync + 'static {
+    const OPERATION: Operation;
+}
+
+/// Files were added and removed without changing table data (compaction,
+/// changing file format, relocating files).
+pub struct Rewrite;
+
+/// Files were added and removed in a logical overwrite.
+pub struct Overwrite;
+
+impl ReplaceFilesMode for Rewrite {
+    const OPERATION: Operation = Operation::Replace;
+}
+
+impl ReplaceFilesMode for Overwrite {
+    const OPERATION: Operation = Operation::Overwrite;
+}
+
+/// A blanket `impl<M: ReplaceFilesMode> SnapshotProduceOperation for M` would
+/// collide with `impl SnapshotProduceOperation for FastAppendOperation`: the
+/// compiler cannot prove `FastAppendOperation` will never implement
+/// `ReplaceFilesMode`. This wrapper carries the shared implementation instead.
+pub(crate) struct ReplaceFilesOperation<M: ReplaceFilesMode>(PhantomData<M>);
+
+impl<M: ReplaceFilesMode> ReplaceFilesOperation<M> {
+    pub(crate) fn new() -> Self {
+        Self(PhantomData)
+    }
+}
+
+impl<M: ReplaceFilesMode> SnapshotProduceOperation for ReplaceFilesOperation<M> {
+    fn operation(&self) -> Operation {
+        M::OPERATION
+    }
+
+    async fn delete_entries(
+        &self,
+        snapshot_produce: &SnapshotProducer<'_>,
+    ) -> Result<Vec<ManifestEntry>> {
+        if snapshot_produce.removed_data_file_identities.is_empty()
+            && snapshot_produce.removed_delete_file_identities.is_empty()
+        {
+            return Ok(vec![]);
+        }
+
+        // generate delete manifest entries from removed files
+        let snapshot = snapshot_produce
+            .table
+            .metadata()
+            .snapshot_for_ref(snapshot_produce.target_branch());
+
+        if let Some(snapshot) = snapshot {
+            let gen_manifest_entry = |old_entry: &Arc<ManifestEntry>| {
+                let mut entry = old_entry.as_ref().clone();
+                entry.status = ManifestStatus::Deleted;
+                entry
+            };
+
+            let manifest_list = snapshot_produce
+                .table
+                .manifest_list_reader(snapshot)
+                .load()
+                .await?;
+
+            let mut deleted_entries = Vec::new();
+
+            for manifest_file in manifest_list.entries() {
+                let manifest = manifest_file
+                    .load_manifest(snapshot_produce.table.file_io())
+                    .await?;
+
+                for entry in manifest.entries() {
+                    if entry.is_alive()
+                        && entry.content_type() == DataContentType::Data
+                        && snapshot_produce
+                            .removed_data_file_identities
+                            .contains(&data_file_identity(entry.data_file()))
+                    {
+                        deleted_entries.push(gen_manifest_entry(entry));
+                    }
+
+                    if entry.is_alive()
+                        && (entry.content_type() == DataContentType::PositionDeletes
+                            || entry.content_type() == DataContentType::EqualityDeletes)
+                        && snapshot_produce
+                            .removed_delete_file_identities
+                            .contains(&data_file_identity(entry.data_file()))
+                    {
+                        deleted_entries.push(gen_manifest_entry(entry));
+                    }
+                }
+            }
+
+            Ok(deleted_entries)
+        } else {
+            Ok(vec![])
+        }
+    }
+
+    async fn existing_manifest(
+        &self,
+        snapshot_produce: &mut SnapshotProducer<'_>,
+    ) -> Result<Vec<ManifestFile>> {
+        let Some(snapshot) = snapshot_produce
+            .table
+            .metadata()
+            .snapshot_for_ref(snapshot_produce.target_branch())
+        else {
+            return Ok(vec![]);
+        };
+
+        let manifest_list = snapshot_produce
+            .table
+            .manifest_list_reader(snapshot)
+            .load()
+            .await?;
+
+        if snapshot_produce.removed_data_file_identities.is_empty()
+            && snapshot_produce.removed_delete_file_identities.is_empty()
+        {
+            return Ok(manifest_list.entries().to_vec());
+        }
+
+        let mut existing_files = Vec::new();
+
+        for manifest_file in manifest_list.entries() {
+            let manifest = manifest_file
+                .load_manifest(snapshot_produce.table.file_io())
+                .await?;
+
+            let found_deleted_files: HashSet<_> = manifest
+                .entries()
+                .iter()
+                .filter_map(|entry| {
+                    let identity = data_file_identity(entry.data_file());
+                    if entry.is_alive()
+                        && (snapshot_produce
+                            .removed_data_file_identities
+                            .contains(&identity)
+                            || snapshot_produce
+                                .removed_delete_file_identities
+                                .contains(&identity))
+                    {
+                        Some(identity)
+                    } else {
+                        None
+                    }
+                })
+                .collect();
+
+            if found_deleted_files.is_empty() {
+                existing_files.push(manifest_file.clone());
+            } else {
+                // Rewrite the manifest file without the deleted data files
+                let survives = |entry: &ManifestEntry| {
+                    entry.is_alive()
+                        && !found_deleted_files.contains(&data_file_identity(entry.data_file()))
+                };
+
+                if manifest.entries().iter().any(|entry| survives(entry)) {
+                    let mut manifest_writer = snapshot_produce.new_manifest_writer(
+                        manifest_file.content,
+                        manifest_file.partition_spec_id,
+                    )?;
+
+                    for entry in manifest.entries() {
+                        // Carry survivors forward as `Existing`: `add_entry` would
+                        // restamp them as `Added` under the new snapshot and drop
+                        // their file sequence number.
+                        if survives(entry) {
+                            manifest_writer.add_existing_entry(entry.as_ref().clone())?;
+                        }
+                    }
+
+                    existing_files.push(manifest_writer.write_manifest_file().await?);
+                }
+            }
+        }
+
+        Ok(existing_files)
+    }
+}
+
+/// Transaction action that replaces one set of files with another.
+///
+/// `M` is sealed to [`Rewrite`] and [`Overwrite`] via the [`RewriteFilesAction`] /
+/// [`OverwriteFilesAction`] type aliases below; `ReplaceFilesMode` itself stays
+/// `pub(crate)` so no other type can be substituted for `M`.
+#[allow(private_bounds)]
+pub struct ReplaceFilesAction<M: ReplaceFilesMode> {
+    // below are properties used to create SnapshotProducer when commit
+    commit_uuid: Option<Uuid>,
+    snapshot_properties: HashMap<String, String>,
+    added_data_files: Vec<DataFile>,
+    added_delete_files: Vec<DataFile>,
+    removed_data_files: Vec<DataFile>,
+    removed_delete_files: Vec<DataFile>,
+    snapshot_id: Option<i64>,
+    new_data_file_sequence_number: Option<i64>,
+    target_branch: Option<String>,
+    enable_delete_filter_manager: bool,
+    check_file_existence: bool,
+
+    _mode: PhantomData<M>,
+}
+
+/// Rewrites files without changing table data — compaction and friends.
+pub type RewriteFilesAction = ReplaceFilesAction<Rewrite>;
+
+/// Rewrites files as a logical overwrite.
+pub type OverwriteFilesAction = ReplaceFilesAction<Overwrite>;
+
+#[allow(private_bounds)]
+impl<M: ReplaceFilesMode> ReplaceFilesAction<M> {
+    pub fn new() -> Self {
+        Self {
+            commit_uuid: None,
+            snapshot_properties: HashMap::new(),
+            added_data_files: Vec::new(),
+            added_delete_files: Vec::new(),
+            removed_data_files: Vec::new(),
+            removed_delete_files: Vec::new(),
+            snapshot_id: None,
+            new_data_file_sequence_number: None,
+            target_branch: None,
+            enable_delete_filter_manager: true,
+            check_file_existence: false,
+            _mode: PhantomData,
+        }
+    }
+
+    /// Add data files to the snapshot.
+    pub fn add_data_files(mut self, data_files: impl IntoIterator<Item = DataFile>) -> Self {
+        for file in data_files {
+            match file.content_type() {
+                DataContentType::Data => self.added_data_files.push(file),
+                DataContentType::PositionDeletes | DataContentType::EqualityDeletes => {
+                    self.added_delete_files.push(file)
+                }
+            }
+        }
+
+        self
+    }
+
+    /// Add remove files to the snapshot.
+    pub fn delete_files(mut self, remove_data_files: impl IntoIterator<Item = DataFile>) -> Self {
+        for file in remove_data_files {
+            match file.content_type() {
+                DataContentType::Data => self.removed_data_files.push(file),
+                DataContentType::PositionDeletes | DataContentType::EqualityDeletes => {
+                    self.removed_delete_files.push(file)
+                }
+            }
+        }
+
+        self
+    }
+
+    /// Set snapshot summary properties.
+    pub fn set_snapshot_properties(&mut self, properties: HashMap<String, String>) -> &mut Self {
+        self.snapshot_properties = properties;
+
+        self
+    }
+
+    /// Set commit UUID for the snapshot.
+    pub fn set_commit_uuid(&mut self, commit_uuid: Uuid) -> &mut Self {
+        self.commit_uuid = Some(commit_uuid);
+        self
+    }
+
+    /// Set snapshot id
+    pub fn set_snapshot_id(mut self, snapshot_id: i64) -> Self {
+        self.snapshot_id = Some(snapshot_id);
+        self
+    }
+
+    /// Enable or disable filtering obsolete delete entries for this snapshot.
+    ///
+    /// Filtering is enabled by default so replacing a data file also drops
+    /// deletion vectors that can no longer apply to any live file.
+    pub fn set_enable_delete_filter_manager(mut self, enable_delete_filter_manager: bool) -> Self {
+        self.enable_delete_filter_manager = enable_delete_filter_manager;
+        self
+    }
+
+    pub fn set_target_branch(mut self, target_branch: String) -> Self {
+        self.target_branch = Some(target_branch);
+        self
+    }
+
+    // If the compaction should use the sequence number of the snapshot at compaction start time for
+    // new data files, instead of using the sequence number of the newly produced snapshot.
+    // This avoids commit conflicts with updates that add newer equality deletes at a higher sequence number.
+    pub fn set_new_data_file_sequence_number(mut self, seq: i64) -> Self {
+        self.new_data_file_sequence_number = Some(seq);
+        self
+    }
+
+    pub fn set_check_file_existence(mut self, check: bool) -> Self {
+        self.check_file_existence = check;
+        self
+    }
+}
+
+#[async_trait::async_trait]
+impl<M: ReplaceFilesMode> TransactionAction for ReplaceFilesAction<M> {
+    async fn commit(self: Arc<Self>, table: &Table) -> Result<ActionCommit> {
+        if let Some(snapshot_id) = self.snapshot_id
+            && table.metadata().snapshot_by_id(snapshot_id).is_some()
+        {
+            return Err(crate::Error::new(
+                crate::ErrorKind::DataInvalid,
+                format!("Snapshot id {snapshot_id} already exists"),
+            ));
+        }
+
+        if let Some(sequence_number) = self.new_data_file_sequence_number {
+            let next_sequence_number = table.metadata().next_sequence_number();
+            if sequence_number < 0 || sequence_number > next_sequence_number {
+                return Err(crate::Error::new(
+                    crate::ErrorKind::DataInvalid,
+                    format!(
+                        "New data file sequence number {sequence_number} must be between 0 and \
+                         the new snapshot sequence number {next_sequence_number}"
+                    ),
+                ));
+            }
+        }
+
+        let mut snapshot_producer = SnapshotProducer::new(
+            table,
+            self.commit_uuid.unwrap_or_else(Uuid::now_v7),
+            self.snapshot_id,
+            self.snapshot_properties.clone(),
+            self.added_data_files.clone(),
+            self.added_delete_files.clone(),
+            self.removed_data_files.clone(),
+            self.removed_delete_files.clone(),
+        );
+
+        if let Some(seq) = self.new_data_file_sequence_number {
+            snapshot_producer.set_new_data_file_sequence_number(seq);
+        }
+
+        if let Some(branch) = &self.target_branch {
+            snapshot_producer.set_target_branch(branch.clone());
+        }
+
+        if self.enable_delete_filter_manager {
+            snapshot_producer.enable_delete_filter_manager()?;
+        }
+
+        snapshot_producer.validate_added_files(&self.added_data_files)?;
+        snapshot_producer.validate_added_files(&self.added_delete_files)?;
+
+        if self.check_file_existence {
+            snapshot_producer.validate_data_file_changes().await?;
+        }
+
+        snapshot_producer
+            .commit(ReplaceFilesOperation::<M>::new(), DefaultManifestProcess)
+            .await
+    }
+}
+
+impl<M: ReplaceFilesMode> Default for ReplaceFilesAction<M> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
+    use uuid::Uuid;
+
+    use super::{Overwrite, ReplaceFilesMode, ReplaceFilesOperation, Rewrite};
+    use crate::spec::{
+        DataContentType, DataFileBuilder, DataFileFormat, Literal, MAIN_BRANCH,
+        ManifestContentType, ManifestEntry, ManifestListWriter, ManifestStatus,
+        ManifestWriterBuilder, Operation, Snapshot, SnapshotRef, SnapshotReference,
+        SnapshotRetention, Struct, Summary, UnboundPartitionSpec,
+    };
+    use crate::transaction::snapshot::{SnapshotProduceOperation, SnapshotProducer};
+    use crate::transaction::tests::{
+        PARENT_SEQUENCE_NUMBER, PARENT_SNAPSHOT_ID, REMOVED_DELETE_FILE, RETAINED_DELETE_FILE,
+        make_encrypted_table, make_v2_minimal_table, make_v2_table_with_delete_manifest,
+        make_v3_minimal_table, position_delete_file,
+    };
+    use crate::transaction::{Transaction, TransactionAction};
+    use crate::{ErrorKind, TableRequirement, TableUpdate};
+
+    #[test]
+    fn test_modes_map_to_their_operations() {
+        assert_eq!(Rewrite::OPERATION, Operation::Replace);
+        assert_eq!(Overwrite::OPERATION, Operation::Overwrite);
+        assert_eq!(
+            ReplaceFilesOperation::<Rewrite>::new().operation(),
+            Operation::Replace
+        );
+        assert_eq!(
+            ReplaceFilesOperation::<Overwrite>::new().operation(),
+            Operation::Overwrite
+        );
+    }
+
+    /// Regression test: a rewrite/overwrite that removes one delete file must not
+    /// mark *unrelated* delete files as deleted.
+    ///
+    /// `delete_entries` once guarded the delete-file branch with
+    ///   `content == PositionDeletes || content == EqualityDeletes && removed.contains(path)`
+    /// and because `&&` binds tighter than `||`, every `PositionDeletes` entry in
+    /// the parent snapshot matched regardless of the requested delete-file identities.
+    async fn assert_only_removed_delete_files_marked<M: ReplaceFilesMode>() {
+        let table = make_v2_table_with_delete_manifest().await;
+        let removed = position_delete_file(&table, REMOVED_DELETE_FILE);
+
+        let producer = SnapshotProducer::new(
+            &table,
+            Uuid::now_v7(),
+            None,
+            HashMap::new(),
+            vec![],
+            vec![],
+            vec![],
+            vec![removed],
+        );
+
+        let deleted_entries = ReplaceFilesOperation::<M>::new()
+            .delete_entries(&producer)
+            .await
+            .unwrap();
+        let deleted_paths: Vec<&str> = deleted_entries
+            .iter()
+            .map(|entry| entry.data_file().file_path())
+            .collect();
+
+        assert_eq!(
+            deleted_paths,
+            vec![REMOVED_DELETE_FILE],
+            "only the removed delete file should be marked deleted; \
+             {RETAINED_DELETE_FILE} must stay live"
+        );
+    }
+
+    /// Regression test: rewriting a partially-deleted *delete* manifest must
+    /// preserve its `Deletes` content type, and must carry survivors forward as
+    /// `Existing` rather than restamping them as `Added`.
+    async fn assert_delete_manifest_carried_forward_intact<M: ReplaceFilesMode>() {
+        let table = make_v2_table_with_delete_manifest().await;
+        let removed = position_delete_file(&table, REMOVED_DELETE_FILE);
+
+        let mut producer = SnapshotProducer::new(
+            &table,
+            Uuid::now_v7(),
+            None,
+            HashMap::new(),
+            vec![],
+            vec![],
+            vec![],
+            vec![removed],
+        );
+
+        let existing = ReplaceFilesOperation::<M>::new()
+            .existing_manifest(&mut producer)
+            .await
+            .unwrap();
+
+        assert_eq!(existing.len(), 1, "the delete manifest should be rewritten");
+        assert_eq!(
+            existing[0].content,
+            ManifestContentType::Deletes,
+            "a rewritten delete manifest must stay a Deletes manifest"
+        );
+
+        let entries = existing[0].load_manifest(table.file_io()).await.unwrap();
+        let paths: Vec<&str> = entries
+            .entries()
+            .iter()
+            .map(|entry| entry.data_file().file_path())
+            .collect();
+        assert_eq!(paths, vec![RETAINED_DELETE_FILE]);
+
+        let retained = &entries.entries()[0];
+        assert_eq!(retained.status(), ManifestStatus::Existing);
+        assert_eq!(retained.snapshot_id(), Some(PARENT_SNAPSHOT_ID));
+        assert_eq!(retained.sequence_number(), Some(PARENT_SEQUENCE_NUMBER));
+        assert_eq!(retained.file_sequence_number, Some(PARENT_SEQUENCE_NUMBER));
+    }
+
+    #[tokio::test]
+    async fn test_overwrite_only_marks_removed_delete_files() {
+        assert_only_removed_delete_files_marked::<Overwrite>().await;
+    }
+
+    #[tokio::test]
+    async fn test_rewrite_only_marks_removed_delete_files() {
+        assert_only_removed_delete_files_marked::<Rewrite>().await;
+    }
+
+    #[tokio::test]
+    async fn test_overwrite_preserves_delete_manifest_content_type() {
+        assert_delete_manifest_carried_forward_intact::<Overwrite>().await;
+    }
+
+    #[tokio::test]
+    async fn test_rewrite_preserves_delete_manifest_content_type() {
+        assert_delete_manifest_carried_forward_intact::<Rewrite>().await;
+    }
+
+    #[tokio::test]
+    async fn test_replace_commit_preserves_delete_manifest_semantics() {
+        let table = make_v2_table_with_delete_manifest().await;
+        let removed = position_delete_file(&table, REMOVED_DELETE_FILE);
+        let snapshot_id = SnapshotProducer::generate_unique_snapshot_id(&table);
+        let action = Transaction::new(&table)
+            .overwrite_files()
+            .set_snapshot_id(snapshot_id)
+            .set_check_file_existence(true)
+            .delete_files([removed]);
+        let mut action_commit = Arc::new(action).commit(&table).await.unwrap();
+        let updates = action_commit.take_updates();
+        let TableUpdate::AddSnapshot { snapshot } = &updates[0] else {
+            unreachable!()
+        };
+
+        assert_eq!(snapshot.snapshot_id(), snapshot_id);
+        assert_eq!(snapshot.summary().operation, Operation::Overwrite);
+        assert_eq!(
+            snapshot
+                .summary()
+                .additional_properties
+                .get("total-delete-files")
+                .map(String::as_str),
+            Some("1")
+        );
+        assert_eq!(
+            snapshot
+                .summary()
+                .additional_properties
+                .get("total-position-deletes")
+                .map(String::as_str),
+            Some("1")
+        );
+        assert_eq!(
+            snapshot
+                .summary()
+                .additional_properties
+                .get("total-files-size")
+                .map(String::as_str),
+            Some("100")
+        );
+        let manifest_list = table
+            .manifest_list_reader(&SnapshotRef::new(snapshot.clone()))
+            .load()
+            .await
+            .unwrap();
+        assert!(
+            manifest_list
+                .entries()
+                .iter()
+                .all(|manifest| manifest.content == ManifestContentType::Deletes)
+        );
+
+        let mut entries = Vec::new();
+        for manifest_file in manifest_list.entries() {
+            entries.extend(
+                manifest_file
+                    .load_manifest(table.file_io())
+                    .await
+                    .unwrap()
+                    .entries()
+                    .iter()
+                    .map(|entry| (entry.file_path().to_string(), entry.status())),
+            );
+        }
+        entries.sort_unstable_by(|left, right| left.0.cmp(&right.0));
+
+        assert_eq!(entries, vec![
+            (REMOVED_DELETE_FILE.to_string(), ManifestStatus::Deleted),
+            (RETAINED_DELETE_FILE.to_string(), ManifestStatus::Existing),
+        ]);
+    }
+
+    #[tokio::test]
+    async fn test_replace_uses_requested_data_sequence_number() {
+        let table = make_v2_table_with_delete_manifest().await;
+        let added_file = DataFileBuilder::default()
+            .content(DataContentType::Data)
+            .file_path("test/replacement.parquet".to_string())
+            .file_format(DataFileFormat::Parquet)
+            .file_size_in_bytes(100)
+            .record_count(1)
+            .partition_spec_id(table.metadata().default_partition_spec_id())
+            .partition(Struct::from_iter([Some(Literal::long(300))]))
+            .build()
+            .unwrap();
+        let added_delete_file = position_delete_file(&table, "test/new-position-delete.parquet");
+        let action = Transaction::new(&table)
+            .rewrite_files()
+            .set_new_data_file_sequence_number(PARENT_SEQUENCE_NUMBER)
+            .add_data_files([added_file, added_delete_file]);
+        let mut action_commit = Arc::new(action).commit(&table).await.unwrap();
+        let updates = action_commit.take_updates();
+        let TableUpdate::AddSnapshot { snapshot } = &updates[0] else {
+            unreachable!()
+        };
+        let manifest_list = table
+            .manifest_list_reader(&SnapshotRef::new(snapshot.clone()))
+            .load()
+            .await
+            .unwrap();
+        let added_manifest = manifest_list
+            .entries()
+            .iter()
+            .find(|manifest| manifest.content == ManifestContentType::Data)
+            .unwrap();
+        let manifest = added_manifest.load_manifest(table.file_io()).await.unwrap();
+        let entry = &manifest.entries()[0];
+
+        assert_eq!(entry.sequence_number(), Some(PARENT_SEQUENCE_NUMBER));
+        assert_eq!(entry.file_sequence_number, Some(snapshot.sequence_number()));
+
+        let added_delete_manifest = manifest_list
+            .entries()
+            .iter()
+            .find(|manifest| {
+                manifest.content == ManifestContentType::Deletes
+                    && manifest.added_snapshot_id == snapshot.snapshot_id()
+            })
+            .unwrap();
+        let manifest = added_delete_manifest
+            .load_manifest(table.file_io())
+            .await
+            .unwrap();
+        assert_eq!(
+            manifest.entries()[0].sequence_number(),
+            Some(snapshot.sequence_number()),
+            "the data-file sequence override must not backdate newly written delete files"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_requested_data_sequence_keeps_newer_delete_files() {
+        let table = make_v2_table_with_delete_manifest().await;
+        let parent = table.metadata().current_snapshot().unwrap();
+        let later_snapshot_id = PARENT_SNAPSHOT_ID + 1;
+        let later_snapshot = Snapshot::builder()
+            .with_snapshot_id(later_snapshot_id)
+            .with_parent_snapshot_id(Some(PARENT_SNAPSHOT_ID))
+            .with_timestamp_ms(parent.timestamp_ms() + 1)
+            .with_sequence_number(PARENT_SEQUENCE_NUMBER + 2)
+            .with_schema_id(parent.schema_id().unwrap())
+            .with_manifest_list(parent.manifest_list())
+            .with_summary(parent.summary().clone())
+            .build();
+        let metadata = table
+            .metadata()
+            .clone()
+            .into_builder(Some("memory:///test/location/metadata/v2.json".to_string()))
+            .add_snapshot(later_snapshot)
+            .unwrap()
+            .set_ref(
+                MAIN_BRANCH,
+                SnapshotReference::new(
+                    later_snapshot_id,
+                    SnapshotRetention::branch(None, None, None),
+                ),
+            )
+            .unwrap()
+            .build()
+            .unwrap()
+            .metadata;
+        let table = table.with_metadata(Arc::new(metadata));
+        let added_file = DataFileBuilder::default()
+            .content(DataContentType::Data)
+            .file_path("test/compacted.parquet".to_string())
+            .file_format(DataFileFormat::Parquet)
+            .file_size_in_bytes(100)
+            .record_count(1)
+            .partition_spec_id(table.metadata().default_partition_spec_id())
+            .partition(Struct::from_iter([Some(Literal::long(300))]))
+            .build()
+            .unwrap();
+
+        let action = Transaction::new(&table)
+            .rewrite_files()
+            .set_new_data_file_sequence_number(PARENT_SEQUENCE_NUMBER)
+            .add_data_files([added_file]);
+        let mut action_commit = Arc::new(action).commit(&table).await.unwrap();
+        let updates = action_commit.take_updates();
+        let TableUpdate::AddSnapshot { snapshot } = &updates[0] else {
+            unreachable!()
+        };
+        let manifest_list = table
+            .manifest_list_reader(&SnapshotRef::new(snapshot.clone()))
+            .load()
+            .await
+            .unwrap();
+
+        let mut delete_statuses = Vec::new();
+        for manifest_file in manifest_list
+            .entries()
+            .iter()
+            .filter(|manifest| manifest.content == ManifestContentType::Deletes)
+        {
+            delete_statuses.extend(
+                manifest_file
+                    .load_manifest(table.file_io())
+                    .await
+                    .unwrap()
+                    .entries()
+                    .iter()
+                    .map(|entry| entry.status()),
+            );
+        }
+
+        assert_eq!(delete_statuses.len(), 2);
+        assert!(
+            delete_statuses
+                .iter()
+                .all(|status| *status != ManifestStatus::Deleted),
+            "delete files newer than the explicitly retained data sequence must stay live"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_replace_rejects_invalid_data_sequence_number() {
+        let table = make_v2_minimal_table();
+        let next_sequence_number = table.metadata().next_sequence_number();
+
+        for sequence_number in [-1, next_sequence_number + 1] {
+            let action = Transaction::new(&table)
+                .rewrite_files()
+                .set_new_data_file_sequence_number(sequence_number);
+            let err = match Arc::new(action).commit(&table).await {
+                Ok(_) => panic!("invalid data sequence number should fail"),
+                Err(err) => err,
+            };
+
+            assert_eq!(err.kind(), ErrorKind::DataInvalid);
+            assert!(err.message().contains("must be between 0"));
+        }
+    }
+
+    #[tokio::test]
+    async fn test_replace_preserves_non_default_partition_spec_id() {
+        let base = make_v2_minimal_table();
+        let metadata = base
+            .metadata()
+            .clone()
+            .into_builder(Some("memory:///test/location/metadata/v1.json".to_string()))
+            .set_location("memory:///test/location".to_string())
+            .add_partition_spec(UnboundPartitionSpec::builder().with_spec_id(1).build())
+            .unwrap()
+            .set_default_partition_spec(-1)
+            .unwrap()
+            .build()
+            .unwrap()
+            .metadata;
+        let table = base.with_metadata(Arc::new(metadata));
+        assert_eq!(table.metadata().default_partition_spec_id(), 1);
+
+        let old_spec = table.metadata().partition_spec_by_id(0).unwrap().clone();
+        let make_old_file = |path: &str| {
+            DataFileBuilder::default()
+                .content(DataContentType::Data)
+                .file_path(path.to_string())
+                .file_format(DataFileFormat::Parquet)
+                .file_size_in_bytes(100)
+                .record_count(1)
+                .partition_spec_id(0)
+                .partition(Struct::from_iter([Some(Literal::long(300))]))
+                .build()
+                .unwrap()
+        };
+        let removed = make_old_file("test/old-spec-removed.parquet");
+        let survivor = make_old_file("test/old-spec-survivor.parquet");
+        let manifest_path = "memory:///test/location/metadata/old-spec-data.avro";
+        let mut manifest_writer = ManifestWriterBuilder::new(
+            table.file_io().new_output(manifest_path).unwrap(),
+            Some(PARENT_SNAPSHOT_ID),
+            table.metadata().current_schema().clone(),
+            old_spec.as_ref().clone(),
+        )
+        .build_v2_data();
+        for file in [removed.clone(), survivor.clone()] {
+            manifest_writer
+                .add_entry(
+                    ManifestEntry::builder()
+                        .status(ManifestStatus::Added)
+                        .data_file(file)
+                        .build(),
+                )
+                .unwrap();
+        }
+        let manifest_file = manifest_writer.write_manifest_file().await.unwrap();
+
+        let manifest_list_path = "memory:///test/location/metadata/old-spec-manifest-list.avro";
+        let output = table
+            .file_io()
+            .new_output(manifest_list_path)
+            .unwrap()
+            .writer()
+            .await
+            .unwrap();
+        let mut manifest_list_writer =
+            ManifestListWriter::v2(output, PARENT_SNAPSHOT_ID, None, PARENT_SEQUENCE_NUMBER);
+        manifest_list_writer
+            .add_manifests([manifest_file].into_iter())
+            .unwrap();
+        manifest_list_writer.close().await.unwrap();
+
+        let parent_snapshot = Snapshot::builder()
+            .with_snapshot_id(PARENT_SNAPSHOT_ID)
+            .with_timestamp_ms(table.metadata().last_updated_ms() + 1)
+            .with_sequence_number(PARENT_SEQUENCE_NUMBER)
+            .with_schema_id(table.metadata().current_schema_id())
+            .with_manifest_list(manifest_list_path)
+            .with_summary(Summary {
+                operation: Operation::Append,
+                additional_properties: [
+                    ("total-data-files".to_string(), "2".to_string()),
+                    ("total-records".to_string(), "2".to_string()),
+                    ("total-files-size".to_string(), "200".to_string()),
+                ]
+                .into_iter()
+                .collect(),
+            })
+            .build();
+        let metadata = table
+            .metadata()
+            .clone()
+            .into_builder(Some("memory:///test/location/metadata/v2.json".to_string()))
+            .add_snapshot(parent_snapshot)
+            .unwrap()
+            .set_ref(
+                MAIN_BRANCH,
+                SnapshotReference::new(
+                    PARENT_SNAPSHOT_ID,
+                    SnapshotRetention::branch(None, None, None),
+                ),
+            )
+            .unwrap()
+            .build()
+            .unwrap()
+            .metadata;
+        let table = table.with_metadata(Arc::new(metadata));
+
+        let action = Transaction::new(&table)
+            .rewrite_files()
+            .delete_files([removed]);
+        let mut action_commit = Arc::new(action).commit(&table).await.unwrap();
+        let updates = action_commit.take_updates();
+        let TableUpdate::AddSnapshot { snapshot } = &updates[0] else {
+            unreachable!()
+        };
+        let manifest_list = table
+            .manifest_list_reader(&SnapshotRef::new(snapshot.clone()))
+            .load()
+            .await
+            .unwrap();
+
+        assert!(
+            manifest_list
+                .entries()
+                .iter()
+                .all(|manifest| manifest.partition_spec_id == 0),
+            "rewritten and deleted-entry manifests must use the source files' spec, not default spec 1"
+        );
+        let mut statuses = Vec::new();
+        for manifest_file in manifest_list.entries() {
+            statuses.extend(
+                manifest_file
+                    .load_manifest(table.file_io())
+                    .await
+                    .unwrap()
+                    .entries()
+                    .iter()
+                    .map(|entry| (entry.file_path().to_string(), entry.status())),
+            );
+        }
+        statuses.sort_unstable_by(|left, right| left.0.cmp(&right.0));
+        assert_eq!(statuses, vec![
+            (
+                "test/old-spec-removed.parquet".to_string(),
+                ManifestStatus::Deleted,
+            ),
+            (
+                "test/old-spec-survivor.parquet".to_string(),
+                ManifestStatus::Existing,
+            ),
+        ]);
+    }
+
+    #[tokio::test]
+    async fn test_replace_existence_validation_rejects_missing_file() {
+        let table = make_v2_minimal_table();
+        let missing_file = DataFileBuilder::default()
+            .content(DataContentType::Data)
+            .file_path("test/missing.parquet".to_string())
+            .file_format(DataFileFormat::Parquet)
+            .file_size_in_bytes(100)
+            .record_count(1)
+            .partition_spec_id(table.metadata().default_partition_spec_id())
+            .partition(Struct::from_iter([Some(Literal::long(300))]))
+            .build()
+            .unwrap();
+        let action = Transaction::new(&table)
+            .rewrite_files()
+            .set_check_file_existence(true)
+            .delete_files([missing_file]);
+        let err = match Arc::new(action).commit(&table).await {
+            Ok(_) => panic!("missing delete file should fail validation"),
+            Err(err) => err,
+        };
+
+        assert_eq!(err.kind(), ErrorKind::DataInvalid);
+        assert!(err.message().contains("branch with no snapshot"));
+    }
+
+    #[tokio::test]
+    async fn test_replace_uses_target_branch_parent_and_requirement() {
+        let table = make_v2_table_with_delete_manifest().await;
+        let main_snapshot_id = PARENT_SNAPSHOT_ID + 1;
+        let parent = table.metadata().snapshot_by_id(PARENT_SNAPSHOT_ID).unwrap();
+        let main_snapshot = Snapshot::builder()
+            .with_snapshot_id(main_snapshot_id)
+            .with_parent_snapshot_id(Some(PARENT_SNAPSHOT_ID))
+            .with_timestamp_ms(parent.timestamp_ms() + 1)
+            .with_sequence_number(PARENT_SEQUENCE_NUMBER + 1)
+            .with_schema_id(parent.schema_id().unwrap())
+            .with_manifest_list(parent.manifest_list())
+            .with_summary(Summary {
+                operation: Operation::Append,
+                additional_properties: parent.summary().additional_properties.clone(),
+            })
+            .build();
+        let metadata = table
+            .metadata()
+            .clone()
+            .into_builder(Some("memory:///test/location/metadata/v2.json".to_string()))
+            .add_snapshot(main_snapshot)
+            .unwrap()
+            .set_ref(
+                "staging",
+                SnapshotReference::new(
+                    PARENT_SNAPSHOT_ID,
+                    SnapshotRetention::branch(None, None, None),
+                ),
+            )
+            .unwrap()
+            .set_ref(
+                MAIN_BRANCH,
+                SnapshotReference::new(
+                    main_snapshot_id,
+                    SnapshotRetention::branch(None, None, None),
+                ),
+            )
+            .unwrap()
+            .build()
+            .unwrap()
+            .metadata;
+        let table = table.with_metadata(Arc::new(metadata));
+        let removed = position_delete_file(&table, REMOVED_DELETE_FILE);
+        let action = Transaction::new(&table)
+            .rewrite_files()
+            .set_target_branch("staging".to_string())
+            .delete_files([removed]);
+        let mut action_commit = Arc::new(action).commit(&table).await.unwrap();
+        let updates = action_commit.take_updates();
+        let requirements = action_commit.take_requirements();
+        let TableUpdate::AddSnapshot { snapshot } = &updates[0] else {
+            unreachable!()
+        };
+
+        assert_eq!(snapshot.parent_snapshot_id(), Some(PARENT_SNAPSHOT_ID));
+        assert!(matches!(
+            &updates[1],
+            TableUpdate::SetSnapshotRef { ref_name, .. } if ref_name == "staging"
+        ));
+        assert_eq!(requirements[1], TableRequirement::RefSnapshotIdMatch {
+            r#ref: "staging".to_string(),
+            snapshot_id: Some(PARENT_SNAPSHOT_ID),
+        });
+    }
+
+    #[tokio::test]
+    async fn test_replace_writes_encrypted_manifest_and_manifest_list() {
+        let table = make_encrypted_table().await;
+        let data_file = DataFileBuilder::default()
+            .content(DataContentType::Data)
+            .file_path("test/encrypted-replacement.parquet".to_string())
+            .file_format(DataFileFormat::Parquet)
+            .file_size_in_bytes(100)
+            .record_count(1)
+            .partition_spec_id(table.metadata().default_partition_spec_id())
+            .partition(Struct::empty())
+            .build()
+            .unwrap();
+        let action = Transaction::new(&table)
+            .rewrite_files()
+            .add_data_files([data_file.clone()]);
+        let mut action_commit = Arc::new(action).commit(&table).await.unwrap();
+        let updates = action_commit.take_updates();
+        let snapshot = updates
+            .iter()
+            .find_map(|update| match update {
+                TableUpdate::AddSnapshot { snapshot } => Some(snapshot),
+                _ => None,
+            })
+            .unwrap();
+        assert!(snapshot.encryption_key_id().is_some());
+
+        let manifest_list = table
+            .manifest_list_reader(&SnapshotRef::new(snapshot.clone()))
+            .load()
+            .await
+            .unwrap();
+        let data_manifest = manifest_list
+            .entries()
+            .iter()
+            .find(|manifest| manifest.content == ManifestContentType::Data)
+            .unwrap();
+        assert!(data_manifest.key_metadata.is_some());
+        let manifest = data_manifest.load_manifest(table.file_io()).await.unwrap();
+        assert_eq!(manifest.entries()[0].data_file(), &data_file);
+    }
+
+    #[tokio::test]
+    async fn test_replace_drops_only_dangling_dv_from_shared_puffin() {
+        const DATA_A: &str = "test/data-a.parquet";
+        const DATA_B: &str = "test/data-b.parquet";
+        const PUFFIN: &str = "test/shared.puffin";
+        const DATA_MANIFEST: &str = "memory:///test/location/metadata/data-manifest.avro";
+        const DELETE_MANIFEST: &str = "memory:///test/location/metadata/delete-manifest.avro";
+        const MANIFEST_LIST: &str = "memory:///test/location/metadata/manifest-list.avro";
+
+        let base = make_v3_minimal_table();
+        let metadata = base
+            .metadata()
+            .clone()
+            .into_builder(Some("memory:///test/location/metadata/v1.json".to_string()))
+            .set_location("memory:///test/location".to_string())
+            .build()
+            .unwrap()
+            .metadata;
+        let table = base.with_metadata(Arc::new(metadata));
+        let make_data_file = |path: &str, first_row_id: i64| {
+            DataFileBuilder::default()
+                .content(DataContentType::Data)
+                .file_path(path.to_string())
+                .file_format(DataFileFormat::Parquet)
+                .file_size_in_bytes(100)
+                .record_count(10)
+                .partition_spec_id(table.metadata().default_partition_spec_id())
+                .partition(Struct::from_iter([Some(Literal::long(300))]))
+                .first_row_id(Some(first_row_id))
+                .build()
+                .unwrap()
+        };
+        let data_a = make_data_file(DATA_A, 0);
+        let data_b = make_data_file(DATA_B, 10);
+        let make_dv = |referenced_data_file: &str, offset: i64| {
+            DataFileBuilder::default()
+                .content(DataContentType::PositionDeletes)
+                .file_path(PUFFIN.to_string())
+                .file_format(DataFileFormat::Puffin)
+                .file_size_in_bytes(256)
+                .record_count(1)
+                .partition_spec_id(table.metadata().default_partition_spec_id())
+                .partition(Struct::from_iter([Some(Literal::long(300))]))
+                .referenced_data_file(Some(referenced_data_file.to_string()))
+                .content_offset(Some(offset))
+                .content_size_in_bytes(Some(64))
+                .build()
+                .unwrap()
+        };
+        let dv_a = make_dv(DATA_A, 4);
+        let dv_b = make_dv(DATA_B, 68);
+
+        let mut data_writer = ManifestWriterBuilder::new(
+            table.file_io().new_output(DATA_MANIFEST).unwrap(),
+            Some(PARENT_SNAPSHOT_ID),
+            table.metadata().current_schema().clone(),
+            table.metadata().default_partition_spec().as_ref().clone(),
+        )
+        .build_v3_data();
+        for file in [data_a.clone(), data_b] {
+            data_writer
+                .add_existing_file(
+                    file,
+                    PARENT_SNAPSHOT_ID,
+                    PARENT_SEQUENCE_NUMBER,
+                    Some(PARENT_SEQUENCE_NUMBER),
+                )
+                .unwrap();
+        }
+        let data_manifest = data_writer.write_manifest_file().await.unwrap();
+
+        let mut delete_writer = ManifestWriterBuilder::new(
+            table.file_io().new_output(DELETE_MANIFEST).unwrap(),
+            Some(PARENT_SNAPSHOT_ID),
+            table.metadata().current_schema().clone(),
+            table.metadata().default_partition_spec().as_ref().clone(),
+        )
+        .build_v3_deletes();
+        for file in [dv_a.clone(), dv_b] {
+            delete_writer
+                .add_existing_file(
+                    file,
+                    PARENT_SNAPSHOT_ID,
+                    PARENT_SEQUENCE_NUMBER,
+                    Some(PARENT_SEQUENCE_NUMBER),
+                )
+                .unwrap();
+        }
+        let delete_manifest = delete_writer.write_manifest_file().await.unwrap();
+
+        let manifest_list_output = table
+            .file_io()
+            .new_output(MANIFEST_LIST)
+            .unwrap()
+            .writer()
+            .await
+            .unwrap();
+        let mut manifest_list_writer = ManifestListWriter::v3(
+            manifest_list_output,
+            PARENT_SNAPSHOT_ID,
+            None,
+            PARENT_SEQUENCE_NUMBER,
+            Some(0),
+        );
+        manifest_list_writer
+            .add_manifests([data_manifest, delete_manifest].into_iter())
+            .unwrap();
+        manifest_list_writer.close().await.unwrap();
+
+        let parent_snapshot = Snapshot::builder()
+            .with_snapshot_id(PARENT_SNAPSHOT_ID)
+            .with_timestamp_ms(table.metadata().last_updated_ms() + 1)
+            .with_sequence_number(PARENT_SEQUENCE_NUMBER)
+            .with_schema_id(table.metadata().current_schema_id())
+            .with_manifest_list(MANIFEST_LIST)
+            .with_summary(Summary {
+                operation: Operation::Append,
+                additional_properties: [
+                    ("total-data-files".to_string(), "2".to_string()),
+                    ("total-delete-files".to_string(), "2".to_string()),
+                    ("total-records".to_string(), "20".to_string()),
+                    ("total-files-size".to_string(), "712".to_string()),
+                    ("total-position-deletes".to_string(), "2".to_string()),
+                ]
+                .into_iter()
+                .collect(),
+            })
+            .with_row_range(0, 20)
+            .build();
+        let metadata = table
+            .metadata()
+            .clone()
+            .into_builder(Some("memory:///test/location/metadata/v1.json".to_string()))
+            .add_snapshot(parent_snapshot)
+            .unwrap()
+            .set_ref(
+                MAIN_BRANCH,
+                SnapshotReference::new(
+                    PARENT_SNAPSHOT_ID,
+                    SnapshotRetention::branch(None, None, None),
+                ),
+            )
+            .unwrap()
+            .build()
+            .unwrap()
+            .metadata;
+        let table = table.with_metadata(Arc::new(metadata));
+
+        let replacement = DataFileBuilder::default()
+            .content(DataContentType::Data)
+            .file_path("test/replacement.parquet".to_string())
+            .file_format(DataFileFormat::Parquet)
+            .file_size_in_bytes(200)
+            .record_count(10)
+            .partition_spec_id(table.metadata().default_partition_spec_id())
+            .partition(Struct::from_iter([Some(Literal::long(300))]))
+            .build()
+            .unwrap();
+        let action = Transaction::new(&table)
+            .rewrite_files()
+            .add_data_files([replacement])
+            .delete_files([data_a]);
+        let mut action_commit = Arc::new(action).commit(&table).await.unwrap();
+        let updates = action_commit.take_updates();
+        let snapshot = updates
+            .iter()
+            .find_map(|update| match update {
+                TableUpdate::AddSnapshot { snapshot } => Some(snapshot),
+                _ => None,
+            })
+            .unwrap();
+        let manifest_list = table
+            .manifest_list_reader(&SnapshotRef::new(snapshot.clone()))
+            .load()
+            .await
+            .unwrap();
+
+        let mut dv_entries = Vec::new();
+        for manifest_file in manifest_list
+            .entries()
+            .iter()
+            .filter(|manifest| manifest.content == ManifestContentType::Deletes)
+        {
+            dv_entries.extend(
+                manifest_file
+                    .load_manifest(table.file_io())
+                    .await
+                    .unwrap()
+                    .entries()
+                    .iter()
+                    .map(|entry| {
+                        (
+                            entry.data_file().referenced_data_file(),
+                            entry.data_file().content_offset(),
+                            entry.status(),
+                        )
+                    }),
+            );
+        }
+        dv_entries.sort_unstable_by_key(|entry| entry.1);
+
+        assert_eq!(dv_entries, vec![
+            (Some(DATA_A.to_string()), Some(4), ManifestStatus::Deleted),
+            (Some(DATA_B.to_string()), Some(68), ManifestStatus::Existing),
+        ]);
+
+        let action = Transaction::new(&table)
+            .rewrite_files()
+            .delete_files([dv_a]);
+        let mut action_commit = Arc::new(action).commit(&table).await.unwrap();
+        let updates = action_commit.take_updates();
+        let snapshot = updates
+            .iter()
+            .find_map(|update| match update {
+                TableUpdate::AddSnapshot { snapshot } => Some(snapshot),
+                _ => None,
+            })
+            .unwrap();
+        let manifest_list = table
+            .manifest_list_reader(&SnapshotRef::new(snapshot.clone()))
+            .load()
+            .await
+            .unwrap();
+        let mut offsets_and_statuses = Vec::new();
+        for manifest_file in manifest_list
+            .entries()
+            .iter()
+            .filter(|manifest| manifest.content == ManifestContentType::Deletes)
+        {
+            offsets_and_statuses.extend(
+                manifest_file
+                    .load_manifest(table.file_io())
+                    .await
+                    .unwrap()
+                    .entries()
+                    .iter()
+                    .map(|entry| (entry.data_file().content_offset().unwrap(), entry.status())),
+            );
+        }
+        offsets_and_statuses.sort_unstable_by_key(|entry| entry.0);
+
+        assert_eq!(offsets_and_statuses, vec![
+            (4, ManifestStatus::Deleted),
+            (68, ManifestStatus::Existing),
+        ]);
+    }
+}

--- a/crates/iceberg/src/transaction/snapshot.rs
+++ b/crates/iceberg/src/transaction/snapshot.rs
@@ -17,22 +17,41 @@
 
 use std::collections::{HashMap, HashSet};
 use std::future::Future;
-use std::ops::RangeFrom;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 
-use futures::TryStreamExt;
-use futures::stream::FuturesUnordered;
+use futures::StreamExt;
 use uuid::Uuid;
 
 use crate::error::Result;
 use crate::spec::{
-    DataFile, DataFileFormat, FormatVersion, MAIN_BRANCH, ManifestContentType, ManifestEntry,
-    ManifestFile, ManifestListWriter, ManifestWriter, ManifestWriterBuilder, Operation, Snapshot,
-    SnapshotReference, SnapshotRetention, SnapshotSummaryCollector, Struct, StructType, Summary,
-    TableProperties, update_snapshot_summaries,
+    DataContentType, DataFile, DataFileFormat, FormatVersion, MAIN_BRANCH, ManifestContentType,
+    ManifestEntry, ManifestFile, ManifestListWriter, ManifestWriter, ManifestWriterBuilder,
+    Operation, Snapshot, SnapshotReference, SnapshotRetention, SnapshotSummaryCollector, Struct,
+    StructType, Summary, TableProperties, UNASSIGNED_SEQUENCE_NUMBER, update_snapshot_summaries,
 };
 use crate::table::Table;
-use crate::transaction::ActionCommit;
+use crate::transaction::{ActionCommit, ManifestFilterManager, ManifestWriterContext};
 use crate::{Error, ErrorKind, TableRequirement, TableUpdate};
+
+pub(crate) type DataFileIdentity = (String, Option<i64>, Option<i64>);
+
+pub(crate) fn data_file_identity(file: &DataFile) -> DataFileIdentity {
+    (
+        file.file_path().to_string(),
+        file.content_offset(),
+        file.content_size_in_bytes(),
+    )
+}
+
+pub(crate) fn format_data_file_identity(identity: &DataFileIdentity) -> String {
+    match (identity.1, identity.2) {
+        (Some(offset), Some(length)) => {
+            format!("{} (offset: {offset}, length: {length})", identity.0)
+        }
+        _ => identity.0.clone(),
+    }
+}
 
 /// A trait that defines how different table operations produce new snapshots.
 ///
@@ -83,7 +102,7 @@ pub(crate) trait SnapshotProduceOperation: Send + Sync {
     /// - **Delete operations**: May exclude manifests for partitions being deleted
     fn existing_manifest(
         &self,
-        snapshot_produce: &SnapshotProducer<'_>,
+        snapshot_produce: &mut SnapshotProducer<'_>,
     ) -> impl Future<Output = Result<Vec<ManifestFile>>> + Send;
 }
 
@@ -112,38 +131,65 @@ pub(crate) struct SnapshotProducer<'a> {
     snapshot_id: i64,
     commit_uuid: Uuid,
     snapshot_properties: HashMap<String, String>,
-    added_data_files: Vec<DataFile>,
+    pub(crate) added_data_files: Vec<DataFile>,
+    pub(crate) added_delete_files: Vec<DataFile>,
+    pub(crate) removed_data_file_paths: HashSet<String>,
+    pub(crate) removed_data_file_identities: HashSet<DataFileIdentity>,
+    pub(crate) removed_delete_file_identities: HashSet<DataFileIdentity>,
+    pub(crate) removed_data_files: Vec<DataFile>,
+    pub(crate) removed_delete_files: Vec<DataFile>,
     // A counter used to generate unique manifest file names.
-    // It starts from 0 and increments for each new manifest file.
-    // Note: This counter is limited to the range of (0..u64::MAX).
-    manifest_counter: RangeFrom<u64>,
+    // It is shared with ManifestWriterContext to avoid naming conflicts.
+    manifest_counter: Arc<AtomicU64>,
+    new_data_file_sequence_number: Option<i64>,
+    target_branch: String,
+    delete_filter_manager: Option<ManifestFilterManager>,
 }
 
 impl<'a> SnapshotProducer<'a> {
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
         table: &'a Table,
         commit_uuid: Uuid,
+        snapshot_id: Option<i64>,
         snapshot_properties: HashMap<String, String>,
         added_data_files: Vec<DataFile>,
+        added_delete_files: Vec<DataFile>,
+        removed_data_files: Vec<DataFile>,
+        removed_delete_files: Vec<DataFile>,
     ) -> Self {
+        let removed_data_file_paths = removed_data_files
+            .iter()
+            .map(|file| file.file_path.clone())
+            .collect();
+        let removed_data_file_identities =
+            removed_data_files.iter().map(data_file_identity).collect();
+        let removed_delete_file_identities = removed_delete_files
+            .iter()
+            .map(data_file_identity)
+            .collect();
+
         Self {
             table,
-            snapshot_id: Self::generate_unique_snapshot_id(table),
+            snapshot_id: snapshot_id.unwrap_or_else(|| Self::generate_unique_snapshot_id(table)),
             commit_uuid,
             snapshot_properties,
             added_data_files,
-            manifest_counter: (0..),
+            added_delete_files,
+            removed_data_file_paths,
+            removed_data_file_identities,
+            removed_delete_file_identities,
+            removed_data_files,
+            removed_delete_files,
+            manifest_counter: Arc::new(AtomicU64::new(0)),
+            new_data_file_sequence_number: None,
+            target_branch: MAIN_BRANCH.to_string(),
+            delete_filter_manager: None,
         }
     }
 
-    pub(crate) fn validate_added_data_files(&self) -> Result<()> {
-        for data_file in &self.added_data_files {
-            if data_file.content_type() != crate::spec::DataContentType::Data {
-                return Err(Error::new(
-                    ErrorKind::DataInvalid,
-                    "Only data content type is allowed for fast append",
-                ));
-            }
+    pub(crate) fn validate_added_files(&self, files: &[DataFile]) -> Result<()> {
+        for data_file in files {
             // Check if the data file partition spec id matches the table default partition spec id.
             if self.table.metadata().default_partition_spec_id() != data_file.partition_spec_id {
                 return Err(Error::new(
@@ -160,54 +206,93 @@ impl<'a> SnapshotProducer<'a> {
         Ok(())
     }
 
-    pub(crate) async fn validate_duplicate_files(&self) -> Result<()> {
-        let Some(current_snapshot) = self.table.metadata().current_snapshot() else {
-            return Ok(());
-        };
-
-        let new_files: HashSet<&str> = self
+    pub(crate) async fn validate_data_file_changes(&self) -> Result<()> {
+        let mut files_to_delete: HashSet<DataFileIdentity> = self
+            .removed_data_files
+            .iter()
+            .chain(self.removed_delete_files.iter())
+            .map(data_file_identity)
+            .collect();
+        let files_to_add: HashSet<DataFileIdentity> = self
             .added_data_files
             .iter()
-            .map(|df| df.file_path.as_str())
+            .chain(self.added_delete_files.iter())
+            .map(data_file_identity)
             .collect();
 
-        let runtime = self.table.runtime();
-        let file_io = self.table.file_io();
-        let manifest_list = self
-            .table
-            .manifest_list_reader(current_snapshot)
-            .load()
-            .await?;
+        if files_to_add.is_empty() && files_to_delete.is_empty() {
+            return Ok(());
+        }
 
-        let new_files_ref = &new_files;
-        let referenced_files: Vec<String> = manifest_list
-            .consume_entries()
-            .into_iter()
-            .map(|entry| {
+        let Some(snapshot) = self.table.metadata().snapshot_for_ref(&self.target_branch) else {
+            if files_to_delete.is_empty() {
+                return Ok(());
+            }
+            let mut paths = files_to_delete
+                .iter()
+                .map(format_data_file_identity)
+                .collect::<Vec<_>>();
+            paths.sort_unstable();
+            return Err(Error::new(
+                ErrorKind::DataInvalid,
+                format!(
+                    "Cannot delete files from a branch with no snapshot, files: {}",
+                    paths.join(", ")
+                ),
+            ));
+        };
+
+        let manifest_list = self.table.manifest_list_reader(snapshot).load().await?;
+        let manifest_files = manifest_list.entries().to_vec();
+        let file_io = self.table.file_io().clone();
+        let concurrency_limit = std::thread::available_parallelism()
+            .map(usize::from)
+            .unwrap_or(1);
+        let mut manifests = futures::stream::iter(manifest_files)
+            .map(|manifest_file| {
                 let file_io = file_io.clone();
-                runtime
-                    .io()
-                    .spawn(async move { entry.load_manifest(&file_io).await })
+                async move { manifest_file.load_manifest(&file_io).await }
             })
-            .collect::<FuturesUnordered<_>>()
-            .try_fold(Vec::new(), |mut acc, manifest| async move {
-                acc.extend(
-                    manifest?
-                        .entries()
-                        .iter()
-                        .filter(|e| new_files_ref.contains(e.file_path()) && e.is_alive())
-                        .map(|e| e.file_path().to_string()),
-                );
-                Ok(acc)
-            })
-            .await?;
+            .buffer_unordered(concurrency_limit);
+        let mut duplicate_files = HashSet::new();
 
-        if !referenced_files.is_empty() {
+        while let Some(manifest) = manifests.next().await {
+            let manifest = manifest?;
+            for entry in manifest.entries().iter().filter(|entry| entry.is_alive()) {
+                let identity = data_file_identity(entry.data_file());
+                if files_to_add.contains(&identity) {
+                    duplicate_files.insert(identity.clone());
+                }
+                files_to_delete.remove(&identity);
+            }
+        }
+
+        if !duplicate_files.is_empty() {
+            let mut paths = duplicate_files
+                .iter()
+                .map(format_data_file_identity)
+                .collect::<Vec<_>>();
+            paths.sort_unstable();
             return Err(Error::new(
                 ErrorKind::DataInvalid,
                 format!(
                     "Cannot add files that are already referenced by table, files: {}",
-                    referenced_files.join(", ")
+                    paths.join(", ")
+                ),
+            ));
+        }
+
+        if !files_to_delete.is_empty() {
+            let mut paths = files_to_delete
+                .iter()
+                .map(format_data_file_identity)
+                .collect::<Vec<_>>();
+            paths.sort_unstable();
+            return Err(Error::new(
+                ErrorKind::DataInvalid,
+                format!(
+                    "Cannot delete files that are not in the target branch, files: {}",
+                    paths.join(", ")
                 ),
             ));
         }
@@ -215,7 +300,7 @@ impl<'a> SnapshotProducer<'a> {
         Ok(())
     }
 
-    fn generate_unique_snapshot_id(table: &Table) -> i64 {
+    pub(crate) fn generate_unique_snapshot_id(table: &Table) -> i64 {
         let generate_random_id = || -> i64 {
             let (lhs, rhs) = Uuid::new_v4().as_u64_pair();
             let snapshot_id = (lhs ^ rhs) as i64;
@@ -237,19 +322,30 @@ impl<'a> SnapshotProducer<'a> {
         snapshot_id
     }
 
-    fn new_manifest_writer(&mut self, content: ManifestContentType) -> Result<ManifestWriter> {
+    pub(crate) fn new_manifest_writer(
+        &self,
+        content: ManifestContentType,
+        partition_spec_id: i32,
+    ) -> Result<ManifestWriter> {
         let new_manifest_path = format!(
             "{}/{}-m{}.{}",
             self.table.metadata().metadata_location()?,
             self.commit_uuid,
-            self.manifest_counter.next().unwrap(),
+            self.manifest_counter.fetch_add(1, Ordering::SeqCst),
             DataFileFormat::Avro
         );
         let output_file = self.table.file_io().new_output(new_manifest_path)?;
         let partition_spec = self
             .table
             .metadata()
-            .default_partition_spec()
+            .partition_spec_by_id(partition_spec_id)
+            .ok_or_else(|| {
+                Error::new(
+                    ErrorKind::DataInvalid,
+                    "Invalid partition spec id for new manifest writer",
+                )
+                .with_context("partition spec id", partition_spec_id.to_string())
+            })?
             .as_ref()
             .clone();
         let schema = self.table.metadata().current_schema().clone();
@@ -309,22 +405,42 @@ impl<'a> SnapshotProducer<'a> {
         Ok(())
     }
 
-    // Write manifest file for added data files and return the ManifestFile for ManifestList.
-    async fn write_added_manifest(&mut self) -> Result<ManifestFile> {
-        let added_data_files = std::mem::take(&mut self.added_data_files);
-        if added_data_files.is_empty() {
+    async fn write_added_manifest(
+        &self,
+        added_files: Vec<DataFile>,
+        data_sequence_number: Option<i64>,
+    ) -> Result<ManifestFile> {
+        let Some(first_file) = added_files.first() else {
             return Err(Error::new(
                 ErrorKind::PreconditionFailed,
-                "No added data files found when write an added manifest file",
+                "No added files found when writing an added manifest",
+            ));
+        };
+
+        let content = match first_file.content_type() {
+            DataContentType::Data => ManifestContentType::Data,
+            DataContentType::PositionDeletes | DataContentType::EqualityDeletes => {
+                ManifestContentType::Deletes
+            }
+        };
+
+        if added_files.iter().any(|file| {
+            matches!(file.content_type(), DataContentType::Data)
+                != matches!(content, ManifestContentType::Data)
+        }) {
+            return Err(Error::new(
+                ErrorKind::DataInvalid,
+                "A manifest cannot mix data files and delete files",
             ));
         }
 
         let snapshot_id = self.snapshot_id;
         let format_version = self.table.metadata().format_version();
-        let manifest_entries = added_data_files.into_iter().map(|data_file| {
+        let manifest_entries = added_files.into_iter().map(|data_file| {
             let builder = ManifestEntry::builder()
                 .status(crate::spec::ManifestStatus::Added)
-                .data_file(data_file);
+                .data_file(data_file)
+                .sequence_number_opt(data_sequence_number);
             if format_version == FormatVersion::V1 {
                 builder.snapshot_id(snapshot_id).build()
             } else {
@@ -333,15 +449,43 @@ impl<'a> SnapshotProducer<'a> {
                 builder.build()
             }
         });
-        let mut writer = self.new_manifest_writer(ManifestContentType::Data)?;
+        let mut writer =
+            self.new_manifest_writer(content, self.table.metadata().default_partition_spec_id())?;
         for entry in manifest_entries {
             writer.add_entry(entry)?;
         }
         writer.write_manifest_file().await
     }
 
-    /// Creates new manifests for data files added or removed,
-    /// and collects all of the manifests to be included in the new snapshot as [ManifestFile] entries.
+    async fn write_delete_manifests(
+        &self,
+        deleted_entries: Vec<ManifestEntry>,
+    ) -> Result<Vec<ManifestFile>> {
+        let mut groups: HashMap<(i32, ManifestContentType), Vec<ManifestEntry>> = HashMap::new();
+        for entry in deleted_entries {
+            let content = match entry.content_type() {
+                DataContentType::Data => ManifestContentType::Data,
+                DataContentType::PositionDeletes | DataContentType::EqualityDeletes => {
+                    ManifestContentType::Deletes
+                }
+            };
+            groups
+                .entry((entry.data_file().partition_spec_id, content))
+                .or_default()
+                .push(entry);
+        }
+
+        let mut manifests = Vec::with_capacity(groups.len());
+        for ((spec_id, content), entries) in groups {
+            let mut writer = self.new_manifest_writer(content, spec_id)?;
+            for entry in entries {
+                writer.add_delete_entry(entry)?;
+            }
+            manifests.push(writer.write_manifest_file().await?);
+        }
+        Ok(manifests)
+    }
+
     async fn produce_manifests<OP: SnapshotProduceOperation, MP: ManifestProcess>(
         &mut self,
         snapshot_produce_operation: &OP,
@@ -352,27 +496,86 @@ impl<'a> SnapshotProducer<'a> {
         // TODO: Allowing snapshot property setup with no added data files is a workaround.
         // We should clean it up after all necessary actions are supported.
         // For details, please refer to https://github.com/apache/iceberg-rust/issues/1548
-        if self.added_data_files.is_empty() && self.snapshot_properties.is_empty() {
+        if self.added_data_files.is_empty()
+            && self.added_delete_files.is_empty()
+            && self.removed_data_file_identities.is_empty()
+            && self.removed_delete_file_identities.is_empty()
+            && self.snapshot_properties.is_empty()
+        {
             return Err(Error::new(
                 ErrorKind::PreconditionFailed,
-                "No added data files or added snapshot properties found when write a manifest file",
+                "No file or snapshot property changes to commit",
             ));
         }
 
         let existing_manifests = snapshot_produce_operation.existing_manifest(self).await?;
-        let mut manifest_files = existing_manifests;
+        let mut manifest_files = if let Some(mut filter) = self.delete_filter_manager.take() {
+            let metadata = self.table.metadata();
+            let schema_id = metadata
+                .snapshot_for_ref(&self.target_branch)
+                .and_then(|snapshot| snapshot.schema_id())
+                .unwrap_or(metadata.current_schema_id());
+            let schema = metadata.schema_by_id(schema_id).ok_or_else(|| {
+                Error::new(
+                    ErrorKind::DataInvalid,
+                    "Invalid schema id for existing manifest filtering",
+                )
+                .with_context("schema id", schema_id.to_string())
+            })?;
 
-        // Process added entries.
+            let (mut data_manifests, delete_manifests): (Vec<_>, Vec<_>) = existing_manifests
+                .into_iter()
+                .partition(|manifest| manifest.content == ManifestContentType::Data);
+            let last_sequence_number = metadata.last_sequence_number();
+            let added_data_sequence_number = (!self.added_data_files.is_empty()).then_some(
+                self.new_data_file_sequence_number
+                    .unwrap_or(last_sequence_number),
+            );
+            let min_data_sequence_number = data_manifests
+                .iter()
+                .map(|manifest| manifest.min_sequence_number)
+                .filter(|sequence| *sequence != UNASSIGNED_SEQUENCE_NUMBER)
+                .chain(added_data_sequence_number)
+                .min()
+                .map(|sequence| sequence.min(last_sequence_number))
+                .unwrap_or(last_sequence_number);
+
+            filter.drop_delete_files_older_than(min_data_sequence_number);
+            filter.remove_dangling_deletes_for(&self.removed_data_file_paths);
+            data_manifests.extend(
+                filter
+                    .filter_manifests(schema.as_ref(), delete_manifests)
+                    .await?,
+            );
+            data_manifests.retain(|manifest| {
+                manifest.has_added_files()
+                    || manifest.has_existing_files()
+                    || manifest.added_snapshot_id == self.snapshot_id
+            });
+            self.delete_filter_manager = Some(filter);
+            data_manifests
+        } else {
+            existing_manifests
+        };
+
         if !self.added_data_files.is_empty() {
-            let added_manifest = self.write_added_manifest().await?;
+            let added_files = std::mem::take(&mut self.added_data_files);
+            let added_manifest = self
+                .write_added_manifest(added_files, self.new_data_file_sequence_number)
+                .await?;
             manifest_files.push(added_manifest);
         }
 
-        // # TODO
-        // Support process delete entries.
+        if !self.added_delete_files.is_empty() {
+            let added_files = std::mem::take(&mut self.added_delete_files);
+            let added_manifest = self.write_added_manifest(added_files, None).await?;
+            manifest_files.push(added_manifest);
+        }
 
-        let manifest_files = manifest_process.process_manifests(self, manifest_files);
-        Ok(manifest_files)
+        let deleted_entries = snapshot_produce_operation.delete_entries(self).await?;
+        manifest_files.extend(self.write_delete_manifests(deleted_entries).await?);
+
+        Ok(manifest_process.process_manifests(self, manifest_files))
     }
 
     // Returns a `Summary` of the current snapshot
@@ -398,15 +601,53 @@ impl<'a> SnapshotProducer<'a> {
 
         summary_collector.set_partition_summary_limit(partition_summary_limit);
 
+        let partition_spec = |file: &DataFile| {
+            table_metadata
+                .partition_spec_by_id(file.partition_spec_id)
+                .cloned()
+                .ok_or_else(|| {
+                    Error::new(
+                        ErrorKind::DataInvalid,
+                        "File references an unknown partition spec",
+                    )
+                    .with_context("partition spec id", file.partition_spec_id.to_string())
+                    .with_context("file path", file.file_path())
+                })
+        };
+
         for data_file in &self.added_data_files {
             summary_collector.add_file(
                 data_file,
                 table_metadata.current_schema().clone(),
-                table_metadata.default_partition_spec().clone(),
+                partition_spec(data_file)?,
             );
         }
 
-        let previous_snapshot = table_metadata.current_snapshot();
+        for delete_file in &self.added_delete_files {
+            summary_collector.add_file(
+                delete_file,
+                table_metadata.current_schema().clone(),
+                partition_spec(delete_file)?,
+            );
+        }
+
+        for data_file in &self.removed_data_files {
+            summary_collector.remove_file(
+                data_file,
+                table_metadata.current_schema().clone(),
+                partition_spec(data_file)?,
+            );
+        }
+
+        for delete_file in &self.removed_delete_files {
+            summary_collector.remove_file(
+                delete_file,
+                table_metadata.current_schema().clone(),
+                partition_spec(delete_file)?,
+            );
+        }
+
+        let previous_snapshot = table_metadata.snapshot_for_ref(&self.target_branch);
 
         // User-supplied snapshot properties are applied first, then the computed
         // metrics overwrite any colliding keys. This matches iceberg-java
@@ -421,11 +662,7 @@ impl<'a> SnapshotProducer<'a> {
             additional_properties,
         };
 
-        update_snapshot_summaries(
-            summary,
-            previous_snapshot.map(|s| s.summary()),
-            snapshot_produce_operation.operation() == Operation::Overwrite,
-        )
+        update_snapshot_summaries(summary, previous_snapshot.map(|s| s.summary()), false)
     }
 
     fn generate_manifest_list_file_path(&self, attempt: i64) -> Result<String> {
@@ -448,6 +685,11 @@ impl<'a> SnapshotProducer<'a> {
         let manifest_list_path = self.generate_manifest_list_file_path(0)?;
         let next_seq_num = self.table.metadata().next_sequence_number();
         let first_row_id = self.table.metadata().next_row_id();
+        let parent_snapshot_id = self
+            .table
+            .metadata()
+            .snapshot_for_ref(&self.target_branch)
+            .map(|snapshot| snapshot.snapshot_id());
 
         let raw_output = self
             .table
@@ -465,7 +707,6 @@ impl<'a> SnapshotProducer<'a> {
             None => (raw_output.writer().await?, None),
         };
 
-        let parent_snapshot_id = self.table.metadata().current_snapshot_id();
         let mut manifest_list_writer = match self.table.metadata().format_version() {
             FormatVersion::V1 => {
                 ManifestListWriter::v1(writer, self.snapshot_id, parent_snapshot_id)
@@ -482,9 +723,8 @@ impl<'a> SnapshotProducer<'a> {
             ),
         };
 
-        // Calling self.summary() before self.produce_manifests() is important because self.added_data_files
-        // will be set to an empty vec after self.produce_manifests() returns, resulting in an empty summary
-        // being generated.
+        // Build the summary before `produce_manifests`, which drains the added
+        // data and delete file vectors.
         let summary = self.summary(&snapshot_produce_operation).map_err(|err| {
             Error::new(ErrorKind::Unexpected, "Failed to create snapshot summary.").with_source(err)
         })?;
@@ -501,7 +741,7 @@ impl<'a> SnapshotProducer<'a> {
         let new_snapshot = Snapshot::builder()
             .with_manifest_list(manifest_list_path)
             .with_snapshot_id(self.snapshot_id)
-            .with_parent_snapshot_id(self.table.metadata().current_snapshot_id())
+            .with_parent_snapshot_id(parent_snapshot_id)
             .with_sequence_number(next_seq_num)
             .with_summary(summary)
             .with_schema_id(self.table.metadata().current_schema_id())
@@ -537,7 +777,7 @@ impl<'a> SnapshotProducer<'a> {
                 snapshot: new_snapshot,
             },
             TableUpdate::SetSnapshotRef {
-                ref_name: MAIN_BRANCH.to_string(),
+                ref_name: self.target_branch.clone(),
                 reference: SnapshotReference::new(
                     self.snapshot_id,
                     SnapshotRetention::branch(None, None, None),
@@ -551,11 +791,50 @@ impl<'a> SnapshotProducer<'a> {
                 uuid: self.table.metadata().uuid(),
             },
             TableRequirement::RefSnapshotIdMatch {
-                r#ref: MAIN_BRANCH.to_string(),
-                snapshot_id: self.table.metadata().current_snapshot_id(),
+                r#ref: self.target_branch,
+                snapshot_id: parent_snapshot_id,
             },
         ];
 
         Ok(ActionCommit::new(updates, requirements))
+    }
+
+    pub(crate) fn set_new_data_file_sequence_number(&mut self, sequence_number: i64) {
+        self.new_data_file_sequence_number = Some(sequence_number);
+    }
+
+    pub(crate) fn set_target_branch(&mut self, target_branch: String) {
+        self.target_branch = target_branch;
+    }
+
+    pub(crate) fn target_branch(&self) -> &str {
+        &self.target_branch
+    }
+
+    pub(crate) fn enable_delete_filter_manager(&mut self) -> Result<()> {
+        if self.delete_filter_manager.is_some() {
+            return Ok(());
+        }
+
+        let metadata = self.table.metadata();
+        let mut manager = ManifestFilterManager::new(
+            self.table.file_io().clone(),
+            ManifestWriterContext::new(
+                metadata.metadata_location()?,
+                self.commit_uuid,
+                self.manifest_counter.clone(),
+                metadata.format_version(),
+                self.snapshot_id,
+                self.table.file_io().clone(),
+                self.table.encryption_manager_ref(),
+            ),
+        );
+
+        for file in &self.removed_delete_files {
+            manager.delete_file(file.clone())?;
+        }
+
+        self.delete_filter_manager = Some(manager);
+        Ok(())
     }
 }


### PR DESCRIPTION
## Which issue does this PR close?

- Part of #191.

## What changes are included in this PR?

- Port the final unified `ReplaceFiles` design as `RewriteFilesAction` and `OverwriteFilesAction`, including pre-generated snapshot IDs, target branches, data sequence-number overrides, optional existence validation, and correct DATA/DELETE manifest output.
- Rebase `SnapshotProducer` and `FastAppendAction` on current upstream snapshot-summary, encryption, manifest-list, row-lineage, and runtime APIs; support added delete files without restoring the unused `MergeAppend` action.
- Add encryption-aware manifest filtering and enable dangling-delete cleanup by default for replace operations, while keeping an explicit opt-out.
- Treat deletion vectors by `(path, offset, length)` identity so filtering, validation, explicit deletion, and append deduplication preserve sibling blobs in a shared Puffin file.
- Add regression coverage for branch commits, partition-spec preservation, sequence-number behavior, encrypted manifests, DELETE-manifest semantics, existence validation, and shared-Puffin deletion vectors.

## Are these changes tested?

- `cargo +nightly-2026-03-05 test -p iceberg --lib` (1509 passed)
- `cargo +nightly-2026-03-05 clippy -p iceberg --all-targets --all-features -- -D warnings`
- Public API snapshot regenerated and verified exactly
- `cargo +nightly-2026-03-05 fmt --all -- --check`
- `git diff --check`
