### PR TITLE
fix(arrow): propagate equality delete load failures

### DIFF
--- a/crates/iceberg/src/arrow/caching_delete_file_loader.rs
+++ b/crates/iceberg/src/arrow/caching_delete_file_loader.rs
@@ -24,7 +24,7 @@ use futures::{StreamExt, TryStreamExt};
 use hashbrown::HashMap;
 use tokio::sync::oneshot::{Receiver, channel};
 
-use super::delete_filter::{DeleteFilter, PosDelLoadAction};
+use super::delete_filter::{DeleteFilter, EqDelLoadGuard, PosDelLoadAction};
 use crate::arrow::delete_file_loader::BasicDeleteFileLoader;
 use crate::arrow::{arrow_primitive_to_literal, arrow_schema_to_schema};
 use crate::delete_vector::{DELETION_VECTOR_PROPERTY_REFERENCED_DATA_FILE, DeleteVector};
@@ -68,7 +68,7 @@ enum DeleteFileContext {
     FreshEqDel {
         batch_stream: ArrowRecordBatchStream,
         equality_ids: HashSet<i32>,
-        sender: tokio::sync::oneshot::Sender<Predicate>,
+        load_guard: EqDelLoadGuard,
     },
 }
 
@@ -274,30 +274,45 @@ impl CachingDeleteFileLoader {
             }
 
             DataContentType::EqualityDeletes => {
-                let Some(notify) = del_filter.try_start_eq_del_load(task.data_file_path()) else {
+                let Some(load_guard) = del_filter.try_start_eq_del_load(task.data_file_path())
+                else {
                     return Ok(DeleteFileContext::ExistingEqDel);
                 };
 
-                let (sender, receiver) = channel();
-                del_filter.insert_equality_delete(task.data_file_path(), receiver);
+                let load_result: Result<_> = async {
+                    // Per the Iceberg spec, evolve schema for equality deletes but only for the
+                    // equality_ids columns, not all table columns.
+                    let equality_ids_vec = task.equality_ids.clone().ok_or_else(|| {
+                        Error::new(
+                            ErrorKind::DataInvalid,
+                            "Equality delete file is missing equality IDs",
+                        )
+                        .with_context("file_path", task.data_file_path())
+                    })?;
+                    let evolved_stream = BasicDeleteFileLoader::evolve_schema(
+                        basic_delete_file_loader
+                            .parquet_to_batch_stream(task.data_file_path(), task.file_size_in_bytes)
+                            .await?,
+                        schema,
+                        &equality_ids_vec,
+                    )
+                    .await?;
 
-                // Per the Iceberg spec, evolve schema for equality deletes but only for the
-                // equality_ids columns, not all table columns.
-                let equality_ids_vec = task.equality_ids.clone().unwrap();
-                let evolved_stream = BasicDeleteFileLoader::evolve_schema(
-                    basic_delete_file_loader
-                        .parquet_to_batch_stream(task.data_file_path(), task.file_size_in_bytes)
-                        .await?,
-                    schema,
-                    &equality_ids_vec,
-                )
-                .await?;
+                    Ok((evolved_stream, HashSet::from_iter(equality_ids_vec)))
+                }
+                .await;
 
-                Ok(DeleteFileContext::FreshEqDel {
-                    batch_stream: evolved_stream,
-                    sender,
-                    equality_ids: HashSet::from_iter(equality_ids_vec),
-                })
+                match load_result {
+                    Ok((batch_stream, equality_ids)) => Ok(DeleteFileContext::FreshEqDel {
+                        batch_stream,
+                        equality_ids,
+                        load_guard,
+                    }),
+                    Err(error) => {
+                        load_guard.fail(&error);
+                        Err(error)
+                    }
+                }
             }
 
             DataContentType::Data => Err(Error::new(
@@ -348,23 +363,24 @@ impl CachingDeleteFileLoader {
                 })
             }
             DeleteFileContext::FreshEqDel {
-                sender,
                 batch_stream,
                 equality_ids,
+                load_guard,
             } => {
-                let predicate =
+                let result =
                     Self::parse_equality_deletes_record_batch_stream(batch_stream, equality_ids)
-                        .await?;
+                        .await;
 
-                sender
-                    .send(predicate)
-                    .map_err(|err| {
-                        Error::new(
-                            ErrorKind::Unexpected,
-                            "Could not send eq delete predicate to state",
-                        )
-                    })
-                    .map(|_| ParsedDeleteFileContext::EqDel)
+                match result {
+                    Ok(predicate) => {
+                        load_guard.finish(predicate);
+                        Ok(ParsedDeleteFileContext::EqDel)
+                    }
+                    Err(error) => {
+                        load_guard.fail(&error);
+                        Err(error)
+                    }
+                }
             }
         }
     }
@@ -714,6 +730,7 @@ mod tests {
     use std::collections::HashMap;
     use std::fs::File;
     use std::sync::Arc;
+    use std::time::Duration;
 
     use arrow_array::cast::AsArray;
     use arrow_array::{
@@ -760,6 +777,118 @@ mod tests {
         let expected = "(((((y != 1) OR (z != 100)) OR (a != \"HELP\")) OR (sa != 4)) OR (b != 62696E6172795F64617461)) AND (((((y != 2) OR (z IS NOT NULL)) OR (a IS NOT NULL)) OR (sa != 5)) OR (b IS NOT NULL))".to_string();
 
         assert_eq!(parsed_eq_delete.to_string(), expected);
+    }
+
+    #[tokio::test]
+    async fn test_equality_delete_read_failure_allows_retry() {
+        let tmp_dir = TempDir::new().unwrap();
+        let table_location = tmp_dir.path().as_os_str().to_str().unwrap();
+        let file_io = FileIO::from_path(table_location).unwrap().build().unwrap();
+        let delete_file_loader = CachingDeleteFileLoader::new(file_io, 10);
+
+        let table_schema = Arc::new(
+            Schema::builder()
+                .with_fields(vec![
+                    crate::spec::NestedField::optional(
+                        2,
+                        "y",
+                        crate::spec::Type::Primitive(crate::spec::PrimitiveType::Long),
+                    )
+                    .into(),
+                    crate::spec::NestedField::optional(
+                        3,
+                        "z",
+                        crate::spec::Type::Primitive(crate::spec::PrimitiveType::Long),
+                    )
+                    .into(),
+                ])
+                .build()
+                .unwrap(),
+        );
+
+        let equality_delete_path = format!("{table_location}/equality-deletes-1.parquet");
+        let mut equality_delete_task = FileScanTask {
+            file_size_in_bytes: 0,
+            start: 0,
+            length: 0,
+            record_count: None,
+            data_file_path: equality_delete_path.clone(),
+            referenced_data_file: None,
+            data_file_content: DataContentType::EqualityDeletes,
+            data_file_format: DataFileFormat::Parquet,
+            schema: table_schema.clone(),
+            project_field_ids: vec![],
+            predicate: None,
+            deletes: vec![],
+            sequence_number: 0,
+            equality_ids: Some(vec![2, 3]),
+            partition: None,
+            partition_spec: None,
+            name_mapping: None,
+            case_sensitive: false,
+        };
+
+        let first_result = tokio::time::timeout(
+            Duration::from_secs(5),
+            delete_file_loader.load_deletes(
+                &[Arc::new(equality_delete_task.clone())],
+                table_schema.clone(),
+            ),
+        )
+        .await
+        .expect("missing equality delete read hung")
+        .expect("delete loader task ended without a result");
+        assert!(first_result.is_err());
+
+        assert_eq!(
+            setup_write_equality_delete_file_1(table_location),
+            equality_delete_path
+        );
+        equality_delete_task.file_size_in_bytes =
+            std::fs::metadata(&equality_delete_path).unwrap().len();
+        let equality_delete_task = Arc::new(equality_delete_task);
+
+        let delete_filter = tokio::time::timeout(
+            Duration::from_secs(5),
+            delete_file_loader.load_deletes(
+                std::slice::from_ref(&equality_delete_task),
+                table_schema.clone(),
+            ),
+        )
+        .await
+        .expect("equality delete retry hung")
+        .expect("delete loader task ended without a result")
+        .expect("equality delete retry failed");
+
+        let data_file_task = FileScanTask {
+            file_size_in_bytes: 0,
+            start: 0,
+            length: 0,
+            record_count: None,
+            data_file_path: format!("{table_location}/data.parquet"),
+            referenced_data_file: None,
+            data_file_content: DataContentType::Data,
+            data_file_format: DataFileFormat::Parquet,
+            schema: table_schema,
+            project_field_ids: vec![2, 3],
+            predicate: None,
+            deletes: vec![equality_delete_task],
+            sequence_number: 0,
+            equality_ids: None,
+            partition: None,
+            partition_spec: None,
+            name_mapping: None,
+            case_sensitive: false,
+        };
+
+        let predicate = tokio::time::timeout(
+            Duration::from_secs(5),
+            delete_filter.build_equality_delete_predicate(&data_file_task),
+        )
+        .await
+        .expect("equality delete predicate build hung")
+        .expect("equality delete predicate build failed");
+        assert!(predicate.is_some());
     }
 
     /// Create a simple field with metadata.

--- a/crates/iceberg/src/arrow/caching_delete_file_loader.rs
+++ b/crates/iceberg/src/arrow/caching_delete_file_loader.rs
@@ -108,8 +108,11 @@ impl CachingDeleteFileLoader {
     ///    another concurrently processing data file scan task. If it is, we skip it.
     ///    If not, the DeleteFilter records a shared result receiver and returns a load guard that
     ///    prevents other tasks from loading the same file. The task streams and parses the file,
-    ///    then uses the guard to publish success or failure to every waiter. Failed or cancelled
-    ///    loads are removed from the cache so a later call can retry them.
+    ///    then uses the guard to publish success or failure to every waiter. Failures stay cached
+    ///    so that consumers arriving later still observe the original error: retryable failures
+    ///    (including cancelled loads) can be reclaimed and retried by a later call, while
+    ///    non-retryable failures keep serving the recorded error instead of re-reading a file
+    ///    that cannot be read successfully.
     ///  * When this gets updated to add support for delete vectors, the load phase will return
     ///    a PuffinReader for them.
     ///  * The parse phase parses each record batch stream according to its associated data type.
@@ -780,11 +783,11 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_equality_delete_read_failure_allows_retry() {
+    async fn test_equality_delete_read_failure_is_cached_and_fresh_loader_retries() {
         let tmp_dir = TempDir::new().unwrap();
         let table_location = tmp_dir.path().as_os_str().to_str().unwrap();
         let file_io = FileIO::from_path(table_location).unwrap().build().unwrap();
-        let delete_file_loader = CachingDeleteFileLoader::new(file_io, 10);
+        let delete_file_loader = CachingDeleteFileLoader::new(file_io.clone(), 10);
 
         let table_schema = Arc::new(
             Schema::builder()
@@ -828,7 +831,7 @@ mod tests {
             case_sensitive: false,
         };
 
-        let first_result = tokio::time::timeout(
+        let first_error = tokio::time::timeout(
             Duration::from_secs(5),
             delete_file_loader.load_deletes(
                 &[Arc::new(equality_delete_task.clone())],
@@ -837,30 +840,10 @@ mod tests {
         )
         .await
         .expect("missing equality delete read hung")
-        .expect("delete loader task ended without a result");
-        assert!(first_result.is_err());
-
-        assert_eq!(
-            setup_write_equality_delete_file_1(table_location),
-            equality_delete_path
-        );
-        equality_delete_task.file_size_in_bytes =
-            std::fs::metadata(&equality_delete_path).unwrap().len();
-        let equality_delete_task = Arc::new(equality_delete_task);
-
-        let delete_filter = tokio::time::timeout(
-            Duration::from_secs(5),
-            delete_file_loader.load_deletes(
-                std::slice::from_ref(&equality_delete_task),
-                table_schema.clone(),
-            ),
-        )
-        .await
-        .expect("equality delete retry hung")
         .expect("delete loader task ended without a result")
-        .expect("equality delete retry failed");
+        .expect_err("reading a missing equality delete file should fail");
 
-        let data_file_task = FileScanTask {
+        let make_data_file_task = |equality_delete_task: Arc<FileScanTask>| FileScanTask {
             file_size_in_bytes: 0,
             start: 0,
             length: 0,
@@ -869,7 +852,7 @@ mod tests {
             referenced_data_file: None,
             data_file_content: DataContentType::Data,
             data_file_format: DataFileFormat::Parquet,
-            schema: table_schema,
+            schema: table_schema.clone(),
             project_field_ids: vec![2, 3],
             predicate: None,
             deletes: vec![equality_delete_task],
@@ -881,9 +864,61 @@ mod tests {
             case_sensitive: false,
         };
 
+        // The read failure is not retryable, so the same loader keeps serving the
+        // original error to consumers that arrive after the failure — even though
+        // they never observed the `Loading` state — instead of a generic missing
+        // predicate error or a doomed re-read.
+        let late_filter = tokio::time::timeout(
+            Duration::from_secs(5),
+            delete_file_loader.load_deletes(
+                &[Arc::new(equality_delete_task.clone())],
+                table_schema.clone(),
+            ),
+        )
+        .await
+        .expect("second equality delete load hung")
+        .expect("delete loader task ended without a result")
+        .expect("skipping a cached failed load must not fail the load phase");
+        let cached_error = tokio::time::timeout(
+            Duration::from_secs(5),
+            late_filter.build_equality_delete_predicate(&make_data_file_task(Arc::new(
+                equality_delete_task.clone(),
+            ))),
+        )
+        .await
+        .expect("cached equality delete failure lookup hung")
+        .expect_err("cached equality delete failure should propagate to late consumers");
+        assert_eq!(cached_error.kind(), first_error.kind());
+        assert_eq!(cached_error.message(), first_error.message());
+        assert_eq!(cached_error.retryable(), first_error.retryable());
+
+        // A fresh loader (e.g. a new scan attempt) is unaffected by the cached
+        // failure and can load the file once it becomes readable.
+        assert_eq!(
+            setup_write_equality_delete_file_1(table_location),
+            equality_delete_path
+        );
+        equality_delete_task.file_size_in_bytes =
+            std::fs::metadata(&equality_delete_path).unwrap().len();
+        let equality_delete_task = Arc::new(equality_delete_task);
+
+        let fresh_loader = CachingDeleteFileLoader::new(file_io, 10);
+        let delete_filter = tokio::time::timeout(
+            Duration::from_secs(5),
+            fresh_loader.load_deletes(
+                std::slice::from_ref(&equality_delete_task),
+                table_schema.clone(),
+            ),
+        )
+        .await
+        .expect("equality delete retry hung")
+        .expect("delete loader task ended without a result")
+        .expect("equality delete retry failed");
+
         let predicate = tokio::time::timeout(
             Duration::from_secs(5),
-            delete_filter.build_equality_delete_predicate(&data_file_task),
+            delete_filter
+                .build_equality_delete_predicate(&make_data_file_task(equality_delete_task)),
         )
         .await
         .expect("equality delete predicate build hung")

--- a/crates/iceberg/src/arrow/caching_delete_file_loader.rs
+++ b/crates/iceberg/src/arrow/caching_delete_file_loader.rs
@@ -95,9 +95,9 @@ impl CachingDeleteFileLoader {
 
     /// Initiates loading of all deletes for all the specified tasks
     ///
-    /// Returned future completes once all positional deletes and delete vectors
-    /// have loaded. EQ deletes are not waited for in this method but the returned
-    /// DeleteFilter will await their loading when queried for them.
+    /// The returned future completes once all newly claimed delete files have loaded.
+    /// Equality deletes already being loaded by another concurrent call are shared; the
+    /// returned DeleteFilter awaits their published result when queried.
     ///
     ///  * Create a single stream of all delete file tasks irrespective of type,
     ///    so that we can respect the combined concurrency limit
@@ -106,18 +106,18 @@ impl CachingDeleteFileLoader {
     ///    stream the file contents out
     ///  * for eq deletes, we first check if the EQ delete is already loaded or being loaded by
     ///    another concurrently processing data file scan task. If it is, we skip it.
-    ///    If not, the DeleteFilter is updated to contain a notifier to prevent other data file
-    ///    tasks from starting to load the same equality delete file. We spawn a task to load
-    ///    the EQ delete's record batch stream, convert it to a predicate, update the delete filter,
-    ///    and notify any task that was waiting for it.
+    ///    If not, the DeleteFilter records a shared result receiver and returns a load guard that
+    ///    prevents other tasks from loading the same file. The task streams and parses the file,
+    ///    then uses the guard to publish success or failure to every waiter. Failed or cancelled
+    ///    loads are removed from the cache so a later call can retry them.
     ///  * When this gets updated to add support for delete vectors, the load phase will return
     ///    a PuffinReader for them.
     ///  * The parse phase parses each record batch stream according to its associated data type.
     ///    The result of this is a map of data file paths to delete vectors for the positional
     ///    delete tasks (and in future for the delete vector tasks). For equality delete
     ///    file tasks, this results in an unbound Predicate.
-    ///  * The unbound Predicates resulting from equality deletes are sent to their associated oneshot
-    ///    channel to store them in the right place in the delete file managers state.
+    ///  * The unbound Predicates resulting from equality deletes are committed through their load
+    ///    guards, which store successful predicates and publish the result to concurrent waiters.
     ///  * The results of all of these futures are awaited on in parallel with the specified
     ///    level of concurrency and collected into a vec. We then combine all the delete
     ///    vector maps that resulted from any positional delete or delete vector files into a
@@ -139,9 +139,9 @@ impl CachingDeleteFileLoader {
     ///                     Pos Del           Del Vec (Not yet Implemented)         EQ Del
     ///                       |                             |                          |
     ///              [parse pos del stream]         [parse del vec puffin]       [parse eq del]
-    ///          HashMap<String, RoaringTreeMap> HashMap<String, RoaringTreeMap>   (Predicate, Sender)
+    ///          HashMap<String, RoaringTreeMap> HashMap<String, RoaringTreeMap> (Predicate, LoadGuard)
     ///                       |                             |                          |
-    ///                       |                             |                 [persist to state]
+    ///                       |                             |              [publish result/state]
     ///                       |                             |                          ()
     ///                       |                             |                          |
     ///                       +-----------------------------+--------------------------+

--- a/crates/iceberg/src/arrow/delete_filter.rs
+++ b/crates/iceberg/src/arrow/delete_filter.rs
@@ -18,8 +18,7 @@
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex, RwLock};
 
-use tokio::sync::Notify;
-use tokio::sync::oneshot::Receiver;
+use tokio::sync::{Notify, watch};
 
 use crate::delete_vector::DeleteVector;
 use crate::expr::Predicate::AlwaysTrue;
@@ -30,8 +29,41 @@ use crate::{Error, ErrorKind, Result};
 
 #[derive(Debug)]
 enum EqDelState {
-    Loading(Arc<Notify>),
+    Loading(watch::Receiver<Option<EqDelLoadResult>>),
     Loaded(Predicate),
+}
+
+type EqDelLoadResult = std::result::Result<Predicate, EqDelLoadError>;
+
+#[derive(Clone, Debug)]
+struct EqDelLoadError {
+    kind: ErrorKind,
+    message: String,
+    retryable: bool,
+}
+
+impl EqDelLoadError {
+    fn from_error(error: &Error) -> Self {
+        Self {
+            kind: error.kind(),
+            message: error.to_string(),
+            retryable: error.retryable(),
+        }
+    }
+
+    fn cancelled() -> Self {
+        Self {
+            kind: ErrorKind::Unexpected,
+            message: "Equality delete load was cancelled before completion".to_string(),
+            retryable: true,
+        }
+    }
+
+    fn into_error(self, file_path: &str) -> Error {
+        Error::new(self.kind, self.message)
+            .with_context("file_path", file_path)
+            .with_retryable(self.retryable)
+    }
 }
 
 /// State tracking for positional delete files.
@@ -56,6 +88,44 @@ struct DeleteFileFilterState {
 #[derive(Clone, Debug, Default)]
 pub(crate) struct DeleteFilter {
     state: Arc<RwLock<DeleteFileFilterState>>,
+}
+
+pub(crate) struct EqDelLoadGuard {
+    filter: DeleteFilter,
+    file_path: String,
+    sender: watch::Sender<Option<EqDelLoadResult>>,
+    completed: bool,
+}
+
+impl EqDelLoadGuard {
+    pub(crate) fn finish(mut self, predicate: Predicate) {
+        self.filter
+            .complete_eq_del_load(&self.file_path, &self.sender, Ok(predicate));
+        self.completed = true;
+    }
+
+    pub(crate) fn fail(mut self, error: &Error) {
+        self.filter.complete_eq_del_load(
+            &self.file_path,
+            &self.sender,
+            Err(EqDelLoadError::from_error(error)),
+        );
+        self.completed = true;
+    }
+}
+
+impl Drop for EqDelLoadGuard {
+    fn drop(&mut self) {
+        if self.completed {
+            return;
+        }
+
+        self.filter.complete_eq_del_load(
+            &self.file_path,
+            &self.sender,
+            Err(EqDelLoadError::cancelled()),
+        );
+    }
 }
 
 /// Action to take when trying to start loading a positional delete file
@@ -90,7 +160,7 @@ impl DeleteFilter {
             .and_then(|st| st.delete_vectors.get(data_file_path).cloned())
     }
 
-    pub(crate) fn try_start_eq_del_load(&self, file_path: &str) -> Option<Arc<Notify>> {
+    pub(crate) fn try_start_eq_del_load(&self, file_path: &str) -> Option<EqDelLoadGuard> {
         let mut state = self.state.write().unwrap();
 
         // Skip if already loaded/loading - another task owns it
@@ -99,12 +169,17 @@ impl DeleteFilter {
         }
 
         // Mark as loading to prevent duplicate work
-        let notifier = Arc::new(Notify::new());
+        let (sender, receiver) = watch::channel(None);
         state
             .equality_deletes
-            .insert(file_path.to_string(), EqDelState::Loading(notifier.clone()));
+            .insert(file_path.to_string(), EqDelState::Loading(receiver));
 
-        Some(notifier)
+        Some(EqDelLoadGuard {
+            filter: self.clone(),
+            file_path: file_path.to_string(),
+            sender,
+            completed: false,
+        })
     }
 
     /// Attempts to mark a positional delete file as "loading".
@@ -152,22 +227,32 @@ impl DeleteFilter {
     pub(crate) async fn get_equality_delete_predicate_for_delete_file_path(
         &self,
         file_path: &str,
-    ) -> Option<Predicate> {
-        let notifier = {
+    ) -> Result<Option<Predicate>> {
+        let mut receiver = {
             match self.state.read().unwrap().equality_deletes.get(file_path) {
-                None => return None,
-                Some(EqDelState::Loading(notifier)) => notifier.clone(),
+                None => return Ok(None),
+                Some(EqDelState::Loading(receiver)) => receiver.clone(),
                 Some(EqDelState::Loaded(predicate)) => {
-                    return Some(predicate.clone());
+                    return Ok(Some(predicate.clone()));
                 }
             }
         };
 
-        notifier.notified().await;
+        loop {
+            if let Some(result) = { receiver.borrow_and_update().clone() } {
+                return result
+                    .map(Some)
+                    .map_err(|error| error.into_error(file_path));
+            }
 
-        match self.state.read().unwrap().equality_deletes.get(file_path) {
-            Some(EqDelState::Loaded(predicate)) => Some(predicate.clone()),
-            _ => unreachable!("Cannot be any other state than loaded"),
+            receiver.changed().await.map_err(|_| {
+                Error::new(
+                    ErrorKind::Unexpected,
+                    "Equality delete load ended without publishing a result",
+                )
+                .with_context("file_path", file_path)
+                .with_retryable(true)
+            })?;
         }
     }
 
@@ -189,7 +274,7 @@ impl DeleteFilter {
 
             let Some(predicate) = self
                 .get_equality_delete_predicate_for_delete_file_path(delete.data_file_path())
-                .await
+                .await?
             else {
                 return Err(Error::new(
                     ErrorKind::Unexpected,
@@ -229,32 +314,25 @@ impl DeleteFilter {
         *entry.lock().unwrap() |= delete_vector;
     }
 
-    pub(crate) fn insert_equality_delete(
+    fn complete_eq_del_load(
         &self,
         delete_file_path: &str,
-        eq_del: Receiver<Predicate>,
+        sender: &watch::Sender<Option<EqDelLoadResult>>,
+        result: EqDelLoadResult,
     ) {
-        let notify = Arc::new(Notify::new());
-        {
-            let mut state = self.state.write().unwrap();
-            state.equality_deletes.insert(
-                delete_file_path.to_string(),
-                EqDelState::Loading(notify.clone()),
-            );
-        }
-
-        let state = self.state.clone();
-        let delete_file_path = delete_file_path.to_string();
-        crate::runtime::spawn(async move {
-            let eq_del = eq_del.await.unwrap();
-            {
-                let mut state = state.write().unwrap();
-                state
-                    .equality_deletes
-                    .insert(delete_file_path, EqDelState::Loaded(eq_del));
+        let mut state = self.state.write().unwrap();
+        match &result {
+            Ok(predicate) => {
+                state.equality_deletes.insert(
+                    delete_file_path.to_string(),
+                    EqDelState::Loaded(predicate.clone()),
+                );
             }
-            notify.notify_waiters();
-        });
+            Err(_) => {
+                state.equality_deletes.remove(delete_file_path);
+            }
+        }
+        sender.send_replace(Some(result));
     }
 }
 
@@ -267,6 +345,7 @@ pub(crate) mod tests {
     use std::fs::File;
     use std::path::Path;
     use std::sync::Arc;
+    use std::time::Duration;
 
     use arrow_array::{Int64Array, RecordBatch, StringArray};
     use arrow_schema::Schema as ArrowSchema;
@@ -285,6 +364,60 @@ pub(crate) mod tests {
 
     const FIELD_ID_POSITIONAL_DELETE_FILE_PATH: u64 = 2147483546;
     const FIELD_ID_POSITIONAL_DELETE_POS: u64 = 2147483545;
+
+    #[tokio::test]
+    async fn test_equality_delete_load_failure_wakes_waiters_and_allows_retry() {
+        let filter = DeleteFilter::default();
+        let load_guard = filter.try_start_eq_del_load("eq-del.parquet").unwrap();
+
+        let waiter_one =
+            filter.get_equality_delete_predicate_for_delete_file_path("eq-del.parquet");
+        let waiter_two =
+            filter.get_equality_delete_predicate_for_delete_file_path("eq-del.parquet");
+        tokio::pin!(waiter_one);
+        tokio::pin!(waiter_two);
+
+        assert!(futures::poll!(&mut waiter_one).is_pending());
+        assert!(futures::poll!(&mut waiter_two).is_pending());
+
+        let load_error =
+            Error::new(ErrorKind::Unexpected, "io timeout reached").with_retryable(true);
+        load_guard.fail(&load_error);
+
+        for waiter in [waiter_one, waiter_two] {
+            let error = tokio::time::timeout(Duration::from_secs(1), waiter)
+                .await
+                .expect("equality delete waiter hung")
+                .expect_err("failed equality delete load should propagate an error");
+            assert!(error.to_string().contains("io timeout reached"));
+            assert!(error.retryable());
+        }
+
+        let predicate = Reference::new("id").equal_to(Datum::long(10));
+        filter
+            .try_start_eq_del_load("eq-del.parquet")
+            .expect("failed loads must be retryable")
+            .finish(predicate.clone());
+
+        assert_eq!(
+            filter
+                .get_equality_delete_predicate_for_delete_file_path("eq-del.parquet")
+                .await
+                .unwrap(),
+            Some(predicate)
+        );
+
+        let cancelled_guard = filter
+            .try_start_eq_del_load("cancelled-eq-del.parquet")
+            .unwrap();
+        drop(cancelled_guard);
+        assert!(
+            filter
+                .try_start_eq_del_load("cancelled-eq-del.parquet")
+                .is_some(),
+            "dropping an in-flight load must not leave a stale Loading entry"
+        );
+    }
 
     #[tokio::test]
     async fn test_delete_file_filter_load_deletes() {
@@ -528,10 +661,10 @@ pub(crate) mod tests {
         // ---------- insert equality delete predicate ----------
         let pred = Reference::new("id").equal_to(Datum::long(10));
 
-        let (tx, rx) = tokio::sync::oneshot::channel();
-        filter.insert_equality_delete("eq-del.parquet", rx);
-
-        tx.send(pred).unwrap();
+        filter
+            .try_start_eq_del_load("eq-del.parquet")
+            .unwrap()
+            .finish(pred);
 
         // ---------- should FAIL ----------
         let result = filter.build_equality_delete_predicate(&task).await;

--- a/crates/iceberg/src/arrow/delete_filter.rs
+++ b/crates/iceberg/src/arrow/delete_filter.rs
@@ -46,7 +46,7 @@ impl EqDelLoadError {
     fn from_error(error: &Error) -> Self {
         Self {
             kind: error.kind(),
-            message: error.to_string(),
+            message: error.message().to_string(),
             retryable: error.retryable(),
         }
     }
@@ -389,7 +389,8 @@ pub(crate) mod tests {
                 .await
                 .expect("equality delete waiter hung")
                 .expect_err("failed equality delete load should propagate an error");
-            assert!(error.to_string().contains("io timeout reached"));
+            assert_eq!(error.kind(), ErrorKind::Unexpected);
+            assert_eq!(error.message(), "io timeout reached");
             assert!(error.retryable());
         }
 

--- a/crates/iceberg/src/arrow/delete_filter.rs
+++ b/crates/iceberg/src/arrow/delete_filter.rs
@@ -31,6 +31,13 @@ use crate::{Error, ErrorKind, Result};
 enum EqDelState {
     Loading(watch::Receiver<Option<EqDelLoadResult>>),
     Loaded(Predicate),
+    /// The load finished with an error. The entry is kept in the cache so that
+    /// consumers arriving after the failure still observe the original error
+    /// (with its `retryable` flag) instead of a generic "missing predicate".
+    /// Retryable failures may be reclaimed by [`DeleteFilter::try_start_eq_del_load`];
+    /// non-retryable failures stay cached to avoid re-reading a file that
+    /// cannot be read successfully.
+    Failed(EqDelLoadError),
 }
 
 type EqDelLoadResult = std::result::Result<Predicate, EqDelLoadError>;
@@ -163,9 +170,16 @@ impl DeleteFilter {
     pub(crate) fn try_start_eq_del_load(&self, file_path: &str) -> Option<EqDelLoadGuard> {
         let mut state = self.state.write().unwrap();
 
-        // Skip if already loaded/loading - another task owns it
-        if state.equality_deletes.contains_key(file_path) {
-            return None;
+        match state.equality_deletes.get(file_path) {
+            // Skip if already loaded/loading - another task owns it
+            Some(EqDelState::Loading(_) | EqDelState::Loaded(_)) => return None,
+            // A non-retryable failure is cached: re-reading the file would fail
+            // identically, so keep serving the recorded error instead of
+            // re-issuing doomed reads.
+            Some(EqDelState::Failed(error)) if !error.retryable => return None,
+            // A retryable failure may be reclaimed so that this attempt can
+            // retry the load.
+            Some(EqDelState::Failed(_)) | None => {}
         }
 
         // Mark as loading to prevent duplicate work
@@ -234,6 +248,9 @@ impl DeleteFilter {
                 Some(EqDelState::Loading(receiver)) => receiver.clone(),
                 Some(EqDelState::Loaded(predicate)) => {
                     return Ok(Some(predicate.clone()));
+                }
+                Some(EqDelState::Failed(error)) => {
+                    return Err(error.clone().into_error(file_path));
                 }
             }
         };
@@ -320,7 +337,14 @@ impl DeleteFilter {
         sender: &watch::Sender<Option<EqDelLoadResult>>,
         result: EqDelLoadResult,
     ) {
-        let mut state = self.state.write().unwrap();
+        // This runs from `EqDelLoadGuard::drop` as well, so it must not panic on a
+        // poisoned lock: panicking while unwinding would abort the process. The
+        // guarded state stays consistent under poison recovery because the update
+        // below is a plain map insert.
+        let mut state = self
+            .state
+            .write()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         match &result {
             Ok(predicate) => {
                 state.equality_deletes.insert(
@@ -328,8 +352,11 @@ impl DeleteFilter {
                     EqDelState::Loaded(predicate.clone()),
                 );
             }
-            Err(_) => {
-                state.equality_deletes.remove(delete_file_path);
+            Err(error) => {
+                state.equality_deletes.insert(
+                    delete_file_path.to_string(),
+                    EqDelState::Failed(error.clone()),
+                );
             }
         }
         sender.send_replace(Some(result));
@@ -418,6 +445,42 @@ pub(crate) mod tests {
                 .is_some(),
             "dropping an in-flight load must not leave a stale Loading entry"
         );
+    }
+
+    #[tokio::test]
+    async fn test_late_consumers_observe_original_error_and_non_retryable_failures_are_cached() {
+        let filter = DeleteFilter::default();
+        let load_guard = filter.try_start_eq_del_load("eq-del.parquet").unwrap();
+
+        // Fail with a non-retryable error before any waiter registers.
+        let load_error = Error::new(ErrorKind::DataInvalid, "malformed equality delete file");
+        assert!(!load_error.retryable());
+        load_guard.fail(&load_error);
+
+        // A consumer arriving only after the failure (it never observed the
+        // `Loading` state) must still receive the original error with its
+        // retryable flag, not a generic "missing predicate" error.
+        let error = filter
+            .get_equality_delete_predicate_for_delete_file_path("eq-del.parquet")
+            .await
+            .expect_err("cached equality delete failure should propagate");
+        assert_eq!(error.kind(), ErrorKind::DataInvalid);
+        assert_eq!(error.message(), "malformed equality delete file");
+        assert!(!error.retryable());
+
+        // Non-retryable failures are cached: re-reading the file would fail
+        // identically, so no new load may be claimed.
+        assert!(
+            filter.try_start_eq_del_load("eq-del.parquet").is_none(),
+            "non-retryable failures must not be reloaded"
+        );
+
+        // The cached error keeps being served on subsequent lookups.
+        let error = filter
+            .get_equality_delete_predicate_for_delete_file_path("eq-del.parquet")
+            .await
+            .expect_err("cached equality delete failure should keep propagating");
+        assert_eq!(error.message(), "malformed equality delete file");
     }
 
     #[tokio::test]

--- a/crates/iceberg/src/arrow/reader.rs
+++ b/crates/iceberg/src/arrow/reader.rs
@@ -348,7 +348,12 @@ impl ArrowReader {
             record_batch_stream_builder = record_batch_stream_builder.with_batch_size(batch_size);
         }
 
-        let delete_filter = delete_filter_rx.await.unwrap()?;
+        let delete_filter = delete_filter_rx.await.map_err(|_| {
+            Error::new(
+                ErrorKind::Unexpected,
+                "Delete file loader ended without publishing a result",
+            )
+        })??;
         let delete_predicate = delete_filter.build_equality_delete_predicate(&task).await?;
 
         // In addition to the optional predicate supplied in the `FileScanTask`,

--- a/crates/iceberg/src/arrow/reader.rs
+++ b/crates/iceberg/src/arrow/reader.rs
@@ -353,6 +353,7 @@ impl ArrowReader {
                 ErrorKind::Unexpected,
                 "Delete file loader ended without publishing a result",
             )
+            .with_retryable(true)
         })??;
         let delete_predicate = delete_filter.build_equality_delete_predicate(&task).await?;
 


### PR DESCRIPTION
## Which issue does this PR close?

- Part of risingwavelabs/risingwave#26476.

## What changes are included in this PR?

- Replace the detached equality-delete oneshot receiver and its `unwrap()` with a per-load result channel.
- Publish success, failure, and cancellation to every existing waiter without a lost-wakeup window.
- Remove failed or cancelled loads from the cache so a later scan can retry the object read.
- Propagate the original error kind, message, and retryable flag to concurrent waiters.
- Return typed errors for missing equality IDs and an unexpectedly closed outer delete-loader channel.
