### PR TITLE
feat(iceberg): add orphan file size in response 

### DIFF
--- a/crates/iceberg/src/actions/remove_orphan_files.rs
+++ b/crates/iceberg/src/actions/remove_orphan_files.rs
@@ -40,6 +40,16 @@ const DEFAULT_LOAD_CONCURRENCY: usize = 16;
 /// Default concurrency limit for file deletion.
 const DEFAULT_DELETE_CONCURRENCY: usize = 10;
 
+/// A file under the table location that is not referenced by any snapshot
+/// or table metadata.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OrphanFile {
+    /// Absolute path of the orphan file.
+    pub path: String,
+    /// Size of the file in bytes, as reported by the storage listing.
+    pub size_bytes: u64,
+}
+
 /// Action to delete orphan files from a table's location.
 ///
 /// ```ignore
@@ -108,8 +118,8 @@ impl RemoveOrphanFilesAction {
         self
     }
 
-    /// Executes the action, returning the list of orphan files.
-    pub async fn execute(self) -> Result<Vec<String>> {
+    /// Executes the action, returning the list of orphan files with their sizes.
+    pub async fn execute(self) -> Result<Vec<OrphanFile>> {
         let file_io = self.table.file_io();
         let location = self.table.metadata().location();
 
@@ -121,7 +131,7 @@ impl RemoveOrphanFilesAction {
         let older_than_ms = self.older_than_ms;
 
         // Find orphan files: not reachable, not a directory, and older than threshold
-        let orphan_files: Vec<String> = file_stream
+        let orphan_files: Vec<OrphanFile> = file_stream
             .try_filter_map(|entry| {
                 let is_orphan =
                     // Must be a file (not directory)
@@ -132,7 +142,12 @@ impl RemoveOrphanFilesAction {
                     // (files without timestamp are skipped to protect in-progress writes)
                     && entry.metadata.last_modified_ms.is_some_and(|ts| ts < older_than_ms);
 
-                async move { Ok(is_orphan.then_some(entry.path)) }
+                async move {
+                    Ok(is_orphan.then_some(OrphanFile {
+                        path: entry.path,
+                        size_bytes: entry.metadata.size,
+                    }))
+                }
             })
             .try_collect()
             .await?;
@@ -146,7 +161,7 @@ impl RemoveOrphanFilesAction {
         // making the resulting future Send-safe (avoids HRTB lifetime issues
         // with borrowed references across await points).
         let file_io = file_io.clone();
-        stream::iter(orphan_files.clone())
+        stream::iter(orphan_files.iter().map(|f| f.path.clone()))
             .map(|path| {
                 let file_io = file_io.clone();
                 async move { file_io.delete(&path).await }

--- a/crates/iceberg/src/writer/file_writer/parquet_writer.rs
+++ b/crates/iceberg/src/writer/file_writer/parquet_writer.rs
@@ -110,6 +110,9 @@ impl FileWriterBuilder for ParquetWriterBuilder {
             current_row_num: 0,
             output_file,
             nan_value_count_visitor: NanValueCountVisitor::new_with_match_mode(self.match_mode),
+            accumulated_compressed: 0,
+            accumulated_uncompressed_proxy: 0,
+            last_bytes_written: 0,
         })
     }
 }
@@ -247,6 +250,17 @@ pub struct ParquetWriter {
     writer_properties: WriterProperties,
     current_row_num: usize,
     nan_value_count_visitor: NanValueCountVisitor,
+    // Compression ratio tracking for `current_written_size`.
+    //
+    // On each write we sample in_progress_size() before and bytes_written() after.
+    // When bytes_written increases a row-group flush occurred: the pre-write
+    // in_progress value is a proxy for the uncompressed bytes that were flushed,
+    // and the delta in bytes_written is the compressed output. Accumulating both
+    // lets current_written_size() extrapolate the buffered bytes using the
+    // observed ratio rather than returning raw (compressed) flushed bytes only.
+    accumulated_compressed: usize,
+    accumulated_uncompressed_proxy: usize,
+    last_bytes_written: usize,
 }
 
 /// Used to aggregate min and max value of each column.
@@ -549,6 +563,10 @@ impl FileWriter for ParquetWriter {
             self.inner_writer.as_mut().unwrap()
         };
 
+        // Sample in_progress BEFORE the write so we capture what was buffered
+        // at the moment the flush fires — not the stale value from the previous call.
+        let pre_in_progress = writer.in_progress_size();
+
         writer.write(batch).await.map_err(|err| {
             Error::new(
                 ErrorKind::Unexpected,
@@ -556,6 +574,16 @@ impl FileWriter for ParquetWriter {
             )
             .with_source(err)
         })?;
+
+        let post_bytes = writer.bytes_written();
+
+        // bytes_written only grows when a row-group is committed to the output.
+        // pre_in_progress is the uncompressed proxy for what was flushed.
+        if post_bytes > self.last_bytes_written && pre_in_progress > 0 {
+            self.accumulated_compressed += post_bytes - self.last_bytes_written;
+            self.accumulated_uncompressed_proxy += pre_in_progress;
+        }
+        self.last_bytes_written = post_bytes;
 
         Ok(())
     }
@@ -605,13 +633,21 @@ impl CurrentFileStatus for ParquetWriter {
     }
 
     fn current_written_size(&self) -> usize {
-        if let Some(inner) = self.inner_writer.as_ref() {
-            // inner/AsyncArrowWriter contains sync and async writers
-            // written size = bytes flushed to inner's async writer + bytes buffered in the inner's sync writer
-            inner.bytes_written() + inner.in_progress_size()
+        let Some(inner) = self.inner_writer.as_ref() else {
+            return 0;
+        };
+        let flushed = inner.bytes_written();
+        let in_progress = inner.in_progress_size();
+
+        if self.accumulated_uncompressed_proxy > 0 {
+            // Observed ratio from row-group flushes: both terms are in writer API units.
+            let ratio =
+                self.accumulated_compressed as f64 / self.accumulated_uncompressed_proxy as f64;
+            flushed + (in_progress as f64 * ratio) as usize
         } else {
-            // inner writer is not initialized yet
-            0
+            // No row group has been flushed yet; return only committed bytes.
+            // should_roll won't fire until the first flush gives us a real ratio.
+            flushed
         }
     }
 }

--- a/crates/iceberg/src/writer/file_writer/parquet_writer.rs
+++ b/crates/iceberg/src/writer/file_writer/parquet_writer.rs
@@ -110,9 +110,6 @@ impl FileWriterBuilder for ParquetWriterBuilder {
             current_row_num: 0,
             output_file,
             nan_value_count_visitor: NanValueCountVisitor::new_with_match_mode(self.match_mode),
-            accumulated_compressed: 0,
-            accumulated_uncompressed_proxy: 0,
-            last_bytes_written: 0,
         })
     }
 }
@@ -250,17 +247,6 @@ pub struct ParquetWriter {
     writer_properties: WriterProperties,
     current_row_num: usize,
     nan_value_count_visitor: NanValueCountVisitor,
-    // Compression ratio tracking for `current_written_size`.
-    //
-    // On each write we sample in_progress_size() before and bytes_written() after.
-    // When bytes_written increases a row-group flush occurred: the pre-write
-    // in_progress value is a proxy for the uncompressed bytes that were flushed,
-    // and the delta in bytes_written is the compressed output. Accumulating both
-    // lets current_written_size() extrapolate the buffered bytes using the
-    // observed ratio rather than returning raw (compressed) flushed bytes only.
-    accumulated_compressed: usize,
-    accumulated_uncompressed_proxy: usize,
-    last_bytes_written: usize,
 }
 
 /// Used to aggregate min and max value of each column.
@@ -563,10 +549,6 @@ impl FileWriter for ParquetWriter {
             self.inner_writer.as_mut().unwrap()
         };
 
-        // Sample in_progress BEFORE the write so we capture what was buffered
-        // at the moment the flush fires — not the stale value from the previous call.
-        let pre_in_progress = writer.in_progress_size();
-
         writer.write(batch).await.map_err(|err| {
             Error::new(
                 ErrorKind::Unexpected,
@@ -574,16 +556,6 @@ impl FileWriter for ParquetWriter {
             )
             .with_source(err)
         })?;
-
-        let post_bytes = writer.bytes_written();
-
-        // bytes_written only grows when a row-group is committed to the output.
-        // pre_in_progress is the uncompressed proxy for what was flushed.
-        if post_bytes > self.last_bytes_written && pre_in_progress > 0 {
-            self.accumulated_compressed += post_bytes - self.last_bytes_written;
-            self.accumulated_uncompressed_proxy += pre_in_progress;
-        }
-        self.last_bytes_written = post_bytes;
 
         Ok(())
     }
@@ -633,21 +605,13 @@ impl CurrentFileStatus for ParquetWriter {
     }
 
     fn current_written_size(&self) -> usize {
-        let Some(inner) = self.inner_writer.as_ref() else {
-            return 0;
-        };
-        let flushed = inner.bytes_written();
-        let in_progress = inner.in_progress_size();
-
-        if self.accumulated_uncompressed_proxy > 0 {
-            // Observed ratio from row-group flushes: both terms are in writer API units.
-            let ratio =
-                self.accumulated_compressed as f64 / self.accumulated_uncompressed_proxy as f64;
-            flushed + (in_progress as f64 * ratio) as usize
+        if let Some(inner) = self.inner_writer.as_ref() {
+            // inner/AsyncArrowWriter contains sync and async writers
+            // written size = bytes flushed to inner's async writer + bytes buffered in the inner's sync writer
+            inner.bytes_written() + inner.in_progress_size()
         } else {
-            // No row group has been flushed yet; return only committed bytes.
-            // should_roll won't fire until the first flush gives us a real ratio.
-            flushed
+            // inner writer is not initialized yet
+            0
         }
     }
 }

--- a/crates/integration_tests/tests/remove_orphan_files_test.rs
+++ b/crates/integration_tests/tests/remove_orphan_files_test.rs
@@ -150,9 +150,12 @@ async fn test_dry_run_and_delete() {
         .await
         .unwrap();
 
-    assert!(result.contains(&orphan_path), "Should find orphan file");
     assert!(
-        !result.iter().any(|p| valid_files.contains(p)),
+        result.iter().any(|f| f.path == orphan_path),
+        "Should find orphan file"
+    );
+    assert!(
+        !result.iter().any(|f| valid_files.contains(&f.path)),
         "Valid files not orphan"
     );
     assert!(
@@ -168,7 +171,10 @@ async fn test_dry_run_and_delete() {
         .await
         .unwrap();
 
-    assert!(result.contains(&orphan_path), "Should have deleted orphan");
+    assert!(
+        result.iter().any(|f| f.path == orphan_path),
+        "Should have deleted orphan"
+    );
     assert!(
         !table.file_io().exists(&orphan_path).await.unwrap(),
         "Orphan deleted"
@@ -221,7 +227,7 @@ async fn test_older_than_threshold() {
         .unwrap();
 
     assert!(
-        !result.contains(&orphan_path),
+        !result.iter().any(|f| f.path == orphan_path),
         "Should not find new orphan with past threshold"
     );
 
@@ -234,7 +240,7 @@ async fn test_older_than_threshold() {
         .unwrap();
 
     assert!(
-        result.contains(&orphan_path),
+        result.iter().any(|f| f.path == orphan_path),
         "Should find orphan with future threshold"
     );
 }
@@ -280,15 +286,15 @@ async fn test_preserves_metadata_files() {
         .await
         .unwrap();
 
-    let orphan_set: HashSet<_> = result.into_iter().collect();
+    let orphan_paths: HashSet<_> = result.iter().map(|f| f.path.as_str()).collect();
 
     // Verify metadata files NOT orphan
     if let Some(loc) = table.metadata_location() {
-        assert!(!orphan_set.contains(loc), "Current metadata not orphan");
+        assert!(!orphan_paths.contains(loc), "Current metadata not orphan");
     }
     for log in table.metadata().metadata_log() {
         assert!(
-            !orphan_set.contains(&log.metadata_file),
+            !orphan_paths.contains(log.metadata_file.as_str()),
             "Historical metadata not orphan"
         );
     }
@@ -296,14 +302,17 @@ async fn test_preserves_metadata_files() {
     // Verify manifest lists NOT orphan
     for snap in table.metadata().snapshots() {
         assert!(
-            !orphan_set.contains(snap.manifest_list()),
+            !orphan_paths.contains(snap.manifest_list()),
             "Manifest list not orphan"
         );
     }
 
     // Verify data files NOT orphan
     for f in &all_data_files {
-        assert!(!orphan_set.contains(f), "Data file not orphan: {f}");
+        assert!(
+            !orphan_paths.contains(f.as_str()),
+            "Data file not orphan: {f}"
+        );
     }
 }
 
@@ -358,15 +367,15 @@ async fn test_after_expire_snapshots() {
         .await
         .unwrap();
 
-    let orphan_set: HashSet<_> = result.into_iter().collect();
+    let orphan_paths: HashSet<_> = result.iter().map(|f| f.path.as_str()).collect();
 
     assert!(
-        !orphan_set.contains(&current_ml),
+        !orphan_paths.contains(current_ml.as_str()),
         "Current manifest list not orphan"
     );
     for ml in &expired_mls {
         assert!(
-            orphan_set.contains(ml),
+            orphan_paths.contains(ml.as_str()),
             "Expired manifest list should be orphan: {ml}"
         );
     }
@@ -490,18 +499,18 @@ async fn test_after_rewrite() {
         .await
         .unwrap();
 
-    let orphan_set: HashSet<_> = result.into_iter().collect();
+    let orphan_paths: HashSet<_> = result.iter().map(|f| f.path.as_str()).collect();
 
     // First manifest-list should be orphan
     assert!(
-        orphan_set.contains(&first_ml),
+        orphan_paths.contains(first_ml.as_str()),
         "First manifest-list should be orphan"
     );
 
     // First manifests should be orphan
     for m in &first_manifests {
         assert!(
-            orphan_set.contains(m),
+            orphan_paths.contains(m.as_str()),
             "First manifest should be orphan: {m}"
         );
     }


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #.

## What changes are included in this PR?

`RemoveOrphanFilesAction` now returns an `OrphanFile` containing:

- `path`: the orphan file’s absolute path
- `size_bytes`: the file size reported by storage

This allows callers to report both the number of orphan files removed and the total bytes freed.

## Are these changes tested?

- Updated the `remove_orphan_files` integration tests for the new return type.