### PR TITLE
fix(spec): support `fixed` and `binary` JSON single values instead of panicking

### DIFF
--- a/crates/iceberg/src/spec/values/literal.rs
+++ b/crates/iceberg/src/spec/values/literal.rs
@@ -677,17 +677,26 @@ impl Literal {
                 (_, PrimitiveLiteral::UInt128(val)) => {
                     Ok(JsonValue::String(Uuid::from_u128(val).to_string()))
                 }
-                // Each byte must be written as exactly two hexadecimal digits: the spec stores
-                // `fixed` and `binary` single values as hexadecimal strings such as "000102ff".
-                // Without zero-padding, [0x00, 0x01, 0x02, 0xff] would serialize to "012ff",
-                // which neither round-trips nor is readable by other engines.
-                (_, PrimitiveLiteral::Binary(val)) => Ok(JsonValue::String(val.iter().fold(
-                    String::with_capacity(val.len() * 2),
-                    |mut acc, x| {
-                        acc.push_str(&format!("{x:02x}"));
-                        acc
-                    },
-                ))),
+                // `fixed` and `binary` share a literal representation but not their constraints, so
+                // they are matched separately: the length of a `fixed(L)` value is part of its type
+                // and is enforced on write as well as on read. Writing a wrong-length value would
+                // otherwise succeed here and then be rejected by `try_from_json`, so a
+                // metadata round-trip would silently drop the default.
+                (PrimitiveType::Fixed(len), PrimitiveLiteral::Binary(val)) => {
+                    if val.len() as u64 != *len {
+                        return Err(Error::new(
+                            ErrorKind::DataInvalid,
+                            format!(
+                                "Invalid value for fixed({len}): expected {len} bytes, got {} bytes.",
+                                val.len()
+                            ),
+                        ));
+                    }
+                    Ok(JsonValue::String(bytes_to_hex_str(&val)))
+                }
+                (PrimitiveType::Binary, PrimitiveLiteral::Binary(val)) => {
+                    Ok(JsonValue::String(bytes_to_hex_str(&val)))
+                }
                 (_, PrimitiveLiteral::Int128(val)) => match r#type {
                     Type::Primitive(PrimitiveType::Decimal {
                         precision: _precision,
@@ -809,4 +818,17 @@ fn hex_str_to_bytes(s: &str) -> Result<Vec<u8>> {
         .chunks(2)
         .map(|pair| Ok((hex_digit_value(pair[0])? << 4) | hex_digit_value(pair[1])?))
         .collect()
+}
+
+/// Encodes bytes as a hexadecimal string, the inverse of [`hex_str_to_bytes`].
+///
+/// Each byte is written as exactly two lower-case digits. The zero-padding is load-bearing: without
+/// it `[0x00, 0x01, 0x02, 0xff]` would produce `"012ff"`, which neither round-trips nor is readable
+/// by other engines.
+fn bytes_to_hex_str(bytes: &[u8]) -> String {
+    let mut s = String::with_capacity(bytes.len() * 2);
+    for b in bytes {
+        s.push_str(&format!("{b:02x}"));
+    }
+    s
 }

--- a/crates/iceberg/src/spec/values/literal.rs
+++ b/crates/iceberg/src/spec/values/literal.rs
@@ -499,8 +499,22 @@ impl Literal {
                 (PrimitiveType::Uuid, JsonValue::String(s)) => Ok(Some(Literal::Primitive(
                     PrimitiveLiteral::UInt128(Uuid::parse_str(&s)?.as_u128()),
                 ))),
-                (PrimitiveType::Fixed(_), JsonValue::String(_)) => todo!(),
-                (PrimitiveType::Binary, JsonValue::String(_)) => todo!(),
+                (PrimitiveType::Fixed(len), JsonValue::String(s)) => {
+                    let bytes = hex_str_to_bytes(&s)?;
+                    if bytes.len() as u64 != *len {
+                        return Err(Error::new(
+                            crate::ErrorKind::DataInvalid,
+                            format!(
+                                "Invalid value for fixed({len}): expected {len} bytes, got {} bytes from the hexadecimal string {s:?}.",
+                                bytes.len()
+                            ),
+                        ));
+                    }
+                    Ok(Some(Literal::Primitive(PrimitiveLiteral::Binary(bytes))))
+                }
+                (PrimitiveType::Binary, JsonValue::String(s)) => Ok(Some(Literal::Primitive(
+                    PrimitiveLiteral::Binary(hex_str_to_bytes(&s)?),
+                ))),
                 (
                     PrimitiveType::Decimal {
                         precision: _,
@@ -663,10 +677,14 @@ impl Literal {
                 (_, PrimitiveLiteral::UInt128(val)) => {
                     Ok(JsonValue::String(Uuid::from_u128(val).to_string()))
                 }
+                // Each byte must be written as exactly two hexadecimal digits: the spec stores
+                // `fixed` and `binary` single values as hexadecimal strings such as "000102ff".
+                // Without zero-padding, [0x00, 0x01, 0x02, 0xff] would serialize to "012ff",
+                // which neither round-trips nor is readable by other engines.
                 (_, PrimitiveLiteral::Binary(val)) => Ok(JsonValue::String(val.iter().fold(
-                    String::new(),
+                    String::with_capacity(val.len() * 2),
                     |mut acc, x| {
-                        acc.push_str(&format!("{x:x}"));
+                        acc.push_str(&format!("{x:02x}"));
                         acc
                     },
                 ))),
@@ -747,4 +765,48 @@ impl Literal {
             _ => unimplemented!(),
         }
     }
+}
+
+/// Converts a single hexadecimal digit into its numeric value.
+fn hex_digit_value(digit: u8) -> Result<u8> {
+    match digit {
+        b'0'..=b'9' => Ok(digit - b'0'),
+        b'a'..=b'f' => Ok(digit - b'a' + 10),
+        b'A'..=b'F' => Ok(digit - b'A' + 10),
+        _ => Err(Error::new(
+            ErrorKind::DataInvalid,
+            format!(
+                "Invalid hexadecimal digit {:?} in a `fixed` or `binary` value.",
+                char::from(digit)
+            ),
+        )),
+    }
+}
+
+/// Decodes a hexadecimal string into bytes.
+///
+/// The Iceberg spec stores `fixed` and `binary` single values as hexadecimal strings, for example
+/// `"000102ff"`, so each byte is represented by exactly two digits. Upper-case digits are accepted
+/// on read even though [`Literal::try_into_json`] always writes lower-case.
+///
+/// This operates on bytes rather than slicing the `&str`, because slicing at a fixed offset would
+/// panic on a multi-byte UTF-8 character (`"0é0"` is four bytes long, so an even-length check alone
+/// does not make `s[0..2]` safe). Values reaching here come from table metadata, which is
+/// attacker- or engine-controlled, so this must return an error rather than panic.
+fn hex_str_to_bytes(s: &str) -> Result<Vec<u8>> {
+    let digits = s.as_bytes();
+    if !digits.len().is_multiple_of(2) {
+        return Err(Error::new(
+            ErrorKind::DataInvalid,
+            format!(
+                "A `fixed` or `binary` value must be a hexadecimal string with an even number of digits, but {s:?} has {}.",
+                digits.len()
+            ),
+        ));
+    }
+
+    digits
+        .chunks(2)
+        .map(|pair| Ok((hex_digit_value(pair[0])? << 4) | hex_digit_value(pair[1])?))
+        .collect()
 }

--- a/crates/iceberg/src/spec/values/tests.rs
+++ b/crates/iceberg/src/spec/values/tests.rs
@@ -241,6 +241,83 @@ fn json_uuid() {
 }
 
 #[test]
+fn json_binary() {
+    // The leading zero byte is the interesting part: without zero-padding on write this
+    // serializes to "12ff" and no longer round-trips.
+    let record = r#""000102ff""#;
+
+    check_json_serde(
+        record,
+        Literal::Primitive(PrimitiveLiteral::Binary(vec![0x00, 0x01, 0x02, 0xff])),
+        &Type::Primitive(PrimitiveType::Binary),
+    );
+}
+
+#[test]
+fn json_binary_empty() {
+    check_json_serde(
+        r#""""#,
+        Literal::Primitive(PrimitiveLiteral::Binary(vec![])),
+        &Type::Primitive(PrimitiveType::Binary),
+    );
+}
+
+#[test]
+fn json_fixed() {
+    // Same byte pattern as the spec's example for `fixed(L)`.
+    let record = r#""000102ff""#;
+
+    check_json_serde(
+        record,
+        Literal::Primitive(PrimitiveLiteral::Binary(vec![0x00, 0x01, 0x02, 0xff])),
+        &Type::Primitive(PrimitiveType::Fixed(4)),
+    );
+}
+
+/// Every one of these used to hit a `todo!()` and panic, which meant a single malformed
+/// `initial-default` in customer table metadata could take down a service that only wanted to read
+/// the schema. They must all produce errors instead.
+#[test]
+fn json_fixed_and_binary_invalid_values_error_instead_of_panicking() {
+    let cases: Vec<(&str, Type)> = vec![
+        // Wrong length for the declared `fixed(L)`.
+        (r#""000102""#, Type::Primitive(PrimitiveType::Fixed(4))),
+        (r#""000102ffff""#, Type::Primitive(PrimitiveType::Fixed(4))),
+        // Odd number of hexadecimal digits, so the last byte is incomplete.
+        (r#""000""#, Type::Primitive(PrimitiveType::Binary)),
+        // Not hexadecimal at all.
+        (r#""zz""#, Type::Primitive(PrimitiveType::Binary)),
+        (r#""00 1""#, Type::Primitive(PrimitiveType::Binary)),
+        // Multi-byte UTF-8. This is an even number of *bytes*, so an even-length check alone
+        // would let it through and then panic when slicing across the char boundary.
+        (r#""0é0""#, Type::Primitive(PrimitiveType::Binary)),
+        (r#""éé""#, Type::Primitive(PrimitiveType::Binary)),
+    ];
+
+    for (json, ty) in cases {
+        let raw = serde_json::from_str::<JsonValue>(json).unwrap();
+        let result = Literal::try_from_json(raw, &ty);
+        assert!(
+            result.is_err(),
+            "expected {json} to be rejected for {ty}, got {result:?}"
+        );
+    }
+}
+
+#[test]
+fn json_binary_accepts_upper_case_hex_digits() {
+    let raw = serde_json::from_str::<JsonValue>(r#""00AbFF""#).unwrap();
+    let literal = Literal::try_from_json(raw, &Type::Primitive(PrimitiveType::Binary)).unwrap();
+
+    assert_eq!(
+        literal,
+        Some(Literal::Primitive(PrimitiveLiteral::Binary(vec![
+            0x00, 0xab, 0xff
+        ])))
+    );
+}
+
+#[test]
 fn json_decimal() {
     let record = r#""14.20""#;
 

--- a/crates/iceberg/src/spec/values/tests.rs
+++ b/crates/iceberg/src/spec/values/tests.rs
@@ -274,6 +274,51 @@ fn json_fixed() {
     );
 }
 
+/// A wrong-length `fixed(L)` value must be rejected when *writing*, not only when reading.
+///
+/// The length is part of the type, so the two directions have to agree. If writing accepted what
+/// reading rejects, a value could be serialized into `metadata.json` and then fail to parse on the
+/// way back, so the default would be silently lost on a round-trip instead of being refused at the
+/// point it was set.
+#[test]
+fn json_fixed_rejects_a_wrong_length_value_in_both_directions() {
+    let ty = Type::Primitive(PrimitiveType::Fixed(4));
+
+    for bytes in [
+        vec![0x00, 0x01, 0x02],             // too short
+        vec![0x00, 0x01, 0x02, 0xff, 0xff], // too long
+        vec![],                             // empty is still the wrong length for fixed(4)
+    ] {
+        let written =
+            Literal::Primitive(PrimitiveLiteral::Binary(bytes.clone())).try_into_json(&ty);
+        assert!(
+            written.is_err(),
+            "expected fixed(4) to reject writing {} bytes, got {written:?}",
+            bytes.len()
+        );
+
+        // The same value is rejected on read, which is what makes the write-side check necessary:
+        // without it the two directions disagree. Encoding via `binary` sidesteps the check under
+        // test so that the read path receives the hexadecimal string it would have written.
+        let json = Literal::Primitive(PrimitiveLiteral::Binary(bytes.clone()))
+            .try_into_json(&Type::Primitive(PrimitiveType::Binary))
+            .unwrap();
+        assert!(
+            Literal::try_from_json(json, &ty).is_err(),
+            "expected fixed(4) to reject reading {} bytes",
+            bytes.len()
+        );
+    }
+
+    // The correct length still round-trips, so the check is not simply refusing everything.
+    assert_eq!(
+        Literal::Primitive(PrimitiveLiteral::Binary(vec![0x00, 0x01, 0x02, 0xff]))
+            .try_into_json(&ty)
+            .unwrap(),
+        JsonValue::String("000102ff".to_string())
+    );
+}
+
 /// Every one of these used to hit a `todo!()` and panic, which meant a single malformed
 /// `initial-default` in customer table metadata could take down a service that only wanted to read
 /// the schema. They must all produce errors instead.


### PR DESCRIPTION
## What

`Literal::try_from_json` had `todo!()` for both `fixed(L)` and `binary`:

```rust
(PrimitiveType::Fixed(_), JsonValue::String(_)) => todo!(),
(PrimitiveType::Binary, JsonValue::String(_)) => todo!(),
```

So a table whose metadata carries an `initial-default` or `write-default` for either type
**panics the process while merely deserializing the schema**. Note this is not caught by the
`.ok()` in `SerdeNestedField -> NestedField`, which only swallows `Err`, not a panic — so it
reaches any service that loads the table.

This implements both arms by decoding the hexadecimal string form the spec defines for
[JSON single-value serialization](https://iceberg.apache.org/spec/#json-single-value-serialization)
(`fixed(L)` and `binary` are both *"Stored as a hexadecimal string"*, e.g. `"000102ff"`), and
validates the decoded byte length for `fixed(L)` — consistent with the existing Avro path, which
already rejects a wrong-length `fixed` (`test_raw_literal_bytes_fixed_wrong_length`).

## Also fixes the serialization direction

While adding the round-trip test I found `try_into_json` writes each byte with `{:x}`, i.e.
**without zero-padding**:

```rust
acc.push_str(&format!("{x:x}"));
```

So `[0x00, 0x01, 0x02, 0xff]` serialized to `"012ff"` instead of `"000102ff"` — it does not
round-trip, and other engines cannot read it. Any byte `< 0x10` is affected. This was previously
unreachable in a round-trip test because the parsing side panicked, so it had no coverage.

I confirmed the new tests are non-vacuous by reverting just the padding fix, which fails with:

```
assertion `left == right` failed
  left: String("012ff")
 right: String("000102ff")
```

## Why the decoder works on bytes rather than slicing the string

Slicing at a fixed offset would panic on multi-byte UTF-8: `"0é0"` is four *bytes*, so it passes an
even-length check and then `s[0..2]` panics on the char boundary. Since these values come from table
metadata, malformed input must produce an error, never a panic. `"0é0"` and `"éé"` are both covered
by tests.

## Tests

- `json_binary`, `json_fixed` — full round-trip via the existing `check_json_serde` helper, using a
  leading zero byte so the padding bug is caught
- `json_binary_empty`
- `json_binary_accepts_upper_case_hex_digits` — accepted on read, though we always write lower-case
- `json_fixed_and_binary_invalid_values_error_instead_of_panicking` — wrong `fixed` length (both
  directions), odd digit count, non-hex input, and the two multi-byte UTF-8 cases

## Verification

`make check-fmt`, `make check-clippy` (`--all-targets --all-features --workspace -- -D warnings`)
and `cargo test -p iceberg --lib` (1293 passed, 0 failed), on the pinned `nightly-2025-10-27`.
`cargo fmt --all -- --check` also clean under `bindings/python`.

## One related thing left alone

`SerdeNestedField`'s serialize direction has two `.expect("We should have checked this in
`NestedField::with_initial_default`")` calls, but `with_initial_default` does not validate anything,
so that comment is inaccurate. It is only reachable by constructing a literal programmatically (a
`variant` default, which `try_from_json` rejects), not from parsed metadata, so I have left it out of
this change to keep the fix focused.
