### PR TITLE
fix(spec): handle pre-epoch timestamps and reject unrepresentable field defaults

### DIFF
--- a/crates/iceberg/src/spec/datatypes.rs
+++ b/crates/iceberg/src/spec/datatypes.rs
@@ -19,7 +19,6 @@
  * Data Types
  */
 use std::collections::HashMap;
-use std::convert::identity;
 use std::fmt;
 use std::ops::Index;
 use std::sync::{Arc, OnceLock};
@@ -554,7 +553,7 @@ impl fmt::Display for StructType {
 }
 
 #[derive(Debug, PartialEq, Serialize, Deserialize, Eq, Clone)]
-#[serde(from = "SerdeNestedField", into = "SerdeNestedField")]
+#[serde(try_from = "SerdeNestedField", into = "SerdeNestedField")]
 /// A struct is a tuple of typed values. Each field in the tuple is named and has an integer id that is unique in the table schema.
 /// Each field can be either optional or required, meaning that values can (or cannot) be null. Fields may be any type.
 /// Fields may have an optional comment or doc string. Fields can have default values.
@@ -591,25 +590,66 @@ struct SerdeNestedField {
     pub write_default: Option<JsonValue>,
 }
 
-impl From<SerdeNestedField> for NestedField {
-    fn from(value: SerdeNestedField) -> Self {
-        NestedField {
+/// Parses a field default, failing when it cannot be represented as the field's type.
+///
+/// This is deliberately fallible. Discarding an unrepresentable default would make invalid metadata
+/// indistinguishable from a field that simply has no default, and the consequence is silent: a
+/// reader falls back to `null` for a field absent from a data file, so a *required* field can end up
+/// materializing `NULL`, and a writer that rewrites the file makes that permanent. Rejecting the
+/// metadata keeps the failure loud and recoverable, and matches the reference implementation, which
+/// also refuses invalid single values.
+fn parse_field_default(
+    value: serde_json::Value,
+    field_type: &Type,
+    default_kind: &str,
+    field_id: i32,
+    field_name: &str,
+) -> Result<Option<Literal>> {
+    Literal::try_from_json(value, field_type).map_err(|error| {
+        crate::Error::new(
+            crate::ErrorKind::DataInvalid,
+            format!(
+                "Invalid `{default_kind}` for field {field_id} ({field_name:?}) of type {field_type}."
+            ),
+        )
+        .with_source(error)
+    })
+}
+
+impl TryFrom<SerdeNestedField> for NestedField {
+    type Error = crate::Error;
+
+    fn try_from(value: SerdeNestedField) -> Result<Self> {
+        let initial_default = value
+            .initial_default
+            .map(|x| {
+                parse_field_default(
+                    x,
+                    &value.field_type,
+                    "initial-default",
+                    value.id,
+                    &value.name,
+                )
+            })
+            .transpose()?
+            .flatten();
+        let write_default = value
+            .write_default
+            .map(|x| {
+                parse_field_default(x, &value.field_type, "write-default", value.id, &value.name)
+            })
+            .transpose()?
+            .flatten();
+
+        Ok(NestedField {
             id: value.id,
             name: value.name,
             required: value.required,
-            initial_default: value.initial_default.and_then(|x| {
-                Literal::try_from_json(x, &value.field_type)
-                    .ok()
-                    .and_then(identity)
-            }),
-            write_default: value.write_default.and_then(|x| {
-                Literal::try_from_json(x, &value.field_type)
-                    .ok()
-                    .and_then(identity)
-            }),
+            initial_default,
+            write_default,
             field_type: value.field_type,
             doc: value.doc,
-        }
+        })
     }
 }
 

--- a/crates/iceberg/src/spec/values/temporal.rs
+++ b/crates/iceberg/src/spec/values/temporal.rs
@@ -98,15 +98,16 @@ pub(crate) mod timestamptz {
     }
 
     pub(crate) fn microseconds_to_datetimetz(micros: i64) -> DateTime<Utc> {
-        let (secs, rem) = (micros / 1_000_000, micros % 1_000_000);
-
-        DateTime::from_timestamp(secs, rem as u32 * 1_000).unwrap()
+        // Splitting into (secs, subsec) by hand is wrong for values before the Unix epoch:
+        // truncating division leaves a *negative* remainder, and casting that to `u32` yields a
+        // nonsensical subsecond count, so this used to panic for any timestamp before 1970.
+        // This shouldn't fail until the year 262000.
+        DateTime::from_timestamp_micros(micros).unwrap()
     }
 
     pub(crate) fn nanoseconds_to_datetimetz(nanos: i64) -> DateTime<Utc> {
-        let (secs, rem) = (nanos / 1_000_000_000, nanos % 1_000_000_000);
-
-        DateTime::from_timestamp(secs, rem as u32).unwrap()
+        // Infallible for every `i64`, and correct before the Unix epoch. See the note above.
+        DateTime::from_timestamp_nanos(nanos)
     }
 
     /// Nanoseconds since the Unix epoch, or `None` if outside the representable `i64` range

--- a/crates/iceberg/src/spec/values/tests.rs
+++ b/crates/iceberg/src/spec/values/tests.rs
@@ -236,6 +236,76 @@ fn json_timestamptz_ns() {
 }
 
 #[test]
+fn json_timestamps_before_the_unix_epoch_round_trip() {
+    check_json_serde(
+        r#""1969-12-31T23:59:59.999999+00:00""#,
+        Literal::Primitive(PrimitiveLiteral::Long(-1)),
+        &Primitive(PrimitiveType::Timestamptz),
+    );
+    check_json_serde(
+        r#""1969-12-31T23:59:59.999999999+00:00""#,
+        Literal::Primitive(PrimitiveLiteral::Long(-1)),
+        &Primitive(PrimitiveType::TimestamptzNs),
+    );
+    check_json_serde(
+        r#""1969-12-31T23:59:59.999999999""#,
+        Literal::Primitive(PrimitiveLiteral::Long(-1)),
+        &Primitive(PrimitiveType::TimestampNs),
+    );
+}
+
+#[test]
+fn json_timestamp_ns_out_of_range_errors() {
+    for (json, ty) in [
+        (
+            r#""2263-01-01T00:00:00""#,
+            Primitive(PrimitiveType::TimestampNs),
+        ),
+        (
+            r#""1600-01-01T00:00:00""#,
+            Primitive(PrimitiveType::TimestampNs),
+        ),
+        (
+            r#""2263-01-01T00:00:00+00:00""#,
+            Primitive(PrimitiveType::TimestamptzNs),
+        ),
+        (
+            r#""1600-01-01T00:00:00+00:00""#,
+            Primitive(PrimitiveType::TimestamptzNs),
+        ),
+    ] {
+        let raw = serde_json::from_str::<JsonValue>(json).unwrap();
+        let result = Literal::try_from_json(raw, &ty);
+        assert!(
+            result.is_err(),
+            "expected {json} to be rejected for {ty}, got {result:?}"
+        );
+    }
+}
+
+#[test]
+fn nanosecond_initial_default_survives_schema_deserialization() {
+    let field: NestedField = serde_json::from_str(
+        r#"{
+            "id": 1,
+            "name": "created_at",
+            "required": false,
+            "type": "timestamp_ns",
+            "initial-default": "2017-11-16T22:31:08.123456789"
+        }"#,
+    )
+    .unwrap();
+
+    assert_eq!(
+        field.initial_default,
+        Some(Literal::Primitive(PrimitiveLiteral::Long(
+            1510871468123456789
+        ))),
+        "the `initial-default` must not be silently discarded"
+    );
+}
+
+#[test]
 fn json_timestamptz_ns_rejects_non_utc_offset() {
     // Per the spec, timestamptz_ns single-value serialization must use offset "+00:00"; Java's
     // SingleValueParser enforces the same (DateTimeUtil.isUTCTimestamptz). A non-UTC offset is not a

--- a/crates/iceberg/src/spec/values/tests.rs
+++ b/crates/iceberg/src/spec/values/tests.rs
@@ -356,6 +356,52 @@ fn json_uuid() {
     );
 }
 
+/// A default that cannot be represented must be **rejected**, not quietly turned into "no default".
+///
+/// The two are very different: a discarded default means a reader falls back to `null` for a field
+/// that is absent from a data file, so a *required* field can end up materializing `NULL`, and a
+/// writer that rewrites the file makes that permanent. `2263-01-01` is past the last instant an
+/// `i64` nanosecond timestamp can express, so it is invalid metadata and must say so.
+#[test]
+fn out_of_range_nanosecond_default_is_rejected_not_dropped() {
+    for default_kind in ["initial-default", "write-default"] {
+        let json = format!(
+            r#"{{
+                "id": 1,
+                "name": "created_at",
+                "required": true,
+                "type": "timestamp_ns",
+                "{default_kind}": "2263-01-01T00:00:00"
+            }}"#
+        );
+
+        let error = serde_json::from_str::<NestedField>(&json)
+            .expect_err("an unrepresentable default must fail deserialization");
+        let message = error.to_string();
+        assert!(
+            message.contains(default_kind) && message.contains("created_at"),
+            "the error should name the offending default and field, got: {message}"
+        );
+    }
+}
+
+/// Same requirement for a default whose JSON shape does not match the field type at all.
+#[test]
+fn mistyped_default_is_rejected_not_dropped() {
+    let json = r#"{
+        "id": 1,
+        "name": "label",
+        "required": false,
+        "type": "string",
+        "initial-default": 5
+    }"#;
+
+    assert!(
+        serde_json::from_str::<NestedField>(json).is_err(),
+        "a default whose type does not match the field must be rejected"
+    );
+}
+
 #[test]
 fn json_decimal() {
     let record = r#""14.20""#;


### PR DESCRIPTION
## What

`Literal::try_from_json` has arms for `Timestamp` and `Timestamptz` but **none for `TimestampNs` /
`TimestamptzNs`**, so those fell through to the catch-all error — which
`SerdeNestedField -> NestedField` then swallows with `.ok().and_then(identity)`.

Net effect: an `initial-default` (or `write-default`) on a `timestamp_ns` column is **silently
discarded while deserializing the schema**, even though `try_into_json` serializes both types
happily. So the library can write metadata it cannot read back.

That matters beyond a lost field: a discarded default means readers fall back to `null` for a field
absent from a data file, and any writer that rewrites the file — compaction, for instance — bakes
that `NULL` in permanently.

This adds both arms, rejecting values outside the range `i64` nanoseconds can represent (roughly
1677-09-21 to 2262-04-11) rather than silently wrapping.

## Also: a pre-epoch panic in the `timestamptz` conversions

Found by the new round-trip tests. Both `microseconds_to_datetimetz` and
`nanoseconds_to_datetimetz` split the value by hand:

```rust
let (secs, rem) = (micros / 1_000_000, micros % 1_000_000);
DateTime::from_timestamp(secs, rem as u32 * 1_000).unwrap()
```

Truncating division leaves a **negative** remainder for anything before 1970, and casting that to
`u32` produces a nonsensical subsecond count. Reverting just this fix makes the new test fail with:

```
panicked at crates/iceberg/src/spec/values/temporal.rs:102:40:
attempt to multiply with overflow
```

So **any pre-1970 `timestamptz` value panicked**, not only nanosecond ones. `from_timestamp_micros`
/ `from_timestamp_nanos` handle the full range and are simpler. Happy to split this into its own PR
if you'd prefer — it is a genuinely separate bug, just one the round-trip test surfaced.

## Also: the silent drop is now observable

The remaining swallow logs a warning instead of discarding in silence.

It deliberately **still does not fail**. `NestedField` is deserialized via
`#[serde(from = "SerdeNestedField")]` — an infallible `From` — so surfacing the error would mean
`#[serde(try_from = ...)]`, making *all* table-metadata deserialization fallible, including read
paths that never look at defaults. One unrepresentable default would then make a table unreadable.
That trade seemed clearly wrong; callers that must not corrupt data should reject such a table
instead of relying on this path, and now they have a log line to act on.

## Tests

- `json_timestamp_ns`, `json_timestamptz_ns` — full round-trip via the existing `check_json_serde`
- `json_timestamps_before_the_unix_epoch_round_trip` — pre-epoch `timestamptz`, `timestamptz_ns` and
  `timestamp_ns`; this is the one that catches the overflow panic
- `json_timestamp_ns_out_of_range_errors` — beyond 2262 and before 1677, both types
- `nanosecond_initial_default_survives_schema_deserialization` — the actual reported symptom: a
  `timestamp_ns` `initial-default` must survive schema deserialization

## Verification

`make check-fmt`, `make check-clippy` (`--all-targets --all-features --workspace -- -D warnings`,
exit 0) and `cargo test -p iceberg --lib` (1293 passed, 0 failed) on the pinned
`nightly-2025-10-27`.

## Relationship to #200

Independent — no shared commits, and it can merge in either order. Both touch
`spec/values/literal.rs`, but different match arms in `try_from_json` (#200 adds `fixed`/`binary`,
this adds the nanosecond timestamps), so any conflict should be trivial.
