### PR TITLE
fix(glue): map Timestamptz/TimestamptzNs to Glue timestamp types

### DIFF
--- a/crates/catalog/glue/src/schema.rs
+++ b/crates/catalog/glue/src/schema.rs
@@ -165,12 +165,10 @@ impl SchemaVisitor for GlueSchemaBuilder {
             PrimitiveType::Date => "date".to_string(),
             PrimitiveType::Timestamp => "timestamp".to_string(),
             PrimitiveType::TimestampNs => "timestamp_ns".to_string(),
-            PrimitiveType::Timestamptz | PrimitiveType::TimestamptzNs => {
-                return Err(Error::new(
-                    ErrorKind::FeatureUnsupported,
-                    format!("Conversion from {p:?} is not supported"),
-                ));
-            }
+            // Glue has no timezone-aware timestamp type; map to the equivalent non-tz type,
+            // matching the behavior of Spark's Glue catalog integration.
+            PrimitiveType::Timestamptz => "timestamp".to_string(),
+            PrimitiveType::TimestamptzNs => "timestamp_ns".to_string(),
             PrimitiveType::Time | PrimitiveType::String | PrimitiveType::Uuid => {
                 "string".to_string()
             }

--- a/crates/catalog/glue/src/schema.rs
+++ b/crates/catalog/glue/src/schema.rs
@@ -26,7 +26,7 @@ use std::collections::HashMap;
 
 use aws_sdk_glue::types::Column;
 use iceberg::spec::{PrimitiveType, SchemaVisitor, TableMetadata, VariantType, visit_schema};
-use iceberg::{Error, ErrorKind, Result};
+use iceberg::Result;
 
 use crate::error::from_aws_build_error;
 


### PR DESCRIPTION
## Problem

Any operation that writes Iceberg metadata through the Glue catalog (e.g.
committing compaction rewrites) fails with `FeatureUnsupported` when the
table schema contains `Timestamptz` or `TimestamptzNs` columns:

```
FeatureUnsupported => Conversion from Timestamptz is not supported
```

Root cause: `GlueSchemaBuilder::primitive()` in
`crates/catalog/glue/src/schema.rs` has no match arms for these types,
so they fall through to an explicit error.

## Fix

Map `Timestamptz` → `"timestamp"` and `TimestamptzNs` → `"timestamp_ns"`,
matching the behaviour of Spark's Glue catalog integration which also drops
timezone information (Glue has no timezone-aware timestamp type).

The same fix has been submitted to the upstream apache/iceberg-rust repo:
https://github.com/apache/iceberg-rust/pull/2956