### PR TITLE
fix(s3,gcs): cache OpenDAL operators by bucket

### DIFF
--- a/crates/iceberg/src/io/storage/opendal/mod.rs
+++ b/crates/iceberg/src/io/storage/opendal/mod.rs
@@ -20,7 +20,7 @@
 use std::collections::HashMap;
 use std::ops::Range;
 use std::sync::Arc;
-#[cfg(feature = "storage-gcs")]
+#[cfg(any(feature = "storage-gcs", feature = "storage-s3"))]
 use std::sync::RwLock;
 use std::time::Duration;
 
@@ -134,6 +134,7 @@ impl StorageFactory for OpenDalStorageFactory {
                 configured_scheme: "s3".to_string(),
                 config: s3_config_parse(config.props().clone())?.into(),
                 customized_credential_load: customized_credential_load.clone(),
+                operator_cache: default_operator_cache(),
             })),
             #[cfg(feature = "storage-gcs")]
             OpenDalStorageFactory::Gcs => Ok(Arc::new(OpenDalStorage::Gcs {
@@ -178,17 +179,17 @@ fn default_memory_operator() -> Operator {
     memory_config_build().expect("Failed to create default memory operator")
 }
 
-#[cfg(feature = "storage-gcs")]
+#[cfg(any(feature = "storage-gcs", feature = "storage-s3"))]
 type OperatorCache = Arc<RwLock<HashMap<String, Operator>>>;
 
 /// Default empty operator cache for serde deserialization.
-#[cfg(feature = "storage-gcs")]
+#[cfg(any(feature = "storage-gcs", feature = "storage-s3"))]
 fn default_operator_cache() -> OperatorCache {
     Arc::new(RwLock::new(HashMap::new()))
 }
 
 /// Returns the cached operator for `key`, creating it while holding the write lock if absent.
-#[cfg(feature = "storage-gcs")]
+#[cfg(any(feature = "storage-gcs", feature = "storage-s3"))]
 fn get_or_create_operator(
     cache: &RwLock<HashMap<String, Operator>>,
     key: &str,
@@ -243,6 +244,9 @@ pub enum OpenDalStorage {
         /// Custom AWS credential loader.
         #[serde(skip)]
         customized_credential_load: Option<CustomAwsCredentialLoader>,
+        /// Operators keyed by bucket so credential and token caches are reused.
+        #[serde(skip, default = "default_operator_cache")]
+        operator_cache: OperatorCache,
     },
     /// GCS storage variant.
     #[cfg(feature = "storage-gcs")]
@@ -302,6 +306,7 @@ impl OpenDalStorage {
                 customized_credential_load: extensions
                     .get::<CustomAwsCredentialLoader>()
                     .map(Arc::unwrap_or_clone),
+                operator_cache: default_operator_cache(),
             }),
             #[cfg(feature = "storage-gcs")]
             Scheme::Gcs => Ok(Self::Gcs {
@@ -384,8 +389,18 @@ impl OpenDalStorage {
                 configured_scheme,
                 config,
                 customized_credential_load,
+                operator_cache,
             } => {
-                let op = s3_config_build(config, customized_credential_load, path)?;
+                let url = url::Url::parse(path)?;
+                let bucket = url.host_str().ok_or_else(|| {
+                    Error::new(
+                        ErrorKind::DataInvalid,
+                        format!("Invalid s3 url: {path}, missing bucket"),
+                    )
+                })?;
+                let op = get_or_create_operator(operator_cache, bucket, || {
+                    s3_config_build(config, customized_credential_load, path)
+                })?;
                 let op_info = op.info();
 
                 // Check prefix of s3 path.
@@ -624,9 +639,9 @@ impl FileWrite for opendal::Writer {
 
 #[cfg(test)]
 mod tests {
-    #[cfg(feature = "storage-gcs")]
+    #[cfg(any(feature = "storage-gcs", feature = "storage-s3"))]
     use std::sync::Barrier;
-    #[cfg(feature = "storage-gcs")]
+    #[cfg(any(feature = "storage-gcs", feature = "storage-s3"))]
     use std::sync::atomic::{AtomicUsize, Ordering};
 
     use super::*;
@@ -636,6 +651,100 @@ mod tests {
     fn test_default_memory_operator() {
         let op = default_memory_operator();
         assert_eq!(op.info().scheme().to_string(), "memory");
+    }
+
+    #[cfg(feature = "storage-s3")]
+    fn test_s3_config() -> S3Config {
+        let mut config = S3Config::default();
+        config.region = Some("us-east-1".to_string());
+        config
+    }
+
+    #[cfg(feature = "storage-s3")]
+    fn test_s3_storage() -> OpenDalStorage {
+        OpenDalStorage::S3 {
+            configured_scheme: "s3".to_string(),
+            config: Arc::new(test_s3_config()),
+            customized_credential_load: None,
+            operator_cache: default_operator_cache(),
+        }
+    }
+
+    #[cfg(feature = "storage-s3")]
+    #[test]
+    fn test_s3_operator_cache_coalesces_concurrent_builds() {
+        const CONCURRENCY: usize = 16;
+
+        let cache = default_operator_cache();
+        let barrier = Arc::new(Barrier::new(CONCURRENCY));
+        let build_count = Arc::new(AtomicUsize::new(0));
+
+        std::thread::scope(|scope| {
+            for _ in 0..CONCURRENCY {
+                let cache = cache.clone();
+                let barrier = barrier.clone();
+                let build_count = build_count.clone();
+                scope.spawn(move || {
+                    barrier.wait();
+                    get_or_create_operator(&cache, "test-bucket", || {
+                        build_count.fetch_add(1, Ordering::SeqCst);
+                        s3_config_build(&test_s3_config(), &None, "s3://test-bucket/path/to/file")
+                    })
+                    .unwrap();
+                });
+            }
+        });
+
+        assert_eq!(build_count.load(Ordering::SeqCst), 1);
+        assert_eq!(cache.read().unwrap().len(), 1);
+    }
+
+    #[cfg(feature = "storage-s3")]
+    #[test]
+    fn test_s3_operator_cache_is_shared_by_clones_and_scoped_to_bucket() {
+        let storage = test_s3_storage();
+        let cloned_storage = storage.clone();
+
+        storage
+            .create_operator(&"s3://bucket-a/path/to/first-file")
+            .unwrap();
+        cloned_storage
+            .create_operator(&"s3://bucket-a/path/to/second-file")
+            .unwrap();
+        cloned_storage
+            .create_operator(&"s3://bucket-b/path/to/third-file")
+            .unwrap();
+
+        let OpenDalStorage::S3 { operator_cache, .. } = &storage else {
+            unreachable!()
+        };
+        let OpenDalStorage::S3 {
+            operator_cache: cloned_operator_cache,
+            ..
+        } = &cloned_storage
+        else {
+            unreachable!()
+        };
+
+        assert!(Arc::ptr_eq(operator_cache, cloned_operator_cache));
+        assert_eq!(operator_cache.read().unwrap().len(), 2);
+    }
+
+    #[cfg(feature = "storage-s3")]
+    #[test]
+    fn test_s3_operator_cache_is_reset_after_deserialization() {
+        let storage = test_s3_storage();
+        storage
+            .create_operator(&"s3://test-bucket/path/to/file")
+            .unwrap();
+
+        let serialized = serde_json::to_string(&storage).unwrap();
+        let deserialized: OpenDalStorage = serde_json::from_str(&serialized).unwrap();
+        let OpenDalStorage::S3 { operator_cache, .. } = deserialized else {
+            unreachable!()
+        };
+
+        assert!(operator_cache.read().unwrap().is_empty());
     }
 
     #[cfg(feature = "storage-gcs")]

--- a/crates/iceberg/src/io/storage/opendal/mod.rs
+++ b/crates/iceberg/src/io/storage/opendal/mod.rs
@@ -20,6 +20,8 @@
 use std::collections::HashMap;
 use std::ops::Range;
 use std::sync::Arc;
+#[cfg(feature = "storage-gcs")]
+use std::sync::RwLock;
 use std::time::Duration;
 
 use async_trait::async_trait;
@@ -136,6 +138,7 @@ impl StorageFactory for OpenDalStorageFactory {
             #[cfg(feature = "storage-gcs")]
             OpenDalStorageFactory::Gcs => Ok(Arc::new(OpenDalStorage::Gcs {
                 config: gcs_config_parse(config.props().clone())?.into(),
+                operator_cache: default_operator_cache(),
             })),
             #[cfg(feature = "storage-azblob")]
             OpenDalStorageFactory::Azblob => Ok(Arc::new(OpenDalStorage::Azblob {
@@ -175,6 +178,51 @@ fn default_memory_operator() -> Operator {
     memory_config_build().expect("Failed to create default memory operator")
 }
 
+#[cfg(feature = "storage-gcs")]
+type OperatorCache = Arc<RwLock<HashMap<String, Operator>>>;
+
+/// Default empty operator cache for serde deserialization.
+#[cfg(feature = "storage-gcs")]
+fn default_operator_cache() -> OperatorCache {
+    Arc::new(RwLock::new(HashMap::new()))
+}
+
+/// Returns the cached operator for `key`, creating it while holding the write lock if absent.
+#[cfg(feature = "storage-gcs")]
+fn get_or_create_operator(
+    cache: &RwLock<HashMap<String, Operator>>,
+    key: &str,
+    build: impl FnOnce() -> Result<Operator>,
+) -> Result<Operator> {
+    {
+        let cache = cache.read().map_err(|error| {
+            Error::new(
+                ErrorKind::Unexpected,
+                format!("Operator cache lock poisoned: {error}"),
+            )
+        })?;
+        if let Some(operator) = cache.get(key) {
+            return Ok(operator.clone());
+        }
+    }
+
+    let mut cache = cache.write().map_err(|error| {
+        Error::new(
+            ErrorKind::Unexpected,
+            format!("Operator cache lock poisoned: {error}"),
+        )
+    })?;
+
+    // Another caller may have populated the cache while this caller waited for the write lock.
+    if let Some(operator) = cache.get(key) {
+        return Ok(operator.clone());
+    }
+
+    let operator = build()?;
+    cache.insert(key.to_string(), operator.clone());
+    Ok(operator)
+}
+
 /// OpenDAL-based storage implementation.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum OpenDalStorage {
@@ -201,6 +249,9 @@ pub enum OpenDalStorage {
     Gcs {
         /// GCS configuration.
         config: Arc<GcsConfig>,
+        /// Operators keyed by bucket so credential and token caches are reused.
+        #[serde(skip, default = "default_operator_cache")]
+        operator_cache: OperatorCache,
     },
     /// AZBLOB storage variant.
     #[cfg(feature = "storage-azblob")]
@@ -255,6 +306,7 @@ impl OpenDalStorage {
             #[cfg(feature = "storage-gcs")]
             Scheme::Gcs => Ok(Self::Gcs {
                 config: gcs_config_parse(props)?.into(),
+                operator_cache: default_operator_cache(),
             }),
             #[cfg(feature = "storage-azblob")]
             Scheme::Azblob => Ok(Self::Azblob {
@@ -348,8 +400,20 @@ impl OpenDalStorage {
                 }
             }
             #[cfg(feature = "storage-gcs")]
-            OpenDalStorage::Gcs { config } => {
-                let operator = gcs_config_build(config, path)?;
+            OpenDalStorage::Gcs {
+                config,
+                operator_cache,
+            } => {
+                let url = url::Url::parse(path)?;
+                let bucket = url.host_str().ok_or_else(|| {
+                    Error::new(
+                        ErrorKind::DataInvalid,
+                        format!("Invalid gcs url: {path}, bucket is required"),
+                    )
+                })?;
+                let operator = get_or_create_operator(operator_cache, bucket, || {
+                    gcs_config_build(config, path)
+                })?;
                 let prefix = format!("gs://{}/", operator.info().name());
                 if path.starts_with(&prefix) {
                     (operator, &path[prefix.len()..])
@@ -560,6 +624,11 @@ impl FileWrite for opendal::Writer {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(feature = "storage-gcs")]
+    use std::sync::Barrier;
+    #[cfg(feature = "storage-gcs")]
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
     use super::*;
 
     #[cfg(feature = "storage-memory")]
@@ -567,5 +636,90 @@ mod tests {
     fn test_default_memory_operator() {
         let op = default_memory_operator();
         assert_eq!(op.info().scheme().to_string(), "memory");
+    }
+
+    #[cfg(feature = "storage-gcs")]
+    fn test_gcs_storage() -> OpenDalStorage {
+        OpenDalStorage::Gcs {
+            config: Arc::new(GcsConfig::default()),
+            operator_cache: default_operator_cache(),
+        }
+    }
+
+    #[cfg(feature = "storage-gcs")]
+    #[test]
+    fn test_gcs_operator_cache_coalesces_concurrent_builds() {
+        const CONCURRENCY: usize = 16;
+
+        let cache = default_operator_cache();
+        let barrier = Arc::new(Barrier::new(CONCURRENCY));
+        let build_count = Arc::new(AtomicUsize::new(0));
+
+        std::thread::scope(|scope| {
+            for _ in 0..CONCURRENCY {
+                let cache = cache.clone();
+                let barrier = barrier.clone();
+                let build_count = build_count.clone();
+                scope.spawn(move || {
+                    barrier.wait();
+                    get_or_create_operator(&cache, "test-bucket", || {
+                        build_count.fetch_add(1, Ordering::SeqCst);
+                        gcs_config_build(&GcsConfig::default(), "gs://test-bucket/path/to/file")
+                    })
+                    .unwrap();
+                });
+            }
+        });
+
+        assert_eq!(build_count.load(Ordering::SeqCst), 1);
+        assert_eq!(cache.read().unwrap().len(), 1);
+    }
+
+    #[cfg(feature = "storage-gcs")]
+    #[test]
+    fn test_gcs_operator_cache_is_shared_by_clones_and_scoped_to_bucket() {
+        let storage = test_gcs_storage();
+        let cloned_storage = storage.clone();
+
+        storage
+            .create_operator(&"gs://bucket-a/path/to/first-file")
+            .unwrap();
+        cloned_storage
+            .create_operator(&"gs://bucket-a/path/to/second-file")
+            .unwrap();
+        cloned_storage
+            .create_operator(&"gs://bucket-b/path/to/third-file")
+            .unwrap();
+
+        let OpenDalStorage::Gcs { operator_cache, .. } = &storage else {
+            unreachable!()
+        };
+        let OpenDalStorage::Gcs {
+            operator_cache: cloned_operator_cache,
+            ..
+        } = &cloned_storage
+        else {
+            unreachable!()
+        };
+
+        assert!(Arc::ptr_eq(operator_cache, cloned_operator_cache));
+        assert_eq!(operator_cache.read().unwrap().len(), 2);
+    }
+
+    #[cfg(feature = "storage-gcs")]
+    #[test]
+    fn test_gcs_operator_cache_is_reset_after_deserialization() {
+        let storage = test_gcs_storage();
+        storage
+            .create_operator(&"gs://test-bucket/path/to/file")
+            .unwrap();
+
+        let serialized = serde_json::to_string(&storage).unwrap();
+        let deserialized: OpenDalStorage = serde_json::from_str(&serialized).unwrap();
+        let OpenDalStorage::Gcs { operator_cache, .. } = deserialized else {
+            unreachable!()
+        };
+
+        assert!(operator_cache.read().unwrap().is_empty());
     }
 }


### PR DESCRIPTION
## Which issue does this PR close?

- Related upstream discussion: apache/iceberg-rust#2177.
- Related RisingWave incident: risingwavelabs/risingwave#25921.

## What changes are included in this PR?

OpenDAL 0.55 keeps the GCS token cache and the S3 reqsign credential cache inside each operator backend. Rebuilding an operator for every Iceberg file therefore creates an independent credential loader/cache. With metadata- or STS-backed credentials, the first authenticated operation on each operator can fan out to the metadata server or STS.

This PR:

- caches the base S3 and GCS OpenDAL `Operator` per bucket inside `OpenDalStorage`;
- shares the cache across cloned storage instances used by `InputFile` and `OutputFile`;
- performs double-checked insertion under an `RwLock`, so warm cache hits can proceed concurrently while cold builds are coalesced;
- applies timeout and retry layers after cache lookup, preserving the existing per-call runtime configuration;
- skips the runtime cache during serde and recreates it empty after deserialization.

This changes the steady-state credential lookup cardinality from one loader per file operation to one loader per `FileIO`/backend/bucket.

## Are these changes tested?

- Added S3 and GCS concurrent unit tests proving one operator build for 16 simultaneous same-bucket callers.
- Added S3 and GCS coverage for cache sharing across clones, isolation across buckets, and serde reset behavior.
- `cargo +nightly-2025-10-27 fmt --all -- --check`
- `cargo +nightly-2025-10-27 clippy -p iceberg --all-features --all-targets -- -D warnings`
- `cargo test -p iceberg --all-features --lib` (1304 passed)
- `cargo test -p iceberg --no-default-features --features storage-s3 --lib test_s3_operator_cache` (3 passed)
- `cargo test -p iceberg --no-default-features --features storage-gcs --lib test_gcs_operator_cache` (3 passed)

## Scope

This PR removes the per-file operator and credential-loader churn. It does not add singleflight inside reqsign token refresh, so a separate upstream change may still be useful to coalesce callers that arrive at the same cold-start or refresh boundary.
