### PR TITLE
feat(scan): prune equality deletes using file metrics

### DIFF
--- a/crates/iceberg/src/delete_file_index.rs
+++ b/crates/iceberg/src/delete_file_index.rs
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use std::cmp::Ordering;
 use std::collections::HashMap;
 use std::ops::Deref;
 use std::sync::{Arc, RwLock};
@@ -44,6 +45,50 @@ fn inferred_referenced_data_file(delete_file: &DataFile) -> Option<String> {
 
     let bytes = lower.to_bytes().ok()?;
     std::str::from_utf8(bytes.as_ref()).ok().map(str::to_owned)
+}
+
+fn may_contain_null(file: &DataFile, field_id: i32) -> bool {
+    file.null_value_counts()
+        .get(&field_id)
+        .is_none_or(|count| *count > 0)
+}
+
+/// Returns whether an equality delete file may contain a row that matches the data file.
+///
+/// File metrics are used only to prove that a match is impossible. Missing or incompatible
+/// metrics fail open so that scan planning never drops a delete that may apply.
+fn can_contain_eq_deletes_for_file(data_file: &DataFile, delete_file: &DataFile) -> bool {
+    let Some(equality_ids) = delete_file.equality_ids.as_deref() else {
+        return true;
+    };
+
+    for &field_id in equality_ids {
+        if may_contain_null(data_file, field_id) && may_contain_null(delete_file, field_id) {
+            // Null equals null for equality deletes, so this field may match.
+            continue;
+        }
+
+        let (Some(data_lower), Some(data_upper), Some(delete_lower), Some(delete_upper)) = (
+            data_file.lower_bounds().get(&field_id),
+            data_file.upper_bounds().get(&field_id),
+            delete_file.lower_bounds().get(&field_id),
+            delete_file.upper_bounds().get(&field_id),
+        ) else {
+            continue;
+        };
+
+        if matches!(
+            data_lower.partial_cmp(delete_upper),
+            Some(Ordering::Greater)
+        ) || matches!(
+            delete_lower.partial_cmp(data_upper),
+            Some(Ordering::Greater)
+        ) {
+            return false;
+        }
+    }
+
+    true
 }
 
 /// Index of delete files
@@ -198,6 +243,7 @@ impl PopulatedDeleteFileIndex {
                 seq_num
                     .map(|seq_num| delete.manifest_entry.sequence_number() > Some(seq_num))
                     .unwrap_or_else(|| true)
+                    && can_contain_eq_deletes_for_file(data_file, delete.manifest_entry.data_file())
             })
             .for_each(|delete| results.push(delete.as_ref().into()));
 
@@ -210,6 +256,10 @@ impl PopulatedDeleteFileIndex {
                         .map(|seq_num| delete.manifest_entry.sequence_number() > Some(seq_num))
                         .unwrap_or_else(|| true)
                         && data_file.partition_spec_id == delete.partition_spec_id
+                        && can_contain_eq_deletes_for_file(
+                            data_file,
+                            delete.manifest_entry.data_file(),
+                        )
                 })
                 .for_each(|delete| results.push(delete.as_ref().into()));
         }
@@ -438,6 +488,53 @@ mod tests {
         assert!(actual_paths_to_apply_for_different_spec.is_empty());
     }
 
+    #[test]
+    fn test_equality_delete_metrics_pruning() {
+        let data_file =
+            with_int_metrics(build_unpartitioned_data_file(), 1, Some(100), Some(200), 0);
+
+        let disjoint_delete =
+            with_int_metrics(build_unpartitioned_eq_delete(), 1, Some(1), Some(10), 0);
+        assert!(!can_contain_eq_deletes_for_file(
+            &data_file,
+            &disjoint_delete
+        ));
+
+        for (lower, upper) in [(150, 250), (200, 250)] {
+            let delete_file = with_int_metrics(
+                build_unpartitioned_eq_delete(),
+                1,
+                Some(lower),
+                Some(upper),
+                0,
+            );
+            assert!(can_contain_eq_deletes_for_file(&data_file, &delete_file));
+        }
+
+        let missing_bound_delete =
+            with_int_metrics(build_unpartitioned_eq_delete(), 1, Some(1), None, 0);
+        assert!(can_contain_eq_deletes_for_file(
+            &data_file,
+            &missing_bound_delete
+        ));
+
+        let data_with_null =
+            with_int_metrics(build_unpartitioned_data_file(), 1, Some(100), Some(200), 1);
+        let delete_with_null =
+            with_int_metrics(build_unpartitioned_eq_delete(), 1, Some(1), Some(10), 1);
+        assert!(can_contain_eq_deletes_for_file(
+            &data_with_null,
+            &delete_with_null
+        ));
+
+        let data_file = with_int_metrics(data_file, 2, Some(10), Some(20), 0);
+        let mut delete_file =
+            with_int_metrics(build_unpartitioned_eq_delete(), 1, Some(150), Some(250), 0);
+        delete_file.equality_ids = Some(vec![1, 2]);
+        let delete_file = with_int_metrics(delete_file, 2, Some(30), Some(40), 0);
+        assert!(!can_contain_eq_deletes_for_file(&data_file, &delete_file));
+    }
+
     fn build_unpartitioned_eq_delete() -> DataFile {
         build_partitioned_eq_delete(&Struct::empty(), 0)
     }
@@ -497,6 +594,23 @@ mod tests {
             .file_size_in_bytes(100)
             .build()
             .unwrap()
+    }
+
+    fn with_int_metrics(
+        mut file: DataFile,
+        field_id: i32,
+        lower: Option<i32>,
+        upper: Option<i32>,
+        null_count: u64,
+    ) -> DataFile {
+        file.null_value_counts.insert(field_id, null_count);
+        if let Some(lower) = lower {
+            file.lower_bounds.insert(field_id, Datum::int(lower));
+        }
+        if let Some(upper) = upper {
+            file.upper_bounds.insert(field_id, Datum::int(upper));
+        }
+        file
     }
 
     fn build_added_manifest_entry(data_seq_number: i64, file: &DataFile) -> ManifestEntry {

--- a/crates/iceberg/src/writer/base_writer/equality_delete_writer.rs
+++ b/crates/iceberg/src/writer/base_writer/equality_delete_writer.rs
@@ -488,6 +488,26 @@ mod test {
         assert_eq!(res.len(), 1);
         let data_file = res.into_iter().next().unwrap();
 
+        assert_eq!(data_file.equality_ids(), Some(vec![0, 8]));
+        assert_eq!(
+            *data_file.null_value_counts(),
+            HashMap::from([(0, 0), (8, 0)])
+        );
+        assert_eq!(
+            *data_file.lower_bounds(),
+            HashMap::from([
+                (0, crate::spec::Datum::int(1)),
+                (8, crate::spec::Datum::int(1))
+            ])
+        );
+        assert_eq!(
+            *data_file.upper_bounds(),
+            HashMap::from([
+                (0, crate::spec::Datum::int(1)),
+                (8, crate::spec::Datum::int(1))
+            ])
+        );
+
         // check
         let to_write_projected = projector.project_batch(to_write)?;
         check_parquet_data_file_with_equality_delete_write(


### PR DESCRIPTION
## Which issue does this PR close?

- None. This is a RisingWave-specific copy-on-write compaction optimization.

## What changes are included in this PR?

- Prune equality delete files from a data-file scan task when file metrics prove that at least one equality field has disjoint value ranges.
- Preserve correctness by failing open when bounds, null counts, equality IDs, or comparable metric types are unavailable.
- Keep equality deletes when both files may contain null for an equality field, because null matches null under equality-delete semantics.
- Extend the existing equality-delete writer test to verify that equality IDs, null counts, and lower/upper bounds are written.

The optimization is intentionally scoped to metrics produced by the current RisingWave writer. Files from other writers remain correct but may not be pruned when their metrics are incomplete.

## Downstream

- https://github.com/nimtable/iceberg-compaction/pull/170
- https://github.com/risingwavelabs/risingwave/pull/26768

## Are these changes tested?

- `RUSTC_WRAPPER= cargo test -p iceberg delete_file_index` (5 passed)
- `RUSTC_WRAPPER= cargo test -p iceberg test_equality_delete_writer` (1 passed)
- `RUSTC_WRAPPER= cargo test -p iceberg test_data_file_serialize_deserialize` (2 passed)
- `RUSTC_WRAPPER= cargo clippy -p iceberg --tests -- -D warnings`

## AI Disclosure

This change was developed with assistance from OpenAI Codex. The resulting implementation and tests were reviewed and validated against the repository code and RisingWave's end-to-end copy-on-write path.
