### PR TITLE
feat(scan): prune position deletes using file path bounds

### DIFF
--- a/crates/iceberg/src/delete_file_index.rs
+++ b/crates/iceberg/src/delete_file_index.rs
@@ -31,20 +31,41 @@ use crate::spec::{DataContentType, DataFile, Struct};
 // Iceberg field ID for the `file_path` column in position delete files.
 const POSITION_DELETE_FILE_PATH_FIELD_ID: i32 = 2147483546;
 
-fn inferred_referenced_data_file(delete_file: &DataFile) -> Option<String> {
-    let lower = delete_file
-        .lower_bounds
-        .get(&POSITION_DELETE_FILE_PATH_FIELD_ID)?;
-    let upper = delete_file
-        .upper_bounds
-        .get(&POSITION_DELETE_FILE_PATH_FIELD_ID)?;
-
-    if lower != upper {
-        return None;
+/// Returns whether a position delete file may contain deletes for the data file.
+///
+/// An explicit referenced data file is exact and takes precedence over metrics. Otherwise, file
+/// path bounds are used only to prove that the data file is outside the delete file's path range.
+/// Missing or incompatible metrics fail open so that scan planning never drops an applicable
+/// delete.
+fn can_contain_pos_deletes_for_file(data_file: &DataFile, delete_file: &DataFile) -> bool {
+    if let Some(referenced_data_file) = delete_file.referenced_data_file() {
+        return referenced_data_file == data_file.file_path();
     }
 
-    let bytes = lower.to_bytes().ok()?;
-    std::str::from_utf8(bytes.as_ref()).ok().map(str::to_owned)
+    let (Some(lower), Some(upper)) = (
+        delete_file
+            .lower_bounds()
+            .get(&POSITION_DELETE_FILE_PATH_FIELD_ID),
+        delete_file
+            .upper_bounds()
+            .get(&POSITION_DELETE_FILE_PATH_FIELD_ID),
+    ) else {
+        return true;
+    };
+    let data_file_path = crate::spec::Datum::string(data_file.file_path());
+
+    let (Some(lower_to_upper), Some(path_to_lower), Some(path_to_upper)) = (
+        lower.partial_cmp(upper),
+        data_file_path.partial_cmp(lower),
+        data_file_path.partial_cmp(upper),
+    ) else {
+        return true;
+    };
+    if lower_to_upper == Ordering::Greater {
+        return true;
+    }
+
+    path_to_lower != Ordering::Less && path_to_upper != Ordering::Greater
 }
 
 fn may_contain_null(file: &DataFile, field_id: i32) -> bool {
@@ -270,16 +291,12 @@ impl PopulatedDeleteFileIndex {
                 // filter that returns true if the provided delete file's sequence number is **greater than or equal to** `seq_num`
                 .filter(|&delete| {
                     let delete_file = delete.manifest_entry.data_file();
-                    let referenced_data_file_matches = delete_file
-                        .referenced_data_file()
-                        .or_else(|| inferred_referenced_data_file(delete_file))
-                        .is_none_or(|path| path == data_file.file_path());
 
                     seq_num
                         .map(|seq_num| delete.manifest_entry.sequence_number() >= Some(seq_num))
                         .unwrap_or_else(|| true)
                         && data_file.partition_spec_id == delete.partition_spec_id
-                        && referenced_data_file_matches
+                        && can_contain_pos_deletes_for_file(data_file, delete_file)
                 })
                 .for_each(|delete| results.push(delete.as_ref().into()));
         }
@@ -571,8 +588,12 @@ mod tests {
     }
 
     fn build_unpartitioned_data_file() -> DataFile {
+        build_unpartitioned_data_file_with_path(format!("{}-data.parquet", Uuid::new_v4()))
+    }
+
+    fn build_unpartitioned_data_file_with_path(file_path: impl Into<String>) -> DataFile {
         DataFileBuilder::default()
-            .file_path(format!("{}-data.parquet", Uuid::new_v4()))
+            .file_path(file_path.into())
             .file_format(DataFileFormat::Parquet)
             .content(DataContentType::Data)
             .record_count(100)
@@ -660,37 +681,42 @@ mod tests {
     }
 
     #[test]
-    fn test_position_delete_single_path_bounds_pruning() {
-        let data_file = build_unpartitioned_data_file();
-        let other_data_file = build_unpartitioned_data_file();
-        let path = Datum::string(data_file.file_path());
-        let bounded_delete = DataFileBuilder::default()
-            .file_path("bounded-delete.parquet".to_string())
-            .file_format(DataFileFormat::Parquet)
-            .content(DataContentType::PositionDeletes)
-            .record_count(1)
-            .lower_bounds(HashMap::from([(
-                POSITION_DELETE_FILE_PATH_FIELD_ID,
-                path.clone(),
-            )]))
-            .upper_bounds(HashMap::from([(POSITION_DELETE_FILE_PATH_FIELD_ID, path)]))
-            .partition(Struct::empty())
-            .partition_spec_id(0)
-            .file_size_in_bytes(100)
-            .build()
-            .unwrap();
+    fn test_position_delete_path_bounds_pruning() {
+        let mut bounded_delete = build_unpartitioned_pos_delete();
+        bounded_delete.lower_bounds.insert(
+            POSITION_DELETE_FILE_PATH_FIELD_ID,
+            Datum::string("s3://bucket/data/file-00002.parquet"),
+        );
+        bounded_delete.upper_bounds.insert(
+            POSITION_DELETE_FILE_PATH_FIELD_ID,
+            Datum::string("s3://bucket/data/file-00004.parquet"),
+        );
         let index = PopulatedDeleteFileIndex::new(vec![DeleteFileContext {
             manifest_entry: build_added_manifest_entry(1, &bounded_delete).into(),
             partition_spec_id: 0,
         }]);
 
+        let matching_file =
+            build_unpartitioned_data_file_with_path("s3://bucket/data/file-00003.parquet");
+        let before_range =
+            build_unpartitioned_data_file_with_path("s3://bucket/data/file-00001.parquet");
+        let after_range =
+            build_unpartitioned_data_file_with_path("s3://bucket/data/file-00005.parquet");
+
         assert_eq!(
-            index.get_deletes_for_data_file(&data_file, Some(0)).len(),
+            index
+                .get_deletes_for_data_file(&matching_file, Some(0))
+                .len(),
             1
         );
         assert!(
             index
-                .get_deletes_for_data_file(&other_data_file, Some(0))
+                .get_deletes_for_data_file(&before_range, Some(0))
+                .is_empty()
+        );
+        assert!(
+            index
+                .get_deletes_for_data_file(&after_range, Some(0))
                 .is_empty()
         );
     }

--- a/crates/iceberg/src/delete_file_index.rs
+++ b/crates/iceberg/src/delete_file_index.rs
@@ -703,6 +703,11 @@ mod tests {
         let after_range =
             build_unpartitioned_data_file_with_path("s3://bucket/data/file-00005.parquet");
 
+        assert!(can_contain_pos_deletes_for_file(
+            &before_range,
+            &build_unpartitioned_pos_delete()
+        ));
+
         assert_eq!(
             index
                 .get_deletes_for_data_file(&matching_file, Some(0))

--- a/crates/iceberg/src/writer/base_writer/position_delete_file_writer.rs
+++ b/crates/iceberg/src/writer/base_writer/position_delete_file_writer.rs
@@ -21,7 +21,7 @@
 //! as required by the Iceberg specification. Ordering and deduplication must be handled by the
 //! caller (e.g. by using a sorting writer) before passing records to this writer.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 use std::sync::Arc;
 
 use arrow_array::RecordBatch;
@@ -32,8 +32,8 @@ use once_cell::sync::Lazy;
 
 use crate::arrow::schema_to_arrow_schema;
 use crate::spec::{
-    DataContentType, DataFile, Datum, NestedField, NestedFieldRef, PartitionKey, PrimitiveType,
-    Schema, Struct, Type,
+    DataContentType, DataFile, NestedField, NestedFieldRef, PartitionKey, PrimitiveType, Schema,
+    Struct, Type,
 };
 use crate::writer::file_writer::FileWriterBuilder;
 use crate::writer::file_writer::location_generator::{FileNameGenerator, LocationGenerator};
@@ -121,7 +121,6 @@ where
             inner: Some(self.inner.build()),
             partition_key,
             distinct_paths: HashSet::new(),
-            path_bounds_by_delete_file: HashMap::new(),
         })
     }
 }
@@ -135,7 +134,6 @@ pub struct PositionDeleteFileWriter<
     inner: Option<RollingFileWriter<B, L, F>>,
     partition_key: Option<PartitionKey>,
     distinct_paths: HashSet<Arc<str>>,
-    path_bounds_by_delete_file: HashMap<String, (Arc<str>, Arc<str>)>,
 }
 
 #[async_trait::async_trait]
@@ -153,25 +151,11 @@ where
         for pd in &input {
             self.distinct_paths.insert(Arc::clone(&pd.path));
         }
-        let lower_path = Arc::clone(&input.first().unwrap().path);
-        let upper_path = Arc::clone(&input.last().unwrap().path);
 
         let batch = build_position_delete_batch(input)?;
 
         if let Some(writer) = self.inner.as_mut() {
-            writer.write(&self.partition_key, &batch).await?;
-            self.path_bounds_by_delete_file
-                .entry(writer.current_file_path())
-                .and_modify(|(lower, upper)| {
-                    if lower_path < *lower {
-                        *lower = lower_path.clone();
-                    }
-                    if upper_path > *upper {
-                        *upper = upper_path.clone();
-                    }
-                })
-                .or_insert((lower_path, upper_path));
-            Ok(())
+            writer.write(&self.partition_key, &batch).await
         } else {
             Err(Error::new(
                 ErrorKind::Unexpected,
@@ -206,23 +190,12 @@ where
                     if let Some(ref_path) = single_ref.as_ref() {
                         builder.referenced_data_file(Some(ref_path.clone()));
                     }
-                    let mut data_file = builder.build().map_err(|e| {
+                    builder.build().map_err(|e| {
                         Error::new(
                             ErrorKind::DataInvalid,
                             format!("Failed to build position delete file: {e}"),
                         )
-                    })?;
-                    if let Some((lower, upper)) =
-                        self.path_bounds_by_delete_file.get(data_file.file_path())
-                    {
-                        data_file
-                            .lower_bounds_mut()
-                            .insert(DELETE_FILE_PATH.id, Datum::string(lower.as_ref()));
-                        data_file
-                            .upper_bounds_mut()
-                            .insert(DELETE_FILE_PATH.id, Datum::string(upper.as_ref()));
-                    }
-                    Ok(data_file)
+                    })
                 })
                 .collect()
         } else {
@@ -308,8 +281,12 @@ mod tests {
             DefaultFileNameGenerator::new("pos_del".to_string(), None, DataFileFormat::Parquet);
 
         let schema = Arc::new(POSITION_DELETE_SCHEMA.clone());
-        let parquet_builder =
-            ParquetWriterBuilder::new(WriterProperties::builder().build(), schema.clone());
+        let parquet_builder = ParquetWriterBuilder::new(
+            WriterProperties::builder()
+                .set_statistics_truncate_length(None)
+                .build(),
+            schema.clone(),
+        );
 
         let rolling_builder = RollingFileWriterBuilder::new_with_default_file_size(
             parquet_builder,

--- a/crates/iceberg/src/writer/base_writer/position_delete_file_writer.rs
+++ b/crates/iceberg/src/writer/base_writer/position_delete_file_writer.rs
@@ -21,7 +21,7 @@
 //! as required by the Iceberg specification. Ordering and deduplication must be handled by the
 //! caller (e.g. by using a sorting writer) before passing records to this writer.
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 use arrow_array::RecordBatch;
@@ -32,8 +32,8 @@ use once_cell::sync::Lazy;
 
 use crate::arrow::schema_to_arrow_schema;
 use crate::spec::{
-    DataContentType, DataFile, NestedField, NestedFieldRef, PartitionKey, PrimitiveType, Schema,
-    Struct, Type,
+    DataContentType, DataFile, Datum, NestedField, NestedFieldRef, PartitionKey, PrimitiveType,
+    Schema, Struct, Type,
 };
 use crate::writer::file_writer::FileWriterBuilder;
 use crate::writer::file_writer::location_generator::{FileNameGenerator, LocationGenerator};
@@ -121,6 +121,7 @@ where
             inner: Some(self.inner.build()),
             partition_key,
             distinct_paths: HashSet::new(),
+            path_bounds_by_delete_file: HashMap::new(),
         })
     }
 }
@@ -134,6 +135,7 @@ pub struct PositionDeleteFileWriter<
     inner: Option<RollingFileWriter<B, L, F>>,
     partition_key: Option<PartitionKey>,
     distinct_paths: HashSet<Arc<str>>,
+    path_bounds_by_delete_file: HashMap<String, (Arc<str>, Arc<str>)>,
 }
 
 #[async_trait::async_trait]
@@ -151,11 +153,25 @@ where
         for pd in &input {
             self.distinct_paths.insert(Arc::clone(&pd.path));
         }
+        let lower_path = Arc::clone(&input.first().unwrap().path);
+        let upper_path = Arc::clone(&input.last().unwrap().path);
 
         let batch = build_position_delete_batch(input)?;
 
         if let Some(writer) = self.inner.as_mut() {
-            writer.write(&self.partition_key, &batch).await
+            writer.write(&self.partition_key, &batch).await?;
+            self.path_bounds_by_delete_file
+                .entry(writer.current_file_path())
+                .and_modify(|(lower, upper)| {
+                    if lower_path < *lower {
+                        *lower = lower_path.clone();
+                    }
+                    if upper_path > *upper {
+                        *upper = upper_path.clone();
+                    }
+                })
+                .or_insert((lower_path, upper_path));
+            Ok(())
         } else {
             Err(Error::new(
                 ErrorKind::Unexpected,
@@ -190,12 +206,23 @@ where
                     if let Some(ref_path) = single_ref.as_ref() {
                         builder.referenced_data_file(Some(ref_path.clone()));
                     }
-                    builder.build().map_err(|e| {
+                    let mut data_file = builder.build().map_err(|e| {
                         Error::new(
                             ErrorKind::DataInvalid,
                             format!("Failed to build position delete file: {e}"),
                         )
-                    })
+                    })?;
+                    if let Some((lower, upper)) =
+                        self.path_bounds_by_delete_file.get(data_file.file_path())
+                    {
+                        data_file
+                            .lower_bounds_mut()
+                            .insert(DELETE_FILE_PATH.id, Datum::string(lower.as_ref()));
+                        data_file
+                            .upper_bounds_mut()
+                            .insert(DELETE_FILE_PATH.id, Datum::string(upper.as_ref()));
+                    }
+                    Ok(data_file)
                 })
                 .collect()
         } else {
@@ -259,8 +286,8 @@ mod tests {
     use super::*;
     use crate::io::FileIO;
     use crate::spec::{
-        DataFileFormat, Literal, NestedField, PartitionKey, PartitionSpec, PrimitiveType, Schema,
-        Struct, Type,
+        DataFileFormat, Datum, Literal, NestedField, PartitionKey, PartitionSpec, PrimitiveType,
+        Schema, Struct, Type,
     };
     use crate::writer::file_writer::ParquetWriterBuilder;
     use crate::writer::file_writer::location_generator::{
@@ -295,10 +322,12 @@ mod tests {
             .build(None)
             .await?;
 
+        let first_path = "s3://bucket/warehouse/namespace/table/data/00000-0-00000000-0000-0000-0000-000000000001.parquet";
+        let second_path = "s3://bucket/warehouse/namespace/table/data/00000-0-00000000-0000-0000-0000-000000000002.parquet";
         let deletes = vec![
-            PositionDeleteInput::new(Arc::from("s3://bucket/data/file-1.parquet"), 1),
-            PositionDeleteInput::new(Arc::from("s3://bucket/data/file-1.parquet"), 2),
-            PositionDeleteInput::new(Arc::from("s3://bucket/data/file-2.parquet"), 5),
+            PositionDeleteInput::new(Arc::from(first_path), 1),
+            PositionDeleteInput::new(Arc::from(first_path), 2),
+            PositionDeleteInput::new(Arc::from(second_path), 5),
         ];
 
         let expected_batch = RecordBatch::try_new(
@@ -315,11 +344,7 @@ mod tests {
                     )])),
             ])),
             vec![
-                Arc::new(StringArray::from(vec![
-                    "s3://bucket/data/file-1.parquet",
-                    "s3://bucket/data/file-1.parquet",
-                    "s3://bucket/data/file-2.parquet",
-                ])),
+                Arc::new(StringArray::from(vec![first_path, first_path, second_path])),
                 Arc::new(Int64Array::from(vec![1, 2, 5])),
             ],
         )?;
@@ -333,6 +358,14 @@ mod tests {
             DataContentType::PositionDeletes
         );
         assert_eq!(data_files[0].partition(), &Struct::empty());
+        assert_eq!(
+            data_files[0].lower_bounds().get(&DELETE_FILE_PATH.id),
+            Some(&Datum::string(first_path))
+        );
+        assert_eq!(
+            data_files[0].upper_bounds().get(&DELETE_FILE_PATH.id),
+            Some(&Datum::string(second_path))
+        );
 
         check_parquet_data_file(&file_io, &data_files[0], &expected_batch).await;
 

--- a/crates/iceberg/src/writer/base_writer/position_delete_file_writer.rs
+++ b/crates/iceberg/src/writer/base_writer/position_delete_file_writer.rs
@@ -259,8 +259,8 @@ mod tests {
     use super::*;
     use crate::io::FileIO;
     use crate::spec::{
-        DataFileFormat, Datum, Literal, NestedField, PartitionKey, PartitionSpec, PrimitiveType,
-        Schema, Struct, Type,
+        DataFileFormat, Literal, NestedField, PartitionKey, PartitionSpec, PrimitiveType, Schema,
+        Struct, Type,
     };
     use crate::writer::file_writer::ParquetWriterBuilder;
     use crate::writer::file_writer::location_generator::{
@@ -281,12 +281,8 @@ mod tests {
             DefaultFileNameGenerator::new("pos_del".to_string(), None, DataFileFormat::Parquet);
 
         let schema = Arc::new(POSITION_DELETE_SCHEMA.clone());
-        let parquet_builder = ParquetWriterBuilder::new(
-            WriterProperties::builder()
-                .set_statistics_truncate_length(None)
-                .build(),
-            schema.clone(),
-        );
+        let parquet_builder =
+            ParquetWriterBuilder::new(WriterProperties::builder().build(), schema.clone());
 
         let rolling_builder = RollingFileWriterBuilder::new_with_default_file_size(
             parquet_builder,
@@ -299,12 +295,10 @@ mod tests {
             .build(None)
             .await?;
 
-        let first_path = "s3://bucket/warehouse/namespace/table/data/00000-0-00000000-0000-0000-0000-000000000001.parquet";
-        let second_path = "s3://bucket/warehouse/namespace/table/data/00000-0-00000000-0000-0000-0000-000000000002.parquet";
         let deletes = vec![
-            PositionDeleteInput::new(Arc::from(first_path), 1),
-            PositionDeleteInput::new(Arc::from(first_path), 2),
-            PositionDeleteInput::new(Arc::from(second_path), 5),
+            PositionDeleteInput::new(Arc::from("s3://bucket/data/file-1.parquet"), 1),
+            PositionDeleteInput::new(Arc::from("s3://bucket/data/file-1.parquet"), 2),
+            PositionDeleteInput::new(Arc::from("s3://bucket/data/file-2.parquet"), 5),
         ];
 
         let expected_batch = RecordBatch::try_new(
@@ -321,7 +315,11 @@ mod tests {
                     )])),
             ])),
             vec![
-                Arc::new(StringArray::from(vec![first_path, first_path, second_path])),
+                Arc::new(StringArray::from(vec![
+                    "s3://bucket/data/file-1.parquet",
+                    "s3://bucket/data/file-1.parquet",
+                    "s3://bucket/data/file-2.parquet",
+                ])),
                 Arc::new(Int64Array::from(vec![1, 2, 5])),
             ],
         )?;
@@ -335,14 +333,6 @@ mod tests {
             DataContentType::PositionDeletes
         );
         assert_eq!(data_files[0].partition(), &Struct::empty());
-        assert_eq!(
-            data_files[0].lower_bounds().get(&DELETE_FILE_PATH.id),
-            Some(&Datum::string(first_path))
-        );
-        assert_eq!(
-            data_files[0].upper_bounds().get(&DELETE_FILE_PATH.id),
-            Some(&Datum::string(second_path))
-        );
 
         check_parquet_data_file(&file_io, &data_files[0], &expected_batch).await;
 


### PR DESCRIPTION
## Which issue does this PR close?

- None. This supports RisingWave copy-on-write compaction planning.

## What changes are included in this PR?

- Use `referenced_data_file` as the exact position-delete scope when it is present.
- Otherwise use existing position-delete `file_path` lower and upper bounds to exclude data files outside that range.
- Fail open when bounds are missing, inverted, or not comparable, so scan planning never drops a possibly applicable delete.
- Leave position-delete writer metrics and Parquet statistics truncation unchanged.

## Downstream

- https://github.com/nimtable/iceberg-compaction/pull/171
- https://github.com/risingwavelabs/risingwave/pull/26768

## Are these changes tested?

- `RUSTC_WRAPPER= cargo test -p iceberg delete_file_index::tests` (5 passed)
- `RUSTC_WRAPPER= cargo clippy -p iceberg --lib --tests -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

## AI Disclosure

This change was developed with assistance from OpenAI Codex. The resulting read-side filtering logic and conservative fallback behavior were reviewed and tested.
