### PR TITLE
feat(transaction): allow delete cleanup sequence override

### DIFF
--- a/crates/iceberg/src/transaction/replace_files.rs
+++ b/crates/iceberg/src/transaction/replace_files.rs
@@ -233,6 +233,7 @@ pub struct ReplaceFilesAction<M: ReplaceFilesMode> {
     removed_delete_files: Vec<DataFile>,
     snapshot_id: Option<i64>,
     new_data_file_sequence_number: Option<i64>,
+    delete_file_cleanup_min_data_sequence_number: Option<i64>,
     target_branch: Option<String>,
     enable_delete_filter_manager: bool,
     check_file_existence: bool,
@@ -258,6 +259,7 @@ impl<M: ReplaceFilesMode> ReplaceFilesAction<M> {
             removed_delete_files: Vec::new(),
             snapshot_id: None,
             new_data_file_sequence_number: None,
+            delete_file_cleanup_min_data_sequence_number: None,
             target_branch: None,
             enable_delete_filter_manager: true,
             check_file_existence: false,
@@ -334,6 +336,16 @@ impl<M: ReplaceFilesMode> ReplaceFilesAction<M> {
         self
     }
 
+    /// Set the minimum data sequence used to retire older delete files.
+    ///
+    /// If omitted, the minimum sequence from all data manifests is used. An
+    /// override must not exceed the data sequence of any live data file to which
+    /// an existing delete may apply.
+    pub fn set_delete_file_cleanup_min_data_sequence_number(mut self, seq: i64) -> Self {
+        self.delete_file_cleanup_min_data_sequence_number = Some(seq);
+        self
+    }
+
     pub fn set_check_file_existence(mut self, check: bool) -> Self {
         self.check_file_existence = check;
         self
@@ -365,6 +377,19 @@ impl<M: ReplaceFilesMode> TransactionAction for ReplaceFilesAction<M> {
             }
         }
 
+        if let Some(sequence_number) = self.delete_file_cleanup_min_data_sequence_number {
+            let last_sequence_number = table.metadata().last_sequence_number();
+            if sequence_number < 0 || sequence_number > last_sequence_number {
+                return Err(crate::Error::new(
+                    crate::ErrorKind::DataInvalid,
+                    format!(
+                        "Delete file cleanup minimum data sequence number {sequence_number} must \
+                         be between 0 and the table's last sequence number {last_sequence_number}"
+                    ),
+                ));
+            }
+        }
+
         let mut snapshot_producer = SnapshotProducer::new(
             table,
             self.commit_uuid.unwrap_or_else(Uuid::now_v7),
@@ -378,6 +403,10 @@ impl<M: ReplaceFilesMode> TransactionAction for ReplaceFilesAction<M> {
 
         if let Some(seq) = self.new_data_file_sequence_number {
             snapshot_producer.set_new_data_file_sequence_number(seq);
+        }
+
+        if let Some(seq) = self.delete_file_cleanup_min_data_sequence_number {
+            snapshot_producer.set_delete_file_cleanup_min_data_sequence_number(seq);
         }
 
         if let Some(branch) = &self.target_branch {
@@ -421,6 +450,7 @@ mod tests {
         ManifestWriterBuilder, Operation, Snapshot, SnapshotRef, SnapshotReference,
         SnapshotRetention, Struct, Summary, UnboundPartitionSpec,
     };
+    use crate::table::Table;
     use crate::test_utils::make_encrypted_table;
     use crate::transaction::snapshot::{SnapshotProduceOperation, SnapshotProducer};
     use crate::transaction::tests::{
@@ -430,6 +460,31 @@ mod tests {
     };
     use crate::transaction::{Transaction, TransactionAction};
     use crate::{ErrorKind, TableRequirement, TableUpdate};
+
+    async fn delete_file_statuses(table: &Table, snapshot: &Snapshot) -> Vec<ManifestStatus> {
+        let manifest_list = table
+            .manifest_list_reader(&SnapshotRef::new(snapshot.clone()))
+            .load()
+            .await
+            .unwrap();
+        let mut statuses = Vec::new();
+        for manifest_file in manifest_list
+            .entries()
+            .iter()
+            .filter(|manifest| manifest.content == ManifestContentType::Deletes)
+        {
+            statuses.extend(
+                manifest_file
+                    .load_manifest(table.file_io())
+                    .await
+                    .unwrap()
+                    .entries()
+                    .iter()
+                    .map(|entry| entry.status()),
+            );
+        }
+        statuses
+    }
 
     #[test]
     fn test_modes_map_to_their_operations() {
@@ -682,7 +737,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_requested_data_sequence_keeps_newer_delete_files() {
+    async fn test_delete_cleanup_sequence_override() {
         let table = make_v2_table_with_delete_manifest().await;
         let parent = table.metadata().current_snapshot().unwrap();
         let later_snapshot_id = PARENT_SNAPSHOT_ID + 1;
@@ -727,34 +782,13 @@ mod tests {
         let action = Transaction::new(&table)
             .rewrite_files()
             .set_new_data_file_sequence_number(PARENT_SEQUENCE_NUMBER)
-            .add_data_files([added_file]);
+            .add_data_files([added_file.clone()]);
         let mut action_commit = Arc::new(action).commit(&table).await.unwrap();
         let updates = action_commit.take_updates();
         let TableUpdate::AddSnapshot { snapshot } = &updates[0] else {
             unreachable!()
         };
-        let manifest_list = table
-            .manifest_list_reader(&SnapshotRef::new(snapshot.clone()))
-            .load()
-            .await
-            .unwrap();
-
-        let mut delete_statuses = Vec::new();
-        for manifest_file in manifest_list
-            .entries()
-            .iter()
-            .filter(|manifest| manifest.content == ManifestContentType::Deletes)
-        {
-            delete_statuses.extend(
-                manifest_file
-                    .load_manifest(table.file_io())
-                    .await
-                    .unwrap()
-                    .entries()
-                    .iter()
-                    .map(|entry| entry.status()),
-            );
-        }
+        let delete_statuses = delete_file_statuses(&table, snapshot).await;
 
         assert_eq!(delete_statuses.len(), 2);
         assert!(
@@ -762,6 +796,23 @@ mod tests {
                 .iter()
                 .all(|status| *status != ManifestStatus::Deleted),
             "delete files newer than the explicitly retained data sequence must stay live"
+        );
+
+        let action = Transaction::new(&table)
+            .rewrite_files()
+            .set_new_data_file_sequence_number(PARENT_SEQUENCE_NUMBER + 1)
+            .set_delete_file_cleanup_min_data_sequence_number(PARENT_SEQUENCE_NUMBER + 1)
+            .add_data_files([added_file]);
+        let mut action_commit = Arc::new(action).commit(&table).await.unwrap();
+        let updates = action_commit.take_updates();
+        let TableUpdate::AddSnapshot { snapshot } = &updates[0] else {
+            unreachable!()
+        };
+        let delete_statuses = delete_file_statuses(&table, snapshot).await;
+        assert!(
+            delete_statuses
+                .iter()
+                .all(|status| *status == ManifestStatus::Deleted)
         );
     }
 

--- a/crates/iceberg/src/transaction/snapshot.rs
+++ b/crates/iceberg/src/transaction/snapshot.rs
@@ -142,6 +142,7 @@ pub(crate) struct SnapshotProducer<'a> {
     // It is shared with ManifestWriterContext to avoid naming conflicts.
     manifest_counter: Arc<AtomicU64>,
     new_data_file_sequence_number: Option<i64>,
+    delete_file_cleanup_min_data_sequence_number: Option<i64>,
     target_branch: String,
     delete_filter_manager: Option<ManifestFilterManager>,
 }
@@ -183,6 +184,7 @@ impl<'a> SnapshotProducer<'a> {
             removed_delete_files,
             manifest_counter: Arc::new(AtomicU64::new(0)),
             new_data_file_sequence_number: None,
+            delete_file_cleanup_min_data_sequence_number: None,
             target_branch: MAIN_BRANCH.to_string(),
             delete_filter_manager: None,
         }
@@ -531,14 +533,21 @@ impl<'a> SnapshotProducer<'a> {
                 self.new_data_file_sequence_number
                     .unwrap_or(last_sequence_number),
             );
-            let min_data_sequence_number = data_manifests
-                .iter()
-                .map(|manifest| manifest.min_sequence_number)
-                .filter(|sequence| *sequence != UNASSIGNED_SEQUENCE_NUMBER)
-                .chain(added_data_sequence_number)
-                .min()
-                .map(|sequence| sequence.min(last_sequence_number))
-                .unwrap_or(last_sequence_number);
+            let min_data_sequence_number =
+                if let Some(sequence_number) = self.delete_file_cleanup_min_data_sequence_number {
+                    added_data_sequence_number
+                        .map(|added_sequence| sequence_number.min(added_sequence))
+                        .unwrap_or(sequence_number)
+                } else {
+                    data_manifests
+                        .iter()
+                        .map(|manifest| manifest.min_sequence_number)
+                        .filter(|sequence| *sequence != UNASSIGNED_SEQUENCE_NUMBER)
+                        .chain(added_data_sequence_number)
+                        .min()
+                        .map(|sequence| sequence.min(last_sequence_number))
+                        .unwrap_or(last_sequence_number)
+                };
 
             filter.drop_delete_files_older_than(min_data_sequence_number);
             filter.remove_dangling_deletes_for(&self.removed_data_file_paths);
@@ -801,6 +810,13 @@ impl<'a> SnapshotProducer<'a> {
 
     pub(crate) fn set_new_data_file_sequence_number(&mut self, sequence_number: i64) {
         self.new_data_file_sequence_number = Some(sequence_number);
+    }
+
+    pub(crate) fn set_delete_file_cleanup_min_data_sequence_number(
+        &mut self,
+        sequence_number: i64,
+    ) {
+        self.delete_file_cleanup_min_data_sequence_number = Some(sequence_number);
     }
 
     pub(crate) fn snapshot_id(&self) -> i64 {


### PR DESCRIPTION
## Which issue does this PR close?

- None. This supports RisingWave copy-on-write compaction cleanup.

## What changes are included in this PR?

- Add an optional minimum data sequence override to `ReplaceFilesAction` for retiring obsolete delete files.
- Preserve the existing global minimum across all live data manifests when the override is not set.
- Cap the override by the sequence of data files added by the action, so delete files that may still apply to newly written data are retained.
- Validate the override against the table sequence range and keep the existing strict `delete_sequence < min_data_sequence` cleanup rule unchanged.

The caller is responsible for supplying a conservative lower bound that does not exceed the data sequence of any live data file to which an existing delete may apply.

## Downstream

- The iceberg-compaction and RisingWave dependency pins are intentionally unchanged until this SDK API is reviewed.

## Are these changes tested?

- `cargo test -p iceberg test_delete_cleanup_sequence_override` (1 passed)
- `cargo clippy -p iceberg --tests -- -D warnings`
- `cargo public-api -p iceberg --all-features -ss | diff - crates/iceberg/public-api.txt`
- `cargo fmt --all -- --check`
- `git diff --check`

## AI Disclosure

This change was developed with assistance from OpenAI Codex. The implementation was reviewed against the existing delete cleanup path and validated with focused SDK tests.
