### PR TITLE
fix(transaction): preserve live delete cleanup bound

### DIFF
--- a/crates/iceberg/src/transaction/replace_files.rs
+++ b/crates/iceberg/src/transaction/replace_files.rs
@@ -388,6 +388,22 @@ impl<M: ReplaceFilesMode> TransactionAction for ReplaceFilesAction<M> {
                     ),
                 ));
             }
+
+            if !self.added_data_files.is_empty() {
+                let added_data_sequence_number = self
+                    .new_data_file_sequence_number
+                    .unwrap_or(last_sequence_number);
+                if sequence_number > added_data_sequence_number {
+                    return Err(crate::Error::new(
+                        crate::ErrorKind::DataInvalid,
+                        format!(
+                            "Delete file cleanup minimum data sequence number {sequence_number} \
+                             must not exceed the added data file sequence number \
+                             {added_data_sequence_number}"
+                        ),
+                    ));
+                }
+            }
         }
 
         let mut snapshot_producer = SnapshotProducer::new(
@@ -797,6 +813,18 @@ mod tests {
                 .all(|status| *status != ManifestStatus::Deleted),
             "delete files newer than the explicitly retained data sequence must stay live"
         );
+
+        let action = Transaction::new(&table)
+            .rewrite_files()
+            .set_new_data_file_sequence_number(PARENT_SEQUENCE_NUMBER)
+            .set_delete_file_cleanup_min_data_sequence_number(PARENT_SEQUENCE_NUMBER + 1)
+            .add_data_files([added_file.clone()]);
+        let err = match Arc::new(action).commit(&table).await {
+            Ok(_) => panic!("cleanup sequence newer than added data should fail"),
+            Err(err) => err,
+        };
+        assert_eq!(err.kind(), ErrorKind::DataInvalid);
+        assert!(err.message().contains("must not exceed"));
 
         let action = Transaction::new(&table)
             .rewrite_files()

--- a/crates/iceberg/src/transaction/snapshot.rs
+++ b/crates/iceberg/src/transaction/snapshot.rs
@@ -541,18 +541,13 @@ impl<'a> SnapshotProducer<'a> {
                 .min()
                 .map(|sequence| sequence.min(last_sequence_number))
                 .unwrap_or(last_sequence_number);
-            // The live-data minimum reflects files that survive this commit, while the
-            // optional override is a planning-derived safe bound. Keep the override below
-            // newly added data, then use whichever cleanup bound has advanced further.
+            // The live-data minimum reflects files that survive this commit. The optional
+            // planning-derived bound is validated against added data before snapshot production,
+            // so either bound can independently advance delete cleanup.
             let min_data_sequence_number = self
                 .delete_file_cleanup_min_data_sequence_number
-                .map(|sequence_number| {
-                    let sequence_number = added_data_sequence_number
-                        .map(|added_sequence| sequence_number.min(added_sequence))
-                        .unwrap_or(sequence_number);
-                    sequence_number.max(live_data_min_sequence_number)
-                })
-                .unwrap_or(live_data_min_sequence_number);
+                .unwrap_or(live_data_min_sequence_number)
+                .max(live_data_min_sequence_number);
 
             filter.drop_delete_files_older_than(min_data_sequence_number);
             filter.remove_dangling_deletes_for(&self.removed_data_file_paths);

--- a/crates/iceberg/src/transaction/snapshot.rs
+++ b/crates/iceberg/src/transaction/snapshot.rs
@@ -533,21 +533,26 @@ impl<'a> SnapshotProducer<'a> {
                 self.new_data_file_sequence_number
                     .unwrap_or(last_sequence_number),
             );
-            let min_data_sequence_number =
-                if let Some(sequence_number) = self.delete_file_cleanup_min_data_sequence_number {
-                    added_data_sequence_number
+            let live_data_min_sequence_number = data_manifests
+                .iter()
+                .map(|manifest| manifest.min_sequence_number)
+                .filter(|sequence| *sequence != UNASSIGNED_SEQUENCE_NUMBER)
+                .chain(added_data_sequence_number)
+                .min()
+                .map(|sequence| sequence.min(last_sequence_number))
+                .unwrap_or(last_sequence_number);
+            // The live-data minimum reflects files that survive this commit, while the
+            // optional override is a planning-derived safe bound. Keep the override below
+            // newly added data, then use whichever cleanup bound has advanced further.
+            let min_data_sequence_number = self
+                .delete_file_cleanup_min_data_sequence_number
+                .map(|sequence_number| {
+                    let sequence_number = added_data_sequence_number
                         .map(|added_sequence| sequence_number.min(added_sequence))
-                        .unwrap_or(sequence_number)
-                } else {
-                    data_manifests
-                        .iter()
-                        .map(|manifest| manifest.min_sequence_number)
-                        .filter(|sequence| *sequence != UNASSIGNED_SEQUENCE_NUMBER)
-                        .chain(added_data_sequence_number)
-                        .min()
-                        .map(|sequence| sequence.min(last_sequence_number))
-                        .unwrap_or(last_sequence_number)
-                };
+                        .unwrap_or(sequence_number);
+                    sequence_number.max(live_data_min_sequence_number)
+                })
+                .unwrap_or(live_data_min_sequence_number);
 
             filter.drop_delete_files_older_than(min_data_sequence_number);
             filter.remove_dangling_deletes_for(&self.removed_data_file_paths);


### PR DESCRIPTION
## Which issue does this PR close?

- None. This is a follow-up to #215.

## What changes are included in this PR?

- Always compute the default cleanup bound from data files that remain live after the current rewrite.
- Combine that bound with the planning-derived override instead of replacing it.
- Keep the existing cap from newly added data file sequence numbers.

This lets a full rewrite advance delete cleanup in the same commit while preserving the affected-file optimization for partial rewrites. The logic remains independent of the compaction task type.

## Are these changes tested?

- `cargo fmt --check -- crates/iceberg/src/transaction/snapshot.rs`
- `git diff --check`
- RisingWave `./risedev slt-clean './e2e_test/iceberg/test_case/pure_slt/iceberg_vacuum.slt'` (`[OK]`), with this checkout used as the Iceberg dependency and the current iceberg-compaction/RisingWave PR changes.

No new test code is included.

## AI Disclosure

This change was developed with assistance from OpenAI Codex. The implementation was reviewed against the existing live-data cleanup fallback and validated with the RisingWave Iceberg vacuum SLT.
