### PR TITLE
fix(arrow): treat variant fields as leaves in RecordBatchProjector

### DIFF
--- a/crates/iceberg/src/arrow/record_batch_projector.rs
+++ b/crates/iceberg/src/arrow/record_batch_projector.rs
@@ -19,10 +19,11 @@ use std::sync::Arc;
 
 use arrow_array::{ArrayRef, RecordBatch, StructArray, make_array};
 use arrow_buffer::NullBuffer;
+use arrow_schema::extension::ExtensionType;
 use arrow_schema::{DataType, Field, FieldRef, Fields, Schema, SchemaRef};
 use parquet::arrow::PARQUET_FIELD_ID_META_KEY;
 
-use crate::arrow::schema::schema_to_arrow_schema;
+use crate::arrow::schema::{VariantExtensionType, schema_to_arrow_schema};
 use crate::error::Result;
 use crate::spec::Schema as IcebergSchema;
 use crate::{Error, ErrorKind};
@@ -139,7 +140,9 @@ impl RecordBatchProjector {
                 index_vec.push(pos);
                 return Ok(Some(field.clone()));
             }
+            // A variant field is a logical leaf: its children carry no field ids.
             if let DataType::Struct(inner) = field.data_type()
+                && field.extension_type_name() != Some(VariantExtensionType::NAME)
                 && searchable_field_func(field)
                 && let Some(res) = Self::fetch_field_index(
                     inner,

--- a/crates/iceberg/src/writer/base_writer/equality_delete_writer.rs
+++ b/crates/iceberg/src/writer/base_writer/equality_delete_writer.rs
@@ -257,7 +257,7 @@ mod test {
     use crate::io::FileIO;
     use crate::spec::{
         DataFile, DataFileFormat, ListType, MapType, NestedField, PrimitiveType, Schema,
-        StructType, Type,
+        StructType, Type, VariantType,
     };
     use crate::writer::base_writer::equality_delete_writer::{
         EqualityDeleteFileWriterBuilder, EqualityDeleteWriterConfig,
@@ -918,5 +918,23 @@ mod test {
             .unwrap();
         assert_eq!(to_write_projected, expect_batch);
         Ok(())
+    }
+
+    #[test]
+    fn test_equality_ids_resolve_behind_variant_column() {
+        let schema = Arc::new(
+            Schema::builder()
+                .with_fields(vec![
+                    NestedField::optional(1, "v", Type::Variant(VariantType)).into(),
+                    NestedField::required(2, "id", Type::Primitive(PrimitiveType::Int)).into(),
+                ])
+                .build()
+                .unwrap(),
+        );
+
+        let config = EqualityDeleteWriterConfig::new(vec![2], schema).unwrap();
+        let projected = config.projected_arrow_schema_ref();
+        assert_eq!(projected.fields().len(), 1);
+        assert_eq!(projected.field(0).name(), "id");
     }
 }


### PR DESCRIPTION
## What

`RecordBatchProjector::fetch_field_index` recurses into every arrow struct while resolving field ids. A variant column is physically `Struct<metadata, value>` whose children deliberately carry no `PARQUET:field_id`, so the scan errors with `Field metadata is missing.` before it can reach any column to the right of the variant column.

Concretely, `EqualityDeleteWriterConfig::new` fails whenever a variant column precedes an equality-delete key column, and the writer then fails on every checkpoint. Hit end-to-end in RisingWave with `create sink ... as select v, id from t with (type='upsert', primary_key='id', ...)` while reviewing risingwavelabs/risingwave#26620.

## How

Treat fields tagged with the `arrow.parquet.variant` extension as logical leaves: never search inside them. This matches the schema visitors, which already dispatch variant fields via `visit_field` before recursing into struct children.

## Test

New unit test: equality ids resolve for a key column sitting behind a variant column. Fails with `Field metadata is missing.` before this change.
