### PR TITLE
fix(spec): enforce primitive source for void partition fields

### DIFF
--- a/crates/iceberg/src/arrow/partition_value_calculator.rs
+++ b/crates/iceberg/src/arrow/partition_value_calculator.rs
@@ -22,12 +22,12 @@
 
 use std::sync::Arc;
 
-use arrow_array::{ArrayRef, RecordBatch, StructArray, new_null_array};
+use arrow_array::{ArrayRef, RecordBatch, StructArray};
 use arrow_schema::DataType;
 
 use super::record_batch_projector::RecordBatchProjector;
 use super::type_to_arrow_type;
-use crate::spec::{PartitionSpec, Schema, StructType, Transform, Type};
+use crate::spec::{PartitionSpec, Schema, StructType, Type};
 use crate::transform::{BoxedTransformFunction, create_transform_function};
 use crate::{Error, ErrorKind, Result};
 
@@ -38,7 +38,7 @@ use crate::{Error, ErrorKind, Result};
 #[derive(Debug)]
 pub struct PartitionValueCalculator {
     projector: RecordBatchProjector,
-    transform_functions: Vec<(Transform, BoxedTransformFunction)>,
+    transform_functions: Vec<BoxedTransformFunction>,
     partition_type: StructType,
     partition_arrow_type: DataType,
 }
@@ -70,10 +70,10 @@ impl PartitionValueCalculator {
         }
 
         // Create transform functions for each partition field
-        let transform_functions: Vec<(Transform, BoxedTransformFunction)> = partition_spec
+        let transform_functions: Vec<BoxedTransformFunction> = partition_spec
             .fields()
             .iter()
-            .map(|pf| Ok((pf.transform, create_transform_function(&pf.transform)?)))
+            .map(|pf| create_transform_function(&pf.transform))
             .collect::<Result<Vec<_>>>()?;
 
         // Extract source field IDs for projection
@@ -149,19 +149,8 @@ impl PartitionValueCalculator {
 
         // Apply transforms to each source column
         let mut partition_values = Vec::with_capacity(self.transform_functions.len());
-        for ((source_column, (transform, transform_fn)), field) in source_columns
-            .iter()
-            .zip(&self.transform_functions)
-            .zip(&expected_struct_fields)
-        {
-            // A compatibility-bound `void` field may use `int` as its result type even
-            // when its source is non-primitive. Construct the all-null result from the
-            // derived partition type rather than from the source array type.
-            let partition_value = if *transform == Transform::Void {
-                new_null_array(field.data_type(), source_column.len())
-            } else {
-                transform_fn.transform(source_column.clone())?
-            };
+        for (source_column, transform_fn) in source_columns.iter().zip(&self.transform_functions) {
+            let partition_value = transform_fn.transform(source_column.clone())?;
             partition_values.push(partition_value);
         }
 
@@ -186,10 +175,7 @@ mod tests {
     use arrow_schema::{Field, Schema as ArrowSchema};
 
     use super::*;
-    use crate::arrow::schema_to_arrow_schema;
-    use crate::spec::{
-        NestedField, PartitionSpec, PartitionSpecBuilder, PrimitiveType, VariantType,
-    };
+    use crate::spec::{NestedField, PartitionSpecBuilder, PrimitiveType, Transform};
 
     #[test]
     fn test_partition_calculator_identity_transform() {
@@ -240,54 +226,6 @@ mod tests {
         assert_eq!(id_partition.value(0), 10);
         assert_eq!(id_partition.value(1), 20);
         assert_eq!(id_partition.value(2), 30);
-    }
-
-    #[test]
-    fn test_partition_calculator_void_non_primitive_source_uses_int_result() {
-        let table_schema = Schema::builder()
-            .with_schema_id(0)
-            .with_fields(vec![
-                NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
-                NestedField::optional(2, "v", Type::Variant(VariantType)).into(),
-            ])
-            .build()
-            .unwrap();
-        let partition_spec: PartitionSpec = serde_json::from_value(serde_json::json!({
-            "spec-id": 0,
-            "fields": [
-                {
-                    "source-id": 2,
-                    "field-id": 1000,
-                    "name": "v_part",
-                    "transform": "void"
-                },
-                {
-                    "source-id": 1,
-                    "field-id": 1001,
-                    "name": "id_part",
-                    "transform": "identity"
-                }
-            ]
-        }))
-        .unwrap();
-        let calculator = PartitionValueCalculator::try_new(&partition_spec, &table_schema).unwrap();
-
-        let arrow_schema = Arc::new(schema_to_arrow_schema(&table_schema).unwrap());
-        let columns: Vec<ArrayRef> = vec![
-            Arc::new(Int32Array::from(vec![1, 2, 3])),
-            new_null_array(arrow_schema.field(1).data_type(), 3),
-        ];
-        let batch = RecordBatch::try_new(arrow_schema, columns).unwrap();
-        let result = calculator.calculate(&batch).unwrap();
-        let struct_array = result.as_any().downcast_ref::<StructArray>().unwrap();
-        let v_partition = struct_array
-            .column_by_name("v_part")
-            .unwrap()
-            .as_any()
-            .downcast_ref::<Int32Array>()
-            .unwrap();
-
-        assert_eq!(v_partition.iter().collect::<Vec<_>>(), vec![None; 3]);
     }
 
     #[test]

--- a/crates/iceberg/src/arrow/partition_value_calculator.rs
+++ b/crates/iceberg/src/arrow/partition_value_calculator.rs
@@ -22,12 +22,12 @@
 
 use std::sync::Arc;
 
-use arrow_array::{ArrayRef, RecordBatch, StructArray};
+use arrow_array::{ArrayRef, RecordBatch, StructArray, new_null_array};
 use arrow_schema::DataType;
 
 use super::record_batch_projector::RecordBatchProjector;
 use super::type_to_arrow_type;
-use crate::spec::{PartitionSpec, Schema, StructType, Type};
+use crate::spec::{PartitionSpec, Schema, StructType, Transform, Type};
 use crate::transform::{BoxedTransformFunction, create_transform_function};
 use crate::{Error, ErrorKind, Result};
 
@@ -38,7 +38,7 @@ use crate::{Error, ErrorKind, Result};
 #[derive(Debug)]
 pub struct PartitionValueCalculator {
     projector: RecordBatchProjector,
-    transform_functions: Vec<BoxedTransformFunction>,
+    transform_functions: Vec<(Transform, BoxedTransformFunction)>,
     partition_type: StructType,
     partition_arrow_type: DataType,
 }
@@ -70,10 +70,10 @@ impl PartitionValueCalculator {
         }
 
         // Create transform functions for each partition field
-        let transform_functions: Vec<BoxedTransformFunction> = partition_spec
+        let transform_functions: Vec<(Transform, BoxedTransformFunction)> = partition_spec
             .fields()
             .iter()
-            .map(|pf| create_transform_function(&pf.transform))
+            .map(|pf| Ok((pf.transform, create_transform_function(&pf.transform)?)))
             .collect::<Result<Vec<_>>>()?;
 
         // Extract source field IDs for projection
@@ -149,8 +149,19 @@ impl PartitionValueCalculator {
 
         // Apply transforms to each source column
         let mut partition_values = Vec::with_capacity(self.transform_functions.len());
-        for (source_column, transform_fn) in source_columns.iter().zip(&self.transform_functions) {
-            let partition_value = transform_fn.transform(source_column.clone())?;
+        for ((source_column, (transform, transform_fn)), field) in source_columns
+            .iter()
+            .zip(&self.transform_functions)
+            .zip(&expected_struct_fields)
+        {
+            // A compatibility-bound `void` field may use `int` as its result type even
+            // when its source is non-primitive. Construct the all-null result from the
+            // derived partition type rather than from the source array type.
+            let partition_value = if *transform == Transform::Void {
+                new_null_array(field.data_type(), source_column.len())
+            } else {
+                transform_fn.transform(source_column.clone())?
+            };
             partition_values.push(partition_value);
         }
 
@@ -175,7 +186,10 @@ mod tests {
     use arrow_schema::{Field, Schema as ArrowSchema};
 
     use super::*;
-    use crate::spec::{NestedField, PartitionSpecBuilder, PrimitiveType, Transform};
+    use crate::arrow::schema_to_arrow_schema;
+    use crate::spec::{
+        NestedField, PartitionSpec, PartitionSpecBuilder, PrimitiveType, VariantType,
+    };
 
     #[test]
     fn test_partition_calculator_identity_transform() {
@@ -226,6 +240,54 @@ mod tests {
         assert_eq!(id_partition.value(0), 10);
         assert_eq!(id_partition.value(1), 20);
         assert_eq!(id_partition.value(2), 30);
+    }
+
+    #[test]
+    fn test_partition_calculator_void_non_primitive_source_uses_int_result() {
+        let table_schema = Schema::builder()
+            .with_schema_id(0)
+            .with_fields(vec![
+                NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
+                NestedField::optional(2, "v", Type::Variant(VariantType)).into(),
+            ])
+            .build()
+            .unwrap();
+        let partition_spec: PartitionSpec = serde_json::from_value(serde_json::json!({
+            "spec-id": 0,
+            "fields": [
+                {
+                    "source-id": 2,
+                    "field-id": 1000,
+                    "name": "v_part",
+                    "transform": "void"
+                },
+                {
+                    "source-id": 1,
+                    "field-id": 1001,
+                    "name": "id_part",
+                    "transform": "identity"
+                }
+            ]
+        }))
+        .unwrap();
+        let calculator = PartitionValueCalculator::try_new(&partition_spec, &table_schema).unwrap();
+
+        let arrow_schema = Arc::new(schema_to_arrow_schema(&table_schema).unwrap());
+        let columns: Vec<ArrayRef> = vec![
+            Arc::new(Int32Array::from(vec![1, 2, 3])),
+            new_null_array(arrow_schema.field(1).data_type(), 3),
+        ];
+        let batch = RecordBatch::try_new(arrow_schema, columns).unwrap();
+        let result = calculator.calculate(&batch).unwrap();
+        let struct_array = result.as_any().downcast_ref::<StructArray>().unwrap();
+        let v_partition = struct_array
+            .column_by_name("v_part")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<Int32Array>()
+            .unwrap();
+
+        assert_eq!(v_partition.iter().collect::<Vec<_>>(), vec![None; 3]);
     }
 
     #[test]

--- a/crates/iceberg/src/spec/partition.rs
+++ b/crates/iceberg/src/spec/partition.rs
@@ -279,18 +279,6 @@ impl UnboundPartitionSpec {
         PartitionSpecBuilder::new_from_unbound(self, schema)?.build()
     }
 
-    /// Bind a partition spec that was already present in table metadata.
-    ///
-    /// Some implementations historically allowed `void` fields sourced from
-    /// non-primitive columns. New specs must reject those fields, but existing
-    /// metadata still needs to remain readable and committable.
-    pub(crate) fn bind_for_existing_metadata(
-        self,
-        schema: impl Into<SchemaRef>,
-    ) -> Result<PartitionSpec> {
-        PartitionSpecBuilder::new_from_existing(self, schema)?.build()
-    }
-
     /// Spec id of the partition spec
     pub fn spec_id(&self) -> Option<i32> {
         self.spec_id
@@ -439,27 +427,11 @@ impl PartitionSpecBuilder {
         unbound: UnboundPartitionSpec,
         schema: impl Into<SchemaRef>,
     ) -> Result<Self> {
-        Self::new_from_unbound_with_compatibility(unbound, schema, false)
-    }
-
-    fn new_from_existing(
-        unbound: UnboundPartitionSpec,
-        schema: impl Into<SchemaRef>,
-    ) -> Result<Self> {
-        Self::new_from_unbound_with_compatibility(unbound, schema, true)
-    }
-
-    fn new_from_unbound_with_compatibility(
-        unbound: UnboundPartitionSpec,
-        schema: impl Into<SchemaRef>,
-        allow_non_primitive_void_source: bool,
-    ) -> Result<Self> {
         let mut builder =
             Self::new(schema).with_spec_id(unbound.spec_id.unwrap_or(DEFAULT_PARTITION_SPEC_ID));
 
         for field in unbound.fields {
-            builder = builder
-                .add_unbound_field_with_compatibility(field, allow_non_primitive_void_source)?;
+            builder = builder.add_unbound_field(field)?;
         }
         Ok(builder)
     }
@@ -514,19 +486,11 @@ impl PartitionSpecBuilder {
     ///
     /// If partition field id is set, it is used as the field id.
     /// Otherwise, a new `field_id` is assigned.
-    pub fn add_unbound_field(self, field: UnboundPartitionField) -> Result<Self> {
-        self.add_unbound_field_with_compatibility(field, false)
-    }
-
-    fn add_unbound_field_with_compatibility(
-        mut self,
-        field: UnboundPartitionField,
-        allow_non_primitive_void_source: bool,
-    ) -> Result<Self> {
+    pub fn add_unbound_field(mut self, field: UnboundPartitionField) -> Result<Self> {
         self.check_name_set_and_unique(&field.name)?;
         self.check_for_redundant_partitions(field.source_id, &field.transform)?;
         Self::check_name_does_not_collide_with_schema(&field, &self.schema)?;
-        Self::check_transform_compatibility(&field, &self.schema, allow_non_primitive_void_source)?;
+        Self::check_transform_compatibility(&field, &self.schema)?;
         if let Some(partition_field_id) = field.field_id {
             self.check_partition_id_unique(partition_field_id)?;
         }
@@ -666,11 +630,7 @@ impl PartitionSpecBuilder {
 
     /// Ensure that the transformation of the field is compatible with type of the field
     /// in the schema. Implicitly also checks if the source field exists in the schema.
-    fn check_transform_compatibility(
-        field: &UnboundPartitionField,
-        schema: &Schema,
-        allow_non_primitive_void_source: bool,
-    ) -> Result<()> {
+    fn check_transform_compatibility(field: &UnboundPartitionField, schema: &Schema) -> Result<()> {
         let schema_field = schema.field_by_id(field.source_id).ok_or_else(|| {
             Error::new(
                 ErrorKind::DataInvalid,
@@ -683,9 +643,7 @@ impl PartitionSpecBuilder {
 
         // The spec requires partition source columns to be primitive for every
         // transform, `void` included.
-        let is_compatible_legacy_void =
-            allow_non_primitive_void_source && field.transform == Transform::Void;
-        if !(schema_field.field_type.is_primitive() || is_compatible_legacy_void) {
+        if !schema_field.field_type.is_primitive() {
             return Err(Error::new(
                 ErrorKind::DataInvalid,
                 format!(
@@ -1415,31 +1373,6 @@ mod tests {
         assert_eq!(
             err.message(),
             "Cannot partition by non-primitive source field: 'variant'."
-        );
-    }
-
-    #[test]
-    fn test_existing_void_on_non_primitive_source_binds_as_int() {
-        let schema = Schema::builder()
-            .with_fields(vec![
-                NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
-                NestedField::optional(2, "v", Type::Variant(crate::spec::VariantType)).into(),
-            ])
-            .build()
-            .unwrap();
-        let unbound = UnboundPartitionSpec::builder()
-            .with_spec_id(1)
-            .add_partition_field(2, "v_part", Transform::Void)
-            .unwrap()
-            .build();
-
-        assert!(unbound.clone().bind(schema.clone()).is_err());
-
-        let spec = unbound.bind_for_existing_metadata(schema.clone()).unwrap();
-        let partition_type = spec.partition_type(&schema).unwrap();
-        assert_eq!(
-            partition_type.fields()[0].field_type.as_ref(),
-            &Type::Primitive(PrimitiveType::Int)
         );
     }
 

--- a/crates/iceberg/src/spec/partition.rs
+++ b/crates/iceberg/src/spec/partition.rs
@@ -641,31 +641,31 @@ impl PartitionSpecBuilder {
             )
         })?;
 
-        if field.transform != Transform::Void {
-            if !schema_field.field_type.is_primitive() {
-                return Err(Error::new(
-                    ErrorKind::DataInvalid,
-                    format!(
-                        "Cannot partition by non-primitive source field: '{}'.",
-                        schema_field.field_type
-                    ),
-                ));
-            }
+        // The spec requires partition source columns to be primitive for every
+        // transform, `void` included.
+        if !schema_field.field_type.is_primitive() {
+            return Err(Error::new(
+                ErrorKind::DataInvalid,
+                format!(
+                    "Cannot partition by non-primitive source field: '{}'.",
+                    schema_field.field_type
+                ),
+            ));
+        }
 
-            if field
-                .transform
-                .result_type(&schema_field.field_type)
-                .is_err()
-            {
-                return Err(Error::new(
-                    ErrorKind::DataInvalid,
-                    format!(
-                        "Invalid source type: '{}' for transform: '{}'.",
-                        schema_field.field_type,
-                        field.transform.dedup_name()
-                    ),
-                ));
-            }
+        if field
+            .transform
+            .result_type(&schema_field.field_type)
+            .is_err()
+        {
+            return Err(Error::new(
+                ErrorKind::DataInvalid,
+                format!(
+                    "Invalid source type: '{}' for transform: '{}'.",
+                    schema_field.field_type,
+                    field.transform.dedup_name()
+                ),
+            ));
         }
 
         Ok(())
@@ -1343,6 +1343,32 @@ mod tests {
                 transform: Transform::Identity,
             }])
             .expect_err("variant must not be allowed as a partition source");
+
+        assert_eq!(
+            err.message(),
+            "Cannot partition by non-primitive source field: 'variant'."
+        );
+    }
+
+    #[test]
+    fn test_builder_disallows_void_on_non_primitive_source() {
+        let schema = Schema::builder()
+            .with_fields(vec![
+                NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
+                NestedField::optional(2, "v", Type::Variant(crate::spec::VariantType)).into(),
+            ])
+            .build()
+            .unwrap();
+
+        let err = PartitionSpec::builder(schema)
+            .with_spec_id(1)
+            .add_unbound_fields(vec![UnboundPartitionField {
+                source_id: 2,
+                field_id: None,
+                name: "v_part".to_string(),
+                transform: Transform::Void,
+            }])
+            .expect_err("void on a non-primitive source must not be allowed");
 
         assert_eq!(
             err.message(),

--- a/crates/iceberg/src/spec/partition.rs
+++ b/crates/iceberg/src/spec/partition.rs
@@ -279,6 +279,18 @@ impl UnboundPartitionSpec {
         PartitionSpecBuilder::new_from_unbound(self, schema)?.build()
     }
 
+    /// Bind a partition spec that was already present in table metadata.
+    ///
+    /// Some implementations historically allowed `void` fields sourced from
+    /// non-primitive columns. New specs must reject those fields, but existing
+    /// metadata still needs to remain readable and committable.
+    pub(crate) fn bind_for_existing_metadata(
+        self,
+        schema: impl Into<SchemaRef>,
+    ) -> Result<PartitionSpec> {
+        PartitionSpecBuilder::new_from_existing(self, schema)?.build()
+    }
+
     /// Spec id of the partition spec
     pub fn spec_id(&self) -> Option<i32> {
         self.spec_id
@@ -427,11 +439,27 @@ impl PartitionSpecBuilder {
         unbound: UnboundPartitionSpec,
         schema: impl Into<SchemaRef>,
     ) -> Result<Self> {
+        Self::new_from_unbound_with_compatibility(unbound, schema, false)
+    }
+
+    fn new_from_existing(
+        unbound: UnboundPartitionSpec,
+        schema: impl Into<SchemaRef>,
+    ) -> Result<Self> {
+        Self::new_from_unbound_with_compatibility(unbound, schema, true)
+    }
+
+    fn new_from_unbound_with_compatibility(
+        unbound: UnboundPartitionSpec,
+        schema: impl Into<SchemaRef>,
+        allow_non_primitive_void_source: bool,
+    ) -> Result<Self> {
         let mut builder =
             Self::new(schema).with_spec_id(unbound.spec_id.unwrap_or(DEFAULT_PARTITION_SPEC_ID));
 
         for field in unbound.fields {
-            builder = builder.add_unbound_field(field)?;
+            builder = builder
+                .add_unbound_field_with_compatibility(field, allow_non_primitive_void_source)?;
         }
         Ok(builder)
     }
@@ -486,11 +514,19 @@ impl PartitionSpecBuilder {
     ///
     /// If partition field id is set, it is used as the field id.
     /// Otherwise, a new `field_id` is assigned.
-    pub fn add_unbound_field(mut self, field: UnboundPartitionField) -> Result<Self> {
+    pub fn add_unbound_field(self, field: UnboundPartitionField) -> Result<Self> {
+        self.add_unbound_field_with_compatibility(field, false)
+    }
+
+    fn add_unbound_field_with_compatibility(
+        mut self,
+        field: UnboundPartitionField,
+        allow_non_primitive_void_source: bool,
+    ) -> Result<Self> {
         self.check_name_set_and_unique(&field.name)?;
         self.check_for_redundant_partitions(field.source_id, &field.transform)?;
         Self::check_name_does_not_collide_with_schema(&field, &self.schema)?;
-        Self::check_transform_compatibility(&field, &self.schema)?;
+        Self::check_transform_compatibility(&field, &self.schema, allow_non_primitive_void_source)?;
         if let Some(partition_field_id) = field.field_id {
             self.check_partition_id_unique(partition_field_id)?;
         }
@@ -630,7 +666,11 @@ impl PartitionSpecBuilder {
 
     /// Ensure that the transformation of the field is compatible with type of the field
     /// in the schema. Implicitly also checks if the source field exists in the schema.
-    fn check_transform_compatibility(field: &UnboundPartitionField, schema: &Schema) -> Result<()> {
+    fn check_transform_compatibility(
+        field: &UnboundPartitionField,
+        schema: &Schema,
+        allow_non_primitive_void_source: bool,
+    ) -> Result<()> {
         let schema_field = schema.field_by_id(field.source_id).ok_or_else(|| {
             Error::new(
                 ErrorKind::DataInvalid,
@@ -643,7 +683,9 @@ impl PartitionSpecBuilder {
 
         // The spec requires partition source columns to be primitive for every
         // transform, `void` included.
-        if !schema_field.field_type.is_primitive() {
+        let is_compatible_legacy_void =
+            allow_non_primitive_void_source && field.transform == Transform::Void;
+        if !(schema_field.field_type.is_primitive() || is_compatible_legacy_void) {
             return Err(Error::new(
                 ErrorKind::DataInvalid,
                 format!(
@@ -1373,6 +1415,31 @@ mod tests {
         assert_eq!(
             err.message(),
             "Cannot partition by non-primitive source field: 'variant'."
+        );
+    }
+
+    #[test]
+    fn test_existing_void_on_non_primitive_source_binds_as_int() {
+        let schema = Schema::builder()
+            .with_fields(vec![
+                NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
+                NestedField::optional(2, "v", Type::Variant(crate::spec::VariantType)).into(),
+            ])
+            .build()
+            .unwrap();
+        let unbound = UnboundPartitionSpec::builder()
+            .with_spec_id(1)
+            .add_partition_field(2, "v_part", Transform::Void)
+            .unwrap()
+            .build();
+
+        assert!(unbound.clone().bind(schema.clone()).is_err());
+
+        let spec = unbound.bind_for_existing_metadata(schema.clone()).unwrap();
+        let partition_type = spec.partition_type(&schema).unwrap();
+        assert_eq!(
+            partition_type.fields()[0].field_type.as_ref(),
+            &Type::Primitive(PrimitiveType::Int)
         );
     }
 

--- a/crates/iceberg/src/spec/table_metadata_builder.rs
+++ b/crates/iceberg/src/spec/table_metadata_builder.rs
@@ -1144,7 +1144,7 @@ impl TableMetadataBuilder {
         self.metadata.default_spec = Arc::new(
             Arc::unwrap_or_clone(self.metadata.default_spec)
                 .into_unbound()
-                .bind(schema.clone())?,
+                .bind_for_existing_metadata(schema.clone())?,
         );
         self.metadata.default_partition_type =
             self.metadata.default_spec.partition_type(&schema)?;

--- a/crates/iceberg/src/spec/table_metadata_builder.rs
+++ b/crates/iceberg/src/spec/table_metadata_builder.rs
@@ -1144,7 +1144,7 @@ impl TableMetadataBuilder {
         self.metadata.default_spec = Arc::new(
             Arc::unwrap_or_clone(self.metadata.default_spec)
                 .into_unbound()
-                .bind_for_existing_metadata(schema.clone())?,
+                .bind(schema.clone())?,
         );
         self.metadata.default_partition_type =
             self.metadata.default_spec.partition_type(&schema)?;

--- a/crates/iceberg/src/spec/transform.rs
+++ b/crates/iceberg/src/spec/transform.rs
@@ -128,8 +128,8 @@ pub enum Transform {
     /// existing partition field so that the field is effectively dropped in
     /// v1 tables.
     ///
-    /// - Source type could be any type..
-    /// - Return type is Source type.
+    /// - Source type could be any type.
+    /// - Return type is the source type for primitive sources, otherwise `int`.
     Void,
     /// Used to represent some customized transform that can't be recognized or supported now.
     Unknown,
@@ -169,7 +169,16 @@ impl Transform {
                     ))
                 }
             }
-            Transform::Void => Ok(input_type.clone()),
+            Transform::Void => {
+                if input_type.is_primitive() {
+                    Ok(input_type.clone())
+                } else {
+                    // The spec permits `int` as the result type of `void`. Use it for
+                    // legacy specs whose source is non-primitive so manifests can still
+                    // represent the always-null partition value.
+                    Ok(Type::Primitive(PrimitiveType::Int))
+                }
+            }
             Transform::Unknown => Ok(Type::Primitive(PrimitiveType::String)),
             Transform::Bucket(_) => {
                 if let Type::Primitive(p) = input_type {

--- a/crates/iceberg/src/spec/transform.rs
+++ b/crates/iceberg/src/spec/transform.rs
@@ -128,8 +128,8 @@ pub enum Transform {
     /// existing partition field so that the field is effectively dropped in
     /// v1 tables.
     ///
-    /// - Source type could be any type.
-    /// - Return type is the source type for primitive sources, otherwise `int`.
+    /// - Source type could be any type..
+    /// - Return type is Source type.
     Void,
     /// Used to represent some customized transform that can't be recognized or supported now.
     Unknown,
@@ -169,16 +169,7 @@ impl Transform {
                     ))
                 }
             }
-            Transform::Void => {
-                if input_type.is_primitive() {
-                    Ok(input_type.clone())
-                } else {
-                    // The spec permits `int` as the result type of `void`. Use it for
-                    // legacy specs whose source is non-primitive so manifests can still
-                    // represent the always-null partition value.
-                    Ok(Type::Primitive(PrimitiveType::Int))
-                }
-            }
+            Transform::Void => Ok(input_type.clone()),
             Transform::Unknown => Ok(Type::Primitive(PrimitiveType::String)),
             Transform::Bucket(_) => {
                 if let Type::Primitive(p) = input_type {

--- a/crates/iceberg/src/transaction/append.rs
+++ b/crates/iceberg/src/transaction/append.rs
@@ -236,7 +236,8 @@ mod tests {
     use crate::spec::{
         DataContentType, DataFile, DataFileBuilder, DataFileFormat, Literal, MAIN_BRANCH,
         ManifestContentType, ManifestEntry, ManifestListWriter, ManifestStatus,
-        ManifestWriterBuilder, SnapshotRef, Struct, TableMetadata,
+        ManifestWriterBuilder, NestedField, PartitionSpec, SnapshotRef, Struct, TableMetadata,
+        Type, VariantType,
     };
     use crate::table::Table;
     use crate::test_utils::{make_encrypted_table, test_runtime};
@@ -855,6 +856,79 @@ mod tests {
         let action = action.add_data_files(vec![data_file.clone()]);
 
         assert!(Arc::new(action).commit(&table).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_fast_append_to_existing_void_non_primitive_partition() {
+        let table = make_v3_minimal_table();
+        let mut metadata = table.metadata().clone();
+        let mut fields = metadata.current_schema().as_struct().fields().to_vec();
+        fields.push(NestedField::optional(4, "v", Type::Variant(VariantType)).into());
+        let schema = crate::spec::Schema::builder()
+            .with_schema_id(metadata.current_schema_id())
+            .with_fields(fields)
+            .build()
+            .unwrap();
+        let legacy_spec: PartitionSpec = serde_json::from_value(serde_json::json!({
+            "spec-id": 0,
+            "fields": [{
+                "source-id": 4,
+                "field-id": 1000,
+                "name": "v_part",
+                "transform": "void"
+            }]
+        }))
+        .unwrap();
+
+        metadata.last_column_id = 4;
+        metadata
+            .schemas
+            .insert(schema.schema_id(), Arc::new(schema.clone()));
+        metadata.partition_specs.clear();
+        metadata
+            .partition_specs
+            .insert(legacy_spec.spec_id(), Arc::new(legacy_spec.clone()));
+        metadata.default_partition_type = legacy_spec.partition_type(&schema).unwrap();
+        metadata.default_spec = Arc::new(legacy_spec);
+        metadata.last_partition_id = 1000;
+
+        // Exercise the real compatibility boundary: metadata produced elsewhere is loaded
+        // from JSON before the append starts.
+        let json = serde_json::to_vec(&metadata).unwrap();
+        let metadata: TableMetadata = serde_json::from_slice(&json).unwrap();
+        let table = table.with_metadata(Arc::new(metadata));
+        assert_eq!(
+            table.metadata().default_partition_type().fields()[0]
+                .field_type
+                .as_ref(),
+            &Type::Primitive(crate::spec::PrimitiveType::Int)
+        );
+
+        let data_file = DataFileBuilder::default()
+            .content(DataContentType::Data)
+            .file_path("test/legacy-void.parquet".to_string())
+            .file_format(DataFileFormat::Parquet)
+            .file_size_in_bytes(100)
+            .record_count(1)
+            .partition_spec_id(table.metadata().default_partition_spec_id())
+            .partition(Struct::from_iter([None]))
+            .build()
+            .unwrap();
+        let action = Transaction::new(&table)
+            .fast_append()
+            .add_data_files(vec![data_file]);
+        let action_commit = Arc::new(action).commit(&table).await.unwrap();
+        let mut updates = Vec::new();
+        let mut requirements = Vec::new();
+        let updated =
+            Transaction::apply(table, action_commit, &mut updates, &mut requirements).unwrap();
+
+        let snapshot = updated.metadata().current_snapshot().unwrap();
+        let manifest_list = updated.manifest_list_reader(snapshot).load().await.unwrap();
+        let summary = manifest_list.entries()[0].partitions.as_ref().unwrap();
+        assert!(summary[0].contains_null);
+        assert!(summary[0].lower_bound.is_none());
+        assert!(summary[0].upper_bound.is_none());
     }
 
     #[tokio::test]

--- a/crates/iceberg/src/transaction/append.rs
+++ b/crates/iceberg/src/transaction/append.rs
@@ -236,8 +236,7 @@ mod tests {
     use crate::spec::{
         DataContentType, DataFile, DataFileBuilder, DataFileFormat, Literal, MAIN_BRANCH,
         ManifestContentType, ManifestEntry, ManifestListWriter, ManifestStatus,
-        ManifestWriterBuilder, NestedField, PartitionSpec, SnapshotRef, Struct, TableMetadata,
-        Type, VariantType,
+        ManifestWriterBuilder, SnapshotRef, Struct, TableMetadata,
     };
     use crate::table::Table;
     use crate::test_utils::{make_encrypted_table, test_runtime};
@@ -856,79 +855,6 @@ mod tests {
         let action = action.add_data_files(vec![data_file.clone()]);
 
         assert!(Arc::new(action).commit(&table).await.is_err());
-    }
-
-    #[tokio::test]
-    async fn test_fast_append_to_existing_void_non_primitive_partition() {
-        let table = make_v3_minimal_table();
-        let mut metadata = table.metadata().clone();
-        let mut fields = metadata.current_schema().as_struct().fields().to_vec();
-        fields.push(NestedField::optional(4, "v", Type::Variant(VariantType)).into());
-        let schema = crate::spec::Schema::builder()
-            .with_schema_id(metadata.current_schema_id())
-            .with_fields(fields)
-            .build()
-            .unwrap();
-        let legacy_spec: PartitionSpec = serde_json::from_value(serde_json::json!({
-            "spec-id": 0,
-            "fields": [{
-                "source-id": 4,
-                "field-id": 1000,
-                "name": "v_part",
-                "transform": "void"
-            }]
-        }))
-        .unwrap();
-
-        metadata.last_column_id = 4;
-        metadata
-            .schemas
-            .insert(schema.schema_id(), Arc::new(schema.clone()));
-        metadata.partition_specs.clear();
-        metadata
-            .partition_specs
-            .insert(legacy_spec.spec_id(), Arc::new(legacy_spec.clone()));
-        metadata.default_partition_type = legacy_spec.partition_type(&schema).unwrap();
-        metadata.default_spec = Arc::new(legacy_spec);
-        metadata.last_partition_id = 1000;
-
-        // Exercise the real compatibility boundary: metadata produced elsewhere is loaded
-        // from JSON before the append starts.
-        let json = serde_json::to_vec(&metadata).unwrap();
-        let metadata: TableMetadata = serde_json::from_slice(&json).unwrap();
-        let table = table.with_metadata(Arc::new(metadata));
-        assert_eq!(
-            table.metadata().default_partition_type().fields()[0]
-                .field_type
-                .as_ref(),
-            &Type::Primitive(crate::spec::PrimitiveType::Int)
-        );
-
-        let data_file = DataFileBuilder::default()
-            .content(DataContentType::Data)
-            .file_path("test/legacy-void.parquet".to_string())
-            .file_format(DataFileFormat::Parquet)
-            .file_size_in_bytes(100)
-            .record_count(1)
-            .partition_spec_id(table.metadata().default_partition_spec_id())
-            .partition(Struct::from_iter([None]))
-            .build()
-            .unwrap();
-        let action = Transaction::new(&table)
-            .fast_append()
-            .add_data_files(vec![data_file]);
-        let action_commit = Arc::new(action).commit(&table).await.unwrap();
-        let mut updates = Vec::new();
-        let mut requirements = Vec::new();
-        let updated =
-            Transaction::apply(table, action_commit, &mut updates, &mut requirements).unwrap();
-
-        let snapshot = updated.metadata().current_snapshot().unwrap();
-        let manifest_list = updated.manifest_list_reader(snapshot).load().await.unwrap();
-        let summary = manifest_list.entries()[0].partitions.as_ref().unwrap();
-        assert!(summary[0].contains_null);
-        assert!(summary[0].lower_bound.is_none());
-        assert!(summary[0].upper_bound.is_none());
     }
 
     #[tokio::test]

--- a/crates/iceberg/src/transaction/snapshot.rs
+++ b/crates/iceberg/src/transaction/snapshot.rs
@@ -389,15 +389,18 @@ impl<'a> SnapshotProducer<'a> {
         }
 
         for (value, field) in partition_value.fields().iter().zip(partition_type.fields()) {
+            // Nothing to validate for null; in particular a `void` field may legally
+            // have a non-primitive type on tables written by other implementations.
+            let Some(value) = value else {
+                continue;
+            };
             let field = field.field_type.as_primitive_type().ok_or_else(|| {
                 Error::new(
                     ErrorKind::Unexpected,
                     "Partition field should only be primitive type.",
                 )
             })?;
-            if let Some(value) = value
-                && !field.compatible(&value.as_primitive_literal().unwrap())
-            {
+            if !field.compatible(&value.as_primitive_literal().unwrap()) {
                 return Err(Error::new(
                     ErrorKind::DataInvalid,
                     "Partition value is not compatible partition type",
@@ -860,5 +863,27 @@ impl<'a> SnapshotProducer<'a> {
 
         self.delete_filter_manager = Some(manager);
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::spec::{Literal, NestedField, PrimitiveType, Type, VariantType};
+
+    #[test]
+    fn test_validate_partition_value_skips_null_non_primitive_fields() {
+        // e.g. a `void` field on a non-primitive source: type non-primitive, value null.
+        let partition_type = StructType::new(vec![
+            NestedField::optional(1000, "v_part", Type::Variant(VariantType)).into(),
+            NestedField::optional(1001, "id_part", Type::Primitive(PrimitiveType::Int)).into(),
+        ]);
+
+        let ok = Struct::from_iter([None, Some(Literal::int(42))]);
+        SnapshotProducer::validate_partition_value(&ok, &partition_type).unwrap();
+
+        // A non-null value on a non-primitive partition field is still rejected.
+        let bad = Struct::from_iter([Some(Literal::int(1)), None]);
+        SnapshotProducer::validate_partition_value(&bad, &partition_type).unwrap_err();
     }
 }

--- a/crates/iceberg/src/transaction/snapshot.rs
+++ b/crates/iceberg/src/transaction/snapshot.rs
@@ -27,8 +27,9 @@ use crate::error::Result;
 use crate::spec::{
     DataContentType, DataFile, DataFileFormat, FormatVersion, MAIN_BRANCH, ManifestContentType,
     ManifestEntry, ManifestFile, ManifestListWriter, ManifestWriter, ManifestWriterBuilder,
-    Operation, Snapshot, SnapshotReference, SnapshotRetention, SnapshotSummaryCollector, Struct,
-    StructType, Summary, TableProperties, UNASSIGNED_SEQUENCE_NUMBER, update_snapshot_summaries,
+    Operation, PartitionSpec, Snapshot, SnapshotReference, SnapshotRetention,
+    SnapshotSummaryCollector, Struct, StructType, Summary, TableProperties, Transform,
+    UNASSIGNED_SEQUENCE_NUMBER, update_snapshot_summaries,
 };
 use crate::table::Table;
 use crate::transaction::{ActionCommit, ManifestFilterManager, ManifestWriterContext};
@@ -202,6 +203,7 @@ impl<'a> SnapshotProducer<'a> {
             Self::validate_partition_value(
                 data_file.partition(),
                 self.table.metadata().default_partition_type(),
+                self.table.metadata().default_partition_spec(),
             )?;
         }
 
@@ -380,27 +382,42 @@ impl<'a> SnapshotProducer<'a> {
     fn validate_partition_value(
         partition_value: &Struct,
         partition_type: &StructType,
+        partition_spec: &PartitionSpec,
     ) -> Result<()> {
-        if partition_value.fields().len() != partition_type.fields().len() {
+        if partition_value.fields().len() != partition_type.fields().len()
+            || partition_value.fields().len() != partition_spec.fields().len()
+        {
             return Err(Error::new(
                 ErrorKind::DataInvalid,
                 "Partition value is not compatible with partition type",
             ));
         }
 
-        for (value, field) in partition_value.fields().iter().zip(partition_type.fields()) {
-            // Nothing to validate for null; in particular a `void` field may legally
-            // have a non-primitive type on tables written by other implementations.
-            let Some(value) = value else {
+        for (idx, (value, field)) in partition_value
+            .fields()
+            .iter()
+            .zip(partition_type.fields())
+            .enumerate()
+        {
+            if partition_spec.fields()[idx].transform == Transform::Void {
+                if value.is_some() {
+                    return Err(Error::new(
+                        ErrorKind::DataInvalid,
+                        "Void partition field must be null",
+                    ));
+                }
                 continue;
-            };
+            }
+
             let field = field.field_type.as_primitive_type().ok_or_else(|| {
                 Error::new(
                     ErrorKind::Unexpected,
                     "Partition field should only be primitive type.",
                 )
             })?;
-            if !field.compatible(&value.as_primitive_literal().unwrap()) {
+            if let Some(value) = value
+                && !field.compatible(&value.as_primitive_literal().unwrap())
+            {
                 return Err(Error::new(
                     ErrorKind::DataInvalid,
                     "Partition value is not compatible partition type",
@@ -869,21 +886,43 @@ impl<'a> SnapshotProducer<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::spec::{Literal, NestedField, PrimitiveType, Type, VariantType};
+    use crate::spec::{Literal, NestedField, PrimitiveType, Schema, Type, VariantType};
 
     #[test]
-    fn test_validate_partition_value_skips_null_non_primitive_fields() {
-        // e.g. a `void` field on a non-primitive source: type non-primitive, value null.
-        let partition_type = StructType::new(vec![
-            NestedField::optional(1000, "v_part", Type::Variant(VariantType)).into(),
-            NestedField::optional(1001, "id_part", Type::Primitive(PrimitiveType::Int)).into(),
-        ]);
+    fn test_validate_partition_value_for_legacy_void_non_primitive_source() {
+        let schema = Schema::builder()
+            .with_fields(vec![
+                NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
+                NestedField::optional(2, "v", Type::Variant(VariantType)).into(),
+            ])
+            .build()
+            .unwrap();
+        let partition_spec: PartitionSpec = serde_json::from_value(serde_json::json!({
+            "spec-id": 0,
+            "fields": [
+                {
+                    "source-id": 2,
+                    "field-id": 1000,
+                    "name": "v_part",
+                    "transform": "void"
+                },
+                {
+                    "source-id": 1,
+                    "field-id": 1001,
+                    "name": "id_part",
+                    "transform": "identity"
+                }
+            ]
+        }))
+        .unwrap();
+        let partition_type = partition_spec.partition_type(&schema).unwrap();
 
         let ok = Struct::from_iter([None, Some(Literal::int(42))]);
-        SnapshotProducer::validate_partition_value(&ok, &partition_type).unwrap();
+        SnapshotProducer::validate_partition_value(&ok, &partition_type, &partition_spec).unwrap();
 
-        // A non-null value on a non-primitive partition field is still rejected.
+        // `void` must remain null even though its compatibility result type is `int`.
         let bad = Struct::from_iter([Some(Literal::int(1)), None]);
-        SnapshotProducer::validate_partition_value(&bad, &partition_type).unwrap_err();
+        SnapshotProducer::validate_partition_value(&bad, &partition_type, &partition_spec)
+            .unwrap_err();
     }
 }

--- a/crates/iceberg/src/transaction/snapshot.rs
+++ b/crates/iceberg/src/transaction/snapshot.rs
@@ -27,9 +27,8 @@ use crate::error::Result;
 use crate::spec::{
     DataContentType, DataFile, DataFileFormat, FormatVersion, MAIN_BRANCH, ManifestContentType,
     ManifestEntry, ManifestFile, ManifestListWriter, ManifestWriter, ManifestWriterBuilder,
-    Operation, PartitionSpec, Snapshot, SnapshotReference, SnapshotRetention,
-    SnapshotSummaryCollector, Struct, StructType, Summary, TableProperties, Transform,
-    UNASSIGNED_SEQUENCE_NUMBER, update_snapshot_summaries,
+    Operation, Snapshot, SnapshotReference, SnapshotRetention, SnapshotSummaryCollector, Struct,
+    StructType, Summary, TableProperties, UNASSIGNED_SEQUENCE_NUMBER, update_snapshot_summaries,
 };
 use crate::table::Table;
 use crate::transaction::{ActionCommit, ManifestFilterManager, ManifestWriterContext};
@@ -203,7 +202,6 @@ impl<'a> SnapshotProducer<'a> {
             Self::validate_partition_value(
                 data_file.partition(),
                 self.table.metadata().default_partition_type(),
-                self.table.metadata().default_partition_spec(),
             )?;
         }
 
@@ -382,42 +380,27 @@ impl<'a> SnapshotProducer<'a> {
     fn validate_partition_value(
         partition_value: &Struct,
         partition_type: &StructType,
-        partition_spec: &PartitionSpec,
     ) -> Result<()> {
-        if partition_value.fields().len() != partition_type.fields().len()
-            || partition_value.fields().len() != partition_spec.fields().len()
-        {
+        if partition_value.fields().len() != partition_type.fields().len() {
             return Err(Error::new(
                 ErrorKind::DataInvalid,
                 "Partition value is not compatible with partition type",
             ));
         }
 
-        for (idx, (value, field)) in partition_value
-            .fields()
-            .iter()
-            .zip(partition_type.fields())
-            .enumerate()
-        {
-            if partition_spec.fields()[idx].transform == Transform::Void {
-                if value.is_some() {
-                    return Err(Error::new(
-                        ErrorKind::DataInvalid,
-                        "Void partition field must be null",
-                    ));
-                }
+        for (value, field) in partition_value.fields().iter().zip(partition_type.fields()) {
+            // Nothing to validate for null; in particular a `void` field may legally
+            // have a non-primitive type on tables written by other implementations.
+            let Some(value) = value else {
                 continue;
-            }
-
+            };
             let field = field.field_type.as_primitive_type().ok_or_else(|| {
                 Error::new(
                     ErrorKind::Unexpected,
                     "Partition field should only be primitive type.",
                 )
             })?;
-            if let Some(value) = value
-                && !field.compatible(&value.as_primitive_literal().unwrap())
-            {
+            if !field.compatible(&value.as_primitive_literal().unwrap()) {
                 return Err(Error::new(
                     ErrorKind::DataInvalid,
                     "Partition value is not compatible partition type",
@@ -886,43 +869,21 @@ impl<'a> SnapshotProducer<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::spec::{Literal, NestedField, PrimitiveType, Schema, Type, VariantType};
+    use crate::spec::{Literal, NestedField, PrimitiveType, Type, VariantType};
 
     #[test]
-    fn test_validate_partition_value_for_legacy_void_non_primitive_source() {
-        let schema = Schema::builder()
-            .with_fields(vec![
-                NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
-                NestedField::optional(2, "v", Type::Variant(VariantType)).into(),
-            ])
-            .build()
-            .unwrap();
-        let partition_spec: PartitionSpec = serde_json::from_value(serde_json::json!({
-            "spec-id": 0,
-            "fields": [
-                {
-                    "source-id": 2,
-                    "field-id": 1000,
-                    "name": "v_part",
-                    "transform": "void"
-                },
-                {
-                    "source-id": 1,
-                    "field-id": 1001,
-                    "name": "id_part",
-                    "transform": "identity"
-                }
-            ]
-        }))
-        .unwrap();
-        let partition_type = partition_spec.partition_type(&schema).unwrap();
+    fn test_validate_partition_value_skips_null_non_primitive_fields() {
+        // e.g. a `void` field on a non-primitive source: type non-primitive, value null.
+        let partition_type = StructType::new(vec![
+            NestedField::optional(1000, "v_part", Type::Variant(VariantType)).into(),
+            NestedField::optional(1001, "id_part", Type::Primitive(PrimitiveType::Int)).into(),
+        ]);
 
         let ok = Struct::from_iter([None, Some(Literal::int(42))]);
-        SnapshotProducer::validate_partition_value(&ok, &partition_type, &partition_spec).unwrap();
+        SnapshotProducer::validate_partition_value(&ok, &partition_type).unwrap();
 
-        // `void` must remain null even though its compatibility result type is `int`.
+        // A non-null value on a non-primitive partition field is still rejected.
         let bad = Struct::from_iter([Some(Literal::int(1)), None]);
-        SnapshotProducer::validate_partition_value(&bad, &partition_type, &partition_spec)
-            .unwrap_err();
+        SnapshotProducer::validate_partition_value(&bad, &partition_type).unwrap_err();
     }
 }

--- a/crates/iceberg/src/transform/void.rs
+++ b/crates/iceberg/src/transform/void.rs
@@ -87,7 +87,9 @@ mod test {
                     Struct(StructType::new(vec![
                         NestedField::optional(1, "a", Primitive(Timestamp)).into(),
                     ])),
-                    Some(Primitive(Int)),
+                    Some(Struct(StructType::new(vec![
+                        NestedField::optional(1, "a", Primitive(Timestamp)).into(),
+                    ]))),
                 ),
             ],
         };

--- a/crates/iceberg/src/transform/void.rs
+++ b/crates/iceberg/src/transform/void.rs
@@ -87,9 +87,7 @@ mod test {
                     Struct(StructType::new(vec![
                         NestedField::optional(1, "a", Primitive(Timestamp)).into(),
                     ])),
-                    Some(Struct(StructType::new(vec![
-                        NestedField::optional(1, "a", Primitive(Timestamp)).into(),
-                    ]))),
+                    Some(Primitive(Int)),
                 ),
             ],
         };


### PR DESCRIPTION
## What

Fixes #217.

`check_transform_compatibility` skips the primitive-source check for `Transform::Void`, so a partition spec like `void(<variant column>)` passes table creation. The commit path (`validate_partition_value`) then requires every partition field to be primitive, so every snapshot commit on such a table fails with `Partition field should only be primitive type.` — forever, and callers treating it as retryable loop indefinitely.

The spec has no `void` exception for source columns: "The source columns, selected by ids, must be a primitive type and cannot be contained in a map or list, but may be nested in a struct."

## How

- Bind time: apply the primitive-source check to `void` fields too. Evolution-voided fields had primitive sources when they were first added, and schema evolution cannot turn a primitive column non-primitive, so this cannot reject a previously legal spec.
- Commit time: `validate_partition_value` skips null values instead of erroring on the field's type first. A `void` field always carries null, and tables written by implementations that skip the primitive check for `void` (e.g. Java's `alwaysNull()`) already exist; they become committable instead of permanently broken.

## Test

- Builder rejects `void` on a variant source.
- `validate_partition_value` accepts a null value on a non-primitive partition field and still rejects a non-null one.
