### PR TITLE
fix: restore variant write support lost in the 2026-08-07 rebase

### DIFF
--- a/crates/iceberg/src/avro/schema.rs
+++ b/crates/iceberg/src/avro/schema.rs
@@ -37,17 +37,61 @@ const FIELD_ID_PROP: &str = "field-id";
 const KEY_ID: &str = "key-id";
 const VALUE_ID: &str = "value-id";
 const MAP_LOGICAL_TYPE: &str = "map";
+const VARIANT_LOGICAL_TYPE: &str = "variant";
 // This const may better to maintain in avro-rs.
 const LOGICAL_TYPE: &str = "logicalType";
 
 struct SchemaToAvroSchema {
     schema: String,
+    // Stack of enclosing field ids, used to derive unique record names for
+    // structural types (e.g. variant) — mirrors Java TypeToSchema.fieldIds.
+    field_ids: Vec<i32>,
 }
 
 type AvroSchemaOrField = Either<AvroSchema, AvroRecordField>;
 
 impl SchemaVisitor for SchemaToAvroSchema {
     type T = AvroSchemaOrField;
+
+    fn before_struct_field(&mut self, field: &NestedFieldRef) -> Result<()> {
+        self.field_ids.push(field.id);
+        Ok(())
+    }
+
+    fn after_struct_field(&mut self, _field: &NestedFieldRef) -> Result<()> {
+        self.field_ids.pop();
+        Ok(())
+    }
+
+    fn before_list_element(&mut self, field: &NestedFieldRef) -> Result<()> {
+        self.field_ids.push(field.id);
+        Ok(())
+    }
+
+    fn after_list_element(&mut self, _field: &NestedFieldRef) -> Result<()> {
+        self.field_ids.pop();
+        Ok(())
+    }
+
+    fn before_map_key(&mut self, field: &NestedFieldRef) -> Result<()> {
+        self.field_ids.push(field.id);
+        Ok(())
+    }
+
+    fn after_map_key(&mut self, _field: &NestedFieldRef) -> Result<()> {
+        self.field_ids.pop();
+        Ok(())
+    }
+
+    fn before_map_value(&mut self, field: &NestedFieldRef) -> Result<()> {
+        self.field_ids.push(field.id);
+        Ok(())
+    }
+
+    fn after_map_value(&mut self, _field: &NestedFieldRef) -> Result<()> {
+        self.field_ids.pop();
+        Ok(())
+    }
 
     fn schema(&mut self, _schema: &Schema, value: AvroSchemaOrField) -> Result<AvroSchemaOrField> {
         let mut avro_schema = value.unwrap_left();
@@ -245,10 +289,43 @@ impl SchemaVisitor for SchemaToAvroSchema {
     }
 
     fn variant(&mut self, _v: &VariantType) -> Result<AvroSchemaOrField> {
-        Err(Error::new(
-            ErrorKind::FeatureUnsupported,
-            "Converting a variant type to an Avro schema is not supported yet",
-        ))
+        let fields = vec![
+            AvroRecordField {
+                name: "metadata".to_string(),
+                schema: AvroSchema::Bytes,
+                order: RecordFieldOrder::Ignore,
+                position: 0,
+                doc: None,
+                aliases: None,
+                default: None,
+                custom_attributes: Default::default(),
+            },
+            AvroRecordField {
+                name: "value".to_string(),
+                schema: AvroSchema::Bytes,
+                order: RecordFieldOrder::Ignore,
+                position: 1,
+                doc: None,
+                aliases: None,
+                default: None,
+                custom_attributes: Default::default(),
+            },
+        ];
+        // Avro record names must be unique within a schema. Derive the name from the
+        // enclosing field id.
+        let record_name = match self.field_ids.last() {
+            Some(id) => format!("r{id}"),
+            None => VARIANT_LOGICAL_TYPE.to_string(),
+        };
+        let mut schema = avro_record_schema(&record_name, fields)?;
+        let AvroSchema::Record(record) = &mut schema else {
+            unreachable!("avro_record_schema must return AvroSchema::Record");
+        };
+        record.attributes.insert(
+            LOGICAL_TYPE.to_string(),
+            Value::String(VARIANT_LOGICAL_TYPE.to_string()),
+        );
+        Ok(Either::Left(schema))
     }
 }
 
@@ -256,6 +333,7 @@ impl SchemaVisitor for SchemaToAvroSchema {
 pub(crate) fn schema_to_avro_schema(name: impl ToString, schema: &Schema) -> Result<AvroSchema> {
     let mut converter = SchemaToAvroSchema {
         schema: name.to_string(),
+        field_ids: Vec::new(),
     };
 
     visit_schema(schema, &mut converter).map(Either::unwrap_left)
@@ -442,6 +520,13 @@ impl AvroSchemaVisitor for AvroSchemaToSchema {
         record: &RecordSchema,
         field_types: Vec<Option<Type>>,
     ) -> Result<Option<Type>> {
+        // A variant is encoded as a record with logicalType "variant" — return it directly
+        // rather than trying to build a struct from its metadata/value byte fields.
+        if record.attributes.get(LOGICAL_TYPE).and_then(Value::as_str) == Some(VARIANT_LOGICAL_TYPE)
+        {
+            return Ok(Some(Type::Variant(VariantType)));
+        }
+
         let mut fields = Vec::with_capacity(field_types.len());
         for (avro_field, field_type) in record.fields.iter().zip_eq(field_types) {
             let field_id =
@@ -1222,17 +1307,162 @@ mod tests {
         );
     }
 
+    /// Adapted from Java TestSchemaConversions.testVariantConversion
     #[test]
-    fn test_variant_to_avro_schema_is_unsupported() {
-        // Converting a variant to an Avro schema is not supported yet; it must error rather
-        // than emit an incorrect schema.
-        let schema = Schema::builder()
+    fn test_variant_schema_conversion() {
+        let avro_schema = AvroSchema::parse_str(
+            r#"
+{
+    "type": "record",
+    "name": "test_schema",
+    "fields": [
+        {
+            "name": "variantCol1",
+            "type": {
+                "type": "record",
+                "name": "r1",
+                "logicalType": "variant",
+                "fields": [
+                    {"name": "metadata", "type": "bytes"},
+                    {"name": "value", "type": "bytes"}
+                ]
+            },
+            "field-id": 1
+        },
+        {
+            "name": "variantCol2",
+            "type": {
+                "type": "record",
+                "name": "r2",
+                "logicalType": "variant",
+                "fields": [
+                    {"name": "metadata", "type": "bytes"},
+                    {"name": "value", "type": "bytes"}
+                ]
+            },
+            "field-id": 2
+        }
+    ]
+}
+            "#,
+        )
+        .unwrap();
+
+        let iceberg_schema = Schema::builder()
+            .with_fields(vec![
+                NestedField::required(1, "variantCol1", Type::Variant(VariantType)).into(),
+                NestedField::required(2, "variantCol2", Type::Variant(VariantType)).into(),
+            ])
+            .build()
+            .unwrap();
+
+        check_schema_conversion(avro_schema, iceberg_schema);
+    }
+
+    #[test]
+    fn test_optional_variant_schema_conversion() {
+        let avro_schema = AvroSchema::parse_str(
+            r#"
+{
+    "type": "record",
+    "name": "test_schema",
+    "fields": [
+        {
+            "name": "v",
+            "type": [
+                "null",
+                {
+                    "type": "record",
+                    "name": "r1",
+                    "logicalType": "variant",
+                    "fields": [
+                        {"name": "metadata", "type": "bytes"},
+                        {"name": "value", "type": "bytes"}
+                    ]
+                }
+            ],
+            "default": null,
+            "field-id": 1
+        }
+    ]
+}
+            "#,
+        )
+        .unwrap();
+
+        let iceberg_schema = Schema::builder()
             .with_fields(vec![
                 NestedField::optional(1, "v", Type::Variant(VariantType)).into(),
             ])
             .build()
             .unwrap();
-        let err = schema_to_avro_schema("t", &schema).unwrap_err();
-        assert_eq!(err.kind(), ErrorKind::FeatureUnsupported, "{err}");
+
+        check_schema_conversion(avro_schema, iceberg_schema);
+    }
+
+    /// Regression: two variant columns nested inside a struct must produce unique
+    /// Avro record names (`r{field_id}`).
+    #[test]
+    fn test_multiple_variants_in_struct_have_unique_record_names() {
+        let iceberg_schema = Schema::builder()
+            .with_fields(vec![
+                NestedField::required(
+                    1,
+                    "nested",
+                    Type::Struct(StructType::new(vec![
+                        NestedField::required(2, "v1", Type::Variant(VariantType)).into(),
+                        NestedField::required(3, "v2", Type::Variant(VariantType)).into(),
+                    ])),
+                )
+                .into(),
+            ])
+            .build()
+            .unwrap();
+
+        let avro_schema = schema_to_avro_schema("test", &iceberg_schema).unwrap();
+
+        // Collect every variant record's name from the resulting Avro schema
+        // and assert they are unique and match the enclosing field ids.
+        let json = serde_json::to_value(&avro_schema).unwrap();
+        fn walk(v: &Value, out: &mut Vec<String>) {
+            match v {
+                Value::Object(map) => {
+                    if map.get("logicalType").and_then(Value::as_str) == Some("variant")
+                        && let Some(name) = map.get("name").and_then(Value::as_str)
+                    {
+                        out.push(name.to_string());
+                    }
+                    for (_k, child) in map {
+                        walk(child, out);
+                    }
+                }
+                Value::Array(arr) => {
+                    for child in arr {
+                        walk(child, out);
+                    }
+                }
+                _ => {}
+            }
+        }
+        let mut variant_record_names: Vec<String> = Vec::new();
+        walk(&json, &mut variant_record_names);
+
+        assert_eq!(
+            variant_record_names.len(),
+            2,
+            "expected two variant records, got {variant_record_names:?}"
+        );
+        assert!(
+            variant_record_names.contains(&"r2".to_string()),
+            "expected variant record 'r2' (field id 2), got {variant_record_names:?}"
+        );
+        assert!(
+            variant_record_names.contains(&"r3".to_string()),
+            "expected variant record 'r3' (field id 3), got {variant_record_names:?}"
+        );
+
+        // Round-trips back to the same Iceberg schema.
+        let roundtrip = avro_schema_to_schema(&avro_schema).unwrap();
+        assert_eq!(iceberg_schema, roundtrip);
     }
 }

--- a/crates/iceberg/src/writer/file_writer/parquet_writer.rs
+++ b/crates/iceberg/src/writer/file_writer/parquet_writer.rs
@@ -277,6 +277,19 @@ impl SchemaVisitor for IndexByParquetPathName {
     }
 
     fn primitive(&mut self, _p: &PrimitiveType) -> Result<Self::T> {
+        self.insert_current_path()
+    }
+
+    // A variant is a leaf: it is indexed by its column name like a primitive. Its
+    // parquet sub-columns (`metadata`/`value`) never match this group path, so no
+    // statistics are collected for it.
+    fn variant(&mut self, _v: &VariantType) -> Result<Self::T> {
+        self.insert_current_path()
+    }
+}
+
+impl IndexByParquetPathName {
+    fn insert_current_path(&mut self) -> Result<()> {
         let full_name = self.field_names.iter().map(String::as_str).join(".");
         let field_id = self.field_id;
         if let Some(existing_field_id) = self.name_to_id.get(full_name.as_str()) {
@@ -291,13 +304,6 @@ impl SchemaVisitor for IndexByParquetPathName {
         }
 
         Ok(())
-    }
-
-    fn variant(&mut self, _v: &VariantType) -> Result<Self::T> {
-        Err(Error::new(
-            ErrorKind::FeatureUnsupported,
-            "Writing variant columns to Parquet is not supported yet",
-        ))
     }
 }
 
@@ -893,18 +899,21 @@ mod tests {
     }
 
     #[test]
-    fn test_index_by_parquet_path_variant_is_unsupported() {
-        // Writing variant columns to Parquet is not supported yet; indexing a schema that
-        // contains one must error rather than silently miss-map columns.
+    fn test_index_by_parquet_path_variant() {
+        // A variant is a leaf, so it is indexed by its column name like a primitive.
         let schema = Schema::builder()
             .with_fields(vec![
-                NestedField::optional(1, "v", Type::Variant(VariantType)).into(),
+                NestedField::optional(1, "id", Type::Primitive(PrimitiveType::Long)).into(),
+                NestedField::optional(2, "v", Type::Variant(VariantType)).into(),
             ])
             .build()
             .unwrap();
         let mut visitor = IndexByParquetPathName::new();
-        let err = visit_schema(&schema, &mut visitor).unwrap_err();
-        assert_eq!(err.kind(), ErrorKind::FeatureUnsupported, "{err}");
+        visit_schema(&schema, &mut visitor).unwrap();
+        assert_eq!(
+            visitor.name_to_id,
+            HashMap::from([("id".to_string(), 1), ("v".to_string(), 2)])
+        );
     }
 
     #[tokio::test]

--- a/crates/integration_tests/tests/read_variant.rs
+++ b/crates/integration_tests/tests/read_variant.rs
@@ -87,6 +87,25 @@ async fn test_variant_schema_is_parsed() {
 }
 
 #[tokio::test]
+async fn test_variant_arrow_schema() {
+    // Full scan without projection: exercises the non-projected read path.
+    let table = load_variant_table().await;
+    let batches: Vec<_> = table
+        .scan()
+        .build()
+        .unwrap()
+        .to_arrow()
+        .await
+        .unwrap()
+        .try_collect()
+        .await
+        .unwrap();
+
+    assert!(!batches.is_empty());
+    assert_variant_column(&batches[0]);
+}
+
+#[tokio::test]
 async fn test_spark_variant_scan_and_projection() {
     let table = load_variant_table().await;
     let batches: Vec<_> = table


### PR DESCRIPTION
## What

The 2026-08-07 rebase (`dev_rebase_main_20260807`) resolved several conflicts to upstream's variant *placeholders*, silently dropping this fork's working variant write support. This PR restores the lost pieces:

1. **Parquet writer** (`IndexByParquetPathName::variant`): the fork's `insert_current_path()` was replaced by upstream's `Err(FeatureUnsupported)`. Since the visitor runs over the whole schema on every file close, any table *containing* a variant column could no longer produce a DataFile at all — and because the failure fires after `writer.finish()`, each attempt also leaked an orphan parquet object. Restored: a variant indexes by its column name like a primitive; its parquet sub-columns never match the group path, so no statistics are collected for it. The test that pinned this behavior had been rewritten to assert the regression (`test_index_by_parquet_path_variant_is_unsupported`); the original test is restored.
2. **Avro ⇄ Variant conversion** (`avro/schema.rs`): the fork's mapping (record `{metadata: bytes, value: bytes}` with `logicalType: variant`, unique `r{field_id}` record names mirroring Java `TypeToSchema`, and the reverse mapping to `Type::Variant`) was replaced by upstream's `Err(FeatureUnsupported)`. Restored along with its three tests.
3. **Integration test**: the full-scan (no projection) variant read test `test_variant_arrow_schema` was dropped; restored, reusing the existing `assert_variant_column` helper.

## Deliberately NOT reverted

Divergences from the old line that come from genuine upstream improvements are kept as-is:
- the variant `value` arrow child is **nullable** (upstream #2188, for shredded variants) — the old line had it non-nullable;
- the canonical `VariantExtensionType` / `ArrowSchemaVisitor::variant` mechanism replacing the old `field_stack`-based extension detection.

## Context

Found while auditing the rebase for lost fork patches after reviewing risingwavelabs/risingwave#26620 (RisingWave's iceberg variant sink, which depends on the parquet write path and currently pins pre-rebase rev `6bd8e98`). Related fixes on this branch: #218, #219. Note #206 (variant column statistics) was written against the restored single-path behavior and should compose with this.

## Test

- `cargo test -p iceberg --lib -- avro parquet_writer`: 65 passed (includes the restored `test_index_by_parquet_path_variant` and the three avro variant tests).
- `cargo check --tests -p iceberg-integration-tests` compiles; the restored full-scan test runs in the integration environment.
